### PR TITLE
chore: onboard this repo for agents

### DIFF
--- a/.claude/hooks/build_hint.py
+++ b/.claude/hooks/build_hint.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: point Claude at the repo's build-run-test skill.
+
+Pairs with the agentify-build skill. The skill holds what a Makefile target name
+cannot carry — toolchain versions, ports, prereqs, offline-test handling — and a
+skill only loads when the model picks it. This hook makes that pick deterministic:
+before the first build-shaped Bash command of a session it injects one line naming
+the skill.
+
+Never blocks. The command runs either way; the hook only adds context.
+
+Fires once per session, keyed on session_id, so a build-fix loop costs one
+reminder. Silent when the skill is absent, when the command is not build-shaped,
+and on any error.
+"""
+
+import json
+import os
+import re
+import sys
+import tempfile
+
+# The skill this hook advertises. Renaming it touches this line only.
+SKILL_NAME = "build-run-test"
+SKILL_REL = os.path.join(".claude", "skills", SKILL_NAME, "SKILL.md")
+
+# Build tools whose every invocation is build-shaped. Deliberately generic and
+# deliberately wide: what this hook has to catch is an agent typing `./gradlew
+# test` on instinct in a repo it has not read yet. Narrowing the table to the
+# build systems a repo actually uses would miss exactly that case, and a false
+# positive here costs one line, once per session.
+BUILD_HEADS = {"make", "gmake", "gradle", "gradlew", "mvn", "mvnw", "sbt",
+               "bazel", "buck", "ninja", "cmake", "tox", "nox", "pytest",
+               "rake", "meson", "scons", "just", "task", "earthly", "jest",
+               "vitest", "rspec", "phpunit", "tsc", "nx", "turbo", "lerna"}
+# Tools that are build-shaped only under certain subcommands: `go test` is,
+# `go fmt` is not, and `python3 deploy.py` is not a build at all.
+BUILD_SUBCOMMANDS = {
+    "cargo": {"build", "test", "run", "check", "bench"},
+    "go": {"build", "test", "run", "install"},
+    "dotnet": {"build", "test", "run", "publish"},
+    "swift": {"build", "test", "run"},
+    "npm": {"run", "test", "start", "ci", "install", "build"},
+    "pnpm": {"run", "test", "start", "install", "build"},
+    "yarn": {"run", "test", "start", "install", "build"},
+    "bun": {"run", "test", "install", "build"},
+    "docker": {"build", "compose"},
+    "podman": {"build", "compose"},
+    "poetry": {"run", "install", "build"},
+    "uv": {"run", "sync", "build"},
+    "pdm": {"run", "install", "build"},
+    "bundle": {"exec", "install"},
+    "mix": {"test", "compile", "run"},
+    "stack": {"build", "test", "run"},
+    "python": {"-m"},
+    "python3": {"-m"},
+}
+# `python -m X` is a build only for these modules.
+PYTHON_MODULES = {"pytest", "unittest", "build", "tox", "nox", "py_compile"}
+
+SEPARATORS = re.compile(r"&&|\|\||;|\||&|\n")
+ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
+# Wrappers Claude Code strips before matching; strip them here for the same reason.
+WRAPPERS = {"timeout", "time", "nice", "nohup", "stdbuf", "command", "builtin",
+            "noglob", "xargs", "env", "sudo"}
+DURATION = re.compile(r"^\d+(\.\d+)?[smhd]?$")
+SAFE_ID = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def head_and_rest(part):
+    """Bare command name and its remaining words, wrappers and env vars removed."""
+    while True:
+        part = part.strip()
+        while ENV_ASSIGN.match(part):
+            part = ENV_ASSIGN.sub("", part, count=1).strip()
+        words = part.split()
+        if not words:
+            return "", []
+        base = os.path.basename(words[0].rstrip("/")) or words[0]
+        if base not in WRAPPERS:
+            return base, words[1:]
+        rest = words[1:]
+        while rest and rest[0].startswith("-"):
+            rest.pop(0)
+        if base in ("timeout", "nice") and rest and DURATION.match(rest[0]):
+            rest.pop(0)
+        part = " ".join(rest)
+
+
+def is_build_command(command):
+    """True when any part of a compound command builds, runs, or tests the repo."""
+    for part in SEPARATORS.split(command):
+        base, rest = head_and_rest(part)
+        if not base:
+            continue
+        if base in BUILD_HEADS:
+            return True
+        wanted = BUILD_SUBCOMMANDS.get(base)
+        if not wanted:
+            continue
+        # The first non-flag word, except for `python -m <module>`.
+        verb = next((w for w in rest if not w.startswith("-")), "")
+        if base in ("python", "python3"):
+            if "-m" in rest and verb in PYTHON_MODULES:
+                return True
+            continue
+        if verb in wanted:
+            return True
+    return False
+
+
+def skill_root(start):
+    """The project holding the skill, or None.
+
+    Claude Code sets CLAUDE_PROJECT_DIR for hooks, and the skill always sits at
+    the repo root, so that answers it outright. Walking up from cwd is the
+    fallback, and it stops at the project rather than running to `/`: above the
+    project any hit belongs to some other checkout, and the relative path this
+    hook prints would not resolve from here.
+    """
+    project = os.environ.get("CLAUDE_PROJECT_DIR")
+    if project:
+        project = os.path.realpath(project)
+        return project if os.path.isfile(os.path.join(project, SKILL_REL)) else None
+
+    directory = os.path.realpath(start or ".")
+    while True:
+        if os.path.isfile(os.path.join(directory, SKILL_REL)):
+            return directory
+        if os.path.isdir(os.path.join(directory, ".git")) or os.path.isfile(
+                os.path.join(directory, ".git")):
+            return None                  # repo root reached, no skill here
+        parent = os.path.dirname(directory)
+        if parent == directory:
+            return None
+        directory = parent
+
+
+def already_fired(session_id):
+    """True when this session was already reminded. Marks it when it was not."""
+    if not session_id:
+        return False
+    marker = os.path.join(tempfile.gettempdir(),
+                          "agentify-build-hint-%s" % SAFE_ID.sub("_", session_id))
+    if os.path.exists(marker):
+        return True
+    with open(marker, "w") as handle:
+        handle.write("")
+    return False
+
+
+def main():
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return
+    payload = json.loads(raw)
+    if payload.get("tool_name") != "Bash":
+        return
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    if not command or not is_build_command(command):
+        return
+    if not skill_root(payload.get("cwd")):
+        return                       # skill not installed here, nothing to point at
+    if already_fired(payload.get("session_id")):
+        return
+
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "additionalContext":
+            "This repo documents how it builds, runs, and tests in the "
+            "`%s` skill (%s): toolchain versions, ports, prereqs, and gotchas a "
+            "command name does not carry. Load it before going further. "
+            "(agentify-build skill)" % (SKILL_NAME, SKILL_REL)}}))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        # Never let a hook error block the tool call.
+        sys.exit(0)

--- a/.claude/hooks/check_conventions.py
+++ b/.claude/hooks/check_conventions.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: hold `git commit`, `gh pr create`, and `gh pr edit` to the repo's
+commit and PR conventions. Runs inside Claude Code, so human contributors are
+untouched.
+
+Checks, all mechanical:
+  - a commit subject and a PR title are held to one format, a Conventional Commit
+  - either opens its summary with the branch's ticket key in brackets, when the
+    branch names one
+  - a PR body passed with --body/--body-file was built from the PR template,
+    with no leftover guidance comments and no empty sections
+  - the punctuation the template bans stays out of the body
+
+Fails open everywhere: an unreadable subject or body (editor commits, `-F -`,
+unbalanced quotes, a missing template) is allowed through. What it can read it
+enforces, with no opt-out flag or environment variable. Don't add one.
+"""
+import json
+import os
+import re
+import shlex
+import sys
+
+TYPES = ("build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor",
+         "revert", "style", "test")
+# The one header spec, worded exactly as the template, the workflow, and the
+# commit-and-pr skill word it. A commit subject and a PR title are the same string.
+HEADER_SPEC = "<type>(<scope>)?!?: [<issue>]? <imperative summary>"
+# The skill holding the full conventions. A deny is the moment an agent needs it,
+# and naming it here is what makes a lazily-loaded skill reliable.
+SKILL_NAME = "commit-and-pr"
+# The bracketed ID lives in the summary, which is free text, so this grammar check
+# is the workflow's pattern with Python's space class in place of [:space:].
+HEADER_PATTERN = re.compile(
+    r"^(%s)(\([^()\s]+\))?!?: .+" % "|".join(TYPES), re.IGNORECASE)
+# The bracketed ticket ID opening the summary: `feat(auth): [YCOM-21] add login`.
+ISSUE_PATTERN = re.compile(r"^[a-z]+(?:\([^()\s]+\))?!?: \[([^\]\s]+)\]",
+                           re.IGNORECASE)
+
+TEMPLATE = os.path.join(".github", "pull_request_template.md")
+# The template says so in its own comments; the hook only enforces what it finds.
+PUNCTUATION_RULE = "No em-dashes, no semicolons"
+BANNED = {"—": "em-dash", "–": "en-dash", ";": "semicolon"}
+
+SEPARATORS = ("&&", "||", ";", "|", "&", "\n")
+WRAPPERS = ("timeout", "time", "nice", "nohup", "stdbuf", "command", "builtin",
+            "noglob", "xargs", "env")
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+# -m, and any short-flag cluster ending in it: -am, -sm, -am"subject".
+SHORT_MESSAGE = re.compile(r"^-[A-Za-z]*m(.*)$")
+GIT_OPTS_WITH_VALUE = ("-C", "-c", "--git-dir", "--work-tree", "--namespace",
+                       "--exec-path")
+# A key as the tracker writes it, uppercase, ending at its digits: `YCOM-21-login`
+# and `feature/ENG-4_x` name a ticket, `release-1` and `fix-2fa-login` do not. A
+# lowercase branch reads as no ticket, which fails open rather than deny wrongly.
+TICKET_IN_BRANCH = re.compile(
+    r"(?:^|[^A-Za-z0-9])([A-Z][A-Z0-9]{1,9}-\d+)(?![A-Za-z0-9])")
+CODE_SPANS = re.compile(r"```.*?```|`[^`]*`", re.DOTALL)
+COMMENTS = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+def segments(tokens):
+    """The compound command's parts, split on shell separators."""
+    part, out = [], []
+    for token in tokens:
+        if token in SEPARATORS:
+            out.append(part)
+            part = []
+        else:
+            part.append(token)
+    out.append(part)
+    return [p for p in out if p]
+
+
+def strip_prefix(tokens):
+    """Drop leading env assignments and wrappers to reach the real command."""
+    while tokens and (ASSIGNMENT.match(tokens[0]) or tokens[0] in WRAPPERS):
+        tokens = tokens[1:]
+    return tokens
+
+
+def subcommand_args(tokens, program, words):
+    """Arguments after `<program> [options] <words...>`, else None."""
+    if not tokens or tokens[0] != program:
+        return None
+    index = 1
+    for word in words:
+        while index < len(tokens):
+            token = tokens[index]
+            if token == word:
+                index += 1
+                break
+            if program == "git" and token in GIT_OPTS_WITH_VALUE:
+                index += 2
+                continue
+            if token.startswith("-"):
+                index += 1
+                continue
+            return None                  # some other subcommand
+        else:
+            return None
+    return tokens[index:]
+
+
+def option(args, *names):
+    """The value of the first of `names` present in args, else None."""
+    for index, token in enumerate(args):
+        if token in names and index + 1 < len(args):
+            return args[index + 1]
+        for name in names:
+            if token.startswith(name + "="):
+                return token.split("=", 1)[1]
+    return None
+
+
+def commit_subjects(args):
+    """Subjects a `git commit` invocation would write."""
+    messages, index = [], 0
+    while index < len(args):
+        token = args[index]
+        short = SHORT_MESSAGE.match(token)
+        if token == "--message" and index + 1 < len(args):
+            messages.append(args[index + 1])
+            index += 2
+            continue
+        if token.startswith("--message="):
+            messages.append(token.split("=", 1)[1])
+        elif short and short.group(1):
+            messages.append(short.group(1))
+        elif short and index + 1 < len(args):
+            messages.append(args[index + 1])
+            index += 2
+            continue
+        index += 1
+    # First -m is the subject; the rest are body paragraphs.
+    return messages[:1]
+
+
+def prose(body):
+    """The body minus code spans and HTML comments, for punctuation checks."""
+    return COMMENTS.sub("", CODE_SPANS.sub("", body))
+
+
+def headings(text):
+    return set(re.findall(r"(?m)^#{2,3}\s+(.+?)\s*$", text))
+
+
+def empty_sections(body):
+    """Headings with nothing under them."""
+    parts = re.split(r"(?m)^(#{2,3}\s+.+?)\s*$", body)
+    empty = []
+    for index in range(1, len(parts) - 1, 2):
+        if not parts[index + 1].strip():
+            empty.append(parts[index].lstrip("# ").strip())
+    return empty
+
+
+def read_file(path):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            return handle.read()
+    except OSError:
+        return ""
+
+
+def body_problems(body, template):
+    """Everything wrong with a PR body, given the repo's template."""
+    problems = []
+    wanted = headings(template)
+    if wanted and not (headings(body) & wanted):
+        problems.append(
+            "the body does not use %s. --body and --body-file skip GitHub's "
+            "prefill, so build the body from that file. Sections: %s"
+            % (TEMPLATE, ", ".join(sorted(wanted))))
+    if COMMENTS.search(body):
+        problems.append("the body still has the template's guidance comments in it. "
+                        "Write over each one, don't keep it")
+    empty = empty_sections(body)
+    if empty:
+        problems.append("empty sections, fill or delete: %s" % ", ".join(empty))
+    if PUNCTUATION_RULE in template:
+        found = sorted({name for mark, name in BANNED.items()
+                        if mark in prose(body)})
+        if found:
+            problems.append("%s in the body. %s: short sentences instead"
+                            % (", ".join(found), PUNCTUATION_RULE.lower()))
+    return problems
+
+
+def header_problems(header, branch):
+    """A commit subject and a PR title are held to the same format."""
+    problems = []
+    if not HEADER_PATTERN.match(header):
+        return ["%r does not match %s. Types: %s. Scope: the module changed, "
+                "in parentheses: (api)"
+                % (header, HEADER_SPEC, ", ".join(TYPES))]
+    ticket = TICKET_IN_BRANCH.search(branch or "")
+    if ticket:
+        key = ticket.group(1)
+        issue = ISSUE_PATTERN.match(header)
+        if not issue or issue.group(1).lower() != key.lower():
+            problems.append(
+                "branch %s names ticket %s, so the summary opens with it: "
+                "<type>: [%s] ..." % (branch, key, key))
+    return problems
+
+
+def git_head_path(cwd):
+    """`HEAD`, following the pointer a worktree or submodule leaves behind.
+
+    In those, `.git` is a file holding `gitdir: <path>` rather than a directory,
+    so reading `.git/HEAD` finds nothing and the branch reads as unknown. That
+    fails open, silently skipping the ticket-key check for every agent working in
+    a worktree.
+    """
+    dot_git = os.path.join(cwd or ".", ".git")
+    if not os.path.isfile(dot_git):
+        return os.path.join(dot_git, "HEAD")
+    pointer = read_file(dot_git).strip()
+    if not pointer.startswith("gitdir:"):
+        return os.path.join(dot_git, "HEAD")
+    target = pointer.partition(":")[2].strip()
+    if not os.path.isabs(target):
+        target = os.path.join(cwd or ".", target)
+    return os.path.join(target, "HEAD")
+
+
+def branch_name(cwd):
+    head = read_file(git_head_path(cwd))
+    return head.strip().rpartition("/")[2] if "ref:" in head else ""
+
+
+def problems_for(command, cwd):
+    """Every convention problem in this command, in report order."""
+    if "commit" not in command and "pr" not in command:
+        return []                        # cheap exit before any parsing
+    try:
+        tokens = shlex.split(command, comments=False)
+    except ValueError:
+        return []
+
+    branch = branch_name(cwd)
+    found = []
+    for part in segments(tokens):
+        part = strip_prefix(part)
+        args = subcommand_args(part, "git", ["commit"])
+        if args is not None:
+            found += ["Commit subject: " + p for subject in commit_subjects(args)
+                      for p in header_problems(subject, branch)]
+            continue
+        for verb in ("create", "edit"):
+            args = subcommand_args(part, "gh", ["pr", verb])
+            if args is None:
+                continue
+            title = option(args, "-t", "--title")
+            if title:
+                found += ["PR title: " + p for p in header_problems(title, branch)]
+            body = option(args, "-b", "--body")
+            body_file = option(args, "-F", "--body-file")
+            if body_file and body_file != "-":
+                body = read_file(os.path.join(cwd or ".", body_file))
+            if body:
+                template = read_file(os.path.join(cwd or ".", TEMPLATE))
+                found += ["PR body: " + p for p in body_problems(body, template)]
+    return found
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    problems = problems_for(command, payload.get("cwd"))
+    if problems:
+        print(json.dumps({"hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": "\n".join(
+                ["Repo conventions (full rules: the `%s` skill):" % SKILL_NAME]
+                + ["  - " + p for p in problems]
+                + ["Fix and retry. No bypass."])}}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/claude_md_hook.py
+++ b/.claude/hooks/claude_md_hook.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: nudge Claude to keep the CLAUDE.md search tree current.
+
+Pairs with the agentify-docs skill. Fires after Edit/Write/MultiEdit. When an
+edit *structurally* changes a directory (a new file appears, i.e. something the
+directory's CLAUDE.md index or its parent's child links should reflect), it
+injects a short reminder naming the affected CLAUDE.md so Claude can update it.
+
+Deliberately does NOT nudge on in-place edits to existing files: rewriting a
+function body rarely changes a one-line directory summary. The hook only detects;
+Claude judges whether the summary actually needs to change and rewrites it.
+
+Self-gating: silent when the file is not in a git repo, when no ancestor
+directory has a CLAUDE.md (tree never built), or when the edit is a plain modify.
+Any unexpected error exits 0 silently so the hook never blocks a tool call.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+STRUCTURAL_TOOLS = {"Edit", "Write", "MultiEdit"}
+CLAUDE_MD = "CLAUDE.md"
+# Named once: every reminder is tagged by emit(), so a skill rename touches one line.
+SKILL_TAG = "(agentify-docs skill)"
+
+
+def git(root, *args):
+    return subprocess.run(
+        ["git", "-C", root, *args],
+        capture_output=True, text=True, check=True,
+    ).stdout
+
+
+def emit(context):
+    """Print PostToolUse additionalContext, skill-tagged, and exit."""
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": "%s %s" % (context, SKILL_TAG),
+        }
+    }))
+    sys.exit(0)
+
+
+def main():
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return
+    payload = json.loads(raw)
+
+    if payload.get("tool_name") not in STRUCTURAL_TOOLS:
+        return
+
+    tool_input = payload.get("tool_input") or {}
+    file_path = tool_input.get("file_path")
+    if not file_path:
+        return
+
+    cwd = payload.get("cwd") or os.getcwd()
+    if not os.path.isabs(file_path):
+        file_path = os.path.join(cwd, file_path)
+    # realpath so it shares a symlink-resolved prefix with git's toplevel
+    # (e.g. macOS /var -> /private/var), keeping relative paths clean.
+    file_path = os.path.realpath(file_path)
+
+    # Never nudge about edits to a CLAUDE.md itself (avoids feedback loops).
+    if os.path.basename(file_path) == CLAUDE_MD:
+        return
+
+    file_dir = os.path.dirname(file_path)
+    try:
+        root = os.path.realpath(git(file_dir, "rev-parse", "--show-toplevel").strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return  # not a git repo
+
+    # lint_claude_md.py never indexes a dot-directory, so nothing under one can need a
+    # CLAUDE.md. `.claude/skills/` in particular is written by the build, contrib,
+    # and boundaries phases, which would otherwise nudge on every run. Judged
+    # relative to the repo root, so a checkout that itself lives under a
+    # dot-directory (~/.local/src/repo) still gets nudges.
+    if any(part.startswith(".")
+           for part in os.path.relpath(file_dir, root).split(os.sep)):
+        return
+
+    # Structural check: only nudge when the file is newly added/untracked.
+    # Plain modifications (" M" / "M ") and staged edits ("MM") are skipped.
+    status = git(root, "status", "--porcelain", "--", file_path)
+    code = status[:2] if status else ""
+    is_new = code in ("??", "A ", "AM")
+    if not is_new:
+        return
+
+    # Walk up from the file's directory to the repo root for the nearest CLAUDE.md.
+    # file_dir and root are both absolute and symlink-resolved, so compare directly.
+    nearest = None
+    d = file_dir
+    while True:
+        candidate = os.path.join(d, CLAUDE_MD)
+        if os.path.isfile(candidate):
+            nearest = candidate
+            break
+        if d == root:
+            break
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+
+    if nearest is None:
+        return  # no CLAUDE.md tree here; skill hasn't been run
+
+    # A hit on the first step up means the file's own directory is already indexed.
+    own_dir_covered = os.path.dirname(nearest) == file_dir
+
+    rel_file = os.path.relpath(file_path, root)
+    rel_md = os.path.relpath(nearest, root)
+
+    if own_dir_covered:
+        emit(
+            f"New file `{rel_file}` was added. Its directory has a CLAUDE.md "
+            f"(`{rel_md}`) that is part of the repo search tree. If this file "
+            f"changes what that directory contains, update the summary in "
+            f"`{rel_md}`. Only edit the index if the description is now "
+            f"inaccurate."
+        )
+
+    rel_dir = os.path.relpath(file_dir, root)
+    emit(
+        f"New file `{rel_file}` was added in `{rel_dir}/`, which has no CLAUDE.md "
+        f"but sits under the search tree indexed by `{rel_md}`. If `{rel_dir}/` is "
+        f"now a meaningful directory, consider adding a CLAUDE.md there and linking "
+        f"it from `{rel_md}`."
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        # Never let a hook error block the tool call.
+        sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,74 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/claude_md_hook.py"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/build_hint.py"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check_conventions.py",
+            "if": "Bash(git commit *)"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check_conventions.py",
+            "if": "Bash(gh pr create *)"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check_conventions.py",
+            "if": "Bash(gh pr edit *)"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(make *)",
+      "Bash(npm ci)",
+      "Bash(npm install)",
+      "Bash(npm run *)",
+      "Bash(npx tsc *)",
+      "Bash(npx prettier *)",
+      "Bash(npx eslint *)",
+      "Bash(node -v)",
+      "Bash(npm -v)",
+      "Bash(npm audit)",
+      "Bash(git *)",
+      "Bash(gh *)"
+    ],
+    "ask": [
+      "Bash(npm run pages:deploy)",
+      "Bash(npm run pages:deploy *)",
+      "Bash(wrangler *)",
+      "Bash(npx wrangler *)"
+    ],
+    "deny": [
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/*.p12)",
+      "Read(**/*.jks)",
+      "Read(**/*credentials.json)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)"
+    ]
+  }
+}

--- a/.claude/skills/build-run-test/SKILL.md
+++ b/.claude/skills/build-run-test/SKILL.md
@@ -10,7 +10,7 @@ description: How to build, run, and test this repo. Read before any npm, make, t
 ## Toolchain
 
 - Node `v20.8` (`.nvmrc`), npm 10 (`lockfileVersion: 3`). `nvm use` before anything. `make setup` fails with an actionable message on a major mismatch.
-- No CI config anywhere. No workflow encodes the build, so the Makefile is the only ground truth.
+- Two CI signals on a PR, neither of which builds the app the way the Makefile does: `conventional-commit-title` (`.github/workflows/pr-title.yml`, Actions is enabled) and `Cloudflare Pages`, which builds from git using the dashboard's own settings. The Makefile is still the only place the local build story is written down.
 
 ## Verified
 
@@ -49,7 +49,7 @@ Tests print a lot of `console.debug` from the scoring path. Expected, not a fail
 - `wrangler.toml` holds `name = "rak-sadness"` (the real Pages project), `compatibility_date`, and the `RAK_SADNESS_BUCKET` R2 binding pointing at the `rak-sadness` bucket.
 - **Do not add `pages_build_output_dir` to `wrangler.toml`.** It makes `pages:dev` fail with `Specify either a directory OR a proxy command, not both`, because that script uses proxy mode to keep hot reload. Its absence is deliberate.
 - `functions/api/picks/[week].ts` reads `picks/<week>.xlsx` from the binding. Locally the bucket is simulated and empty, so `/api/picks/:week` returns 404 until seeded: `wrangler r2 object put rak-sadness/picks/1.xlsx --file <path> --local`.
-- `pages:deploy` and the Cloudflare-side git build have not been exercised against this `wrangler.toml`. The project builds from git, so watch the first deploy after this file landed.
+- The Cloudflare Pages build passed on the branch that added this `wrangler.toml`, so the config does not break the git-triggered build. `npm run pages:deploy` from a laptop has still never run against it.
 - Not a blocker for local work: `src/components/RakSadness.tsx` deliberately skips that fetch on localhost and falls back to manual spreadsheet upload.
 - `npm run pages:deploy` needs Cloudflare auth (`wrangler login`, or `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`). Deliberately not a make target: deploying is not an agent action to take unprompted.
 - Wrangler is pinned at 3.x and warns that 4.x is out.

--- a/.claude/skills/build-run-test/SKILL.md
+++ b/.claude/skills/build-run-test/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: build-run-test
+description: How to build, run, and test this repo. Read before any npm, make, tsc, eslint, prettier, or wrangler command here, before adding a Makefile target, before touching CI. Make targets, node version, ports, Cloudflare prereqs, known gotchas.
+---
+
+# Build, run, test
+
+`make help` lists targets. Run targets, not raw npm scripts.
+
+## Toolchain
+
+- Node `v20.8` (`.nvmrc`), npm 10 (`lockfileVersion: 3`). `nvm use` before anything. `make setup` fails with an actionable message on a major mismatch.
+- No CI config anywhere. No workflow encodes the build, so the Makefile is the only ground truth.
+
+## Verified
+
+From a clean checkout: `make setup`, `make build`, `make run`, `make test`, `make check` all green. `make run` serves `http://localhost:3000`, HTTP 200, `<title>Rak Madness Scoreboard</title>`. `CI=true npm run build` also green — keep it that way, since CI treats warnings as errors and the codebase has warning-free build lint today.
+
+## Tests
+
+67 cases, 4 suites, all offline:
+
+- `src/utils/getPickResults.test.ts` — spread scoring (favorite covers / fails to cover, underdog, push, tie, half-point spread, missing pick vs missing game, live and upcoming state). `getPickResults` is exported from `getPlayerScores.ts` for this. `getPlayerScores` itself is not directly testable: it takes an `ArrayBuffer` workbook and calls `getLeagueResults`, which hits ESPN.
+- `src/context/ToastContext.test.tsx` — queue cap of 3, removal by id, 5-second auto-dismiss. Uses fake timers, so `userEvent.setup` is passed `advanceTimers`.
+- `src/components/table/explanation/ExplanationTable.test.tsx` — headers, per-pick status classes, explanation toasts. Mocks `useToastContext`.
+- `src/components/RakSadness.test.tsx` — week lookup, localhost picks-fetch skip, upload, results views, refresh, export. Mocks `getLeagueInfo`, `getPlayerScores`, `buildSpreadsheetBuffer`.
+
+Writing a component test here:
+
+- Mount `RakSadness` inside `ToastContextProvider` with `Toaster` beside it, like `index.tsx` does. Toasts render in `Toaster`, so without it no toast assertion can pass.
+- The week `Select` compares option values by reference, so a fixture's `activeWeek` must be the same object as its entry in `weeks`.
+- Don't name a helper `render*` unless it returns the render result — `testing-library/render-result-naming-convention` is an error, not a warning.
+- `testing-library/no-node-access` is off for test files (`.eslintrc.json` overrides): the file input is hidden and the navbar buttons are only identifiable by class.
+
+Tests print a lot of `console.debug` from the scoring path. Expected, not a failure.
+
+## Gotchas
+
+- `make run`: set `BROWSER=none` for a headless start, or CRA opens a browser tab. `make run PORT=3001` moves it, which is how you get two dev servers side by side.
+- Sass prints `legacy-js-api` deprecation warnings on every dev-server compile. Noise, not breakage.
+- One ESLint config: `.eslintrc.json`, extending `react-app` and `react-app/jest` alongside the TypeScript and import presets. `package.json` has no `eslintConfig` key. `npm run lint` and the lint pass inside `react-scripts build` now enforce the same rules. Keep it that way — a second surface means rules that silently apply to only one.
+- Lint is warning-free and must stay so: `CI=true npm run build` (which is what a Cloudflare Pages CI build does) treats warnings as errors.
+- `make format` runs `eslint --fix` first, then prettier. That order matters: eslint's fixes are not prettier-clean, so the formatter has to run last or `make check` fails right after `make format`.
+- Root `tsconfig.json` excludes `functions/**/*`, so `make typecheck` runs `tsc` twice, once per config.
+
+## Cloudflare Pages, not wrapped in make
+
+- `npm run pages:dev` works: wrangler proxies on 3000, CRA runs on 3001 (`PORT=3001` in the script). Verified serving `/` 200 and executing the Pages Function. No make target wraps it because wrangler warns the `-- <command>` form is deprecated, so this script is on borrowed time.
+- `wrangler.toml` holds `name = "rak-sadness"` (the real Pages project), `compatibility_date`, and the `RAK_SADNESS_BUCKET` R2 binding pointing at the `rak-sadness` bucket.
+- **Do not add `pages_build_output_dir` to `wrangler.toml`.** It makes `pages:dev` fail with `Specify either a directory OR a proxy command, not both`, because that script uses proxy mode to keep hot reload. Its absence is deliberate.
+- `functions/api/picks/[week].ts` reads `picks/<week>.xlsx` from the binding. Locally the bucket is simulated and empty, so `/api/picks/:week` returns 404 until seeded: `wrangler r2 object put rak-sadness/picks/1.xlsx --file <path> --local`.
+- `pages:deploy` and the Cloudflare-side git build have not been exercised against this `wrangler.toml`. The project builds from git, so watch the first deploy after this file landed.
+- Not a blocker for local work: `src/components/RakSadness.tsx` deliberately skips that fetch on localhost and falls back to manual spreadsheet upload.
+- `npm run pages:deploy` needs Cloudflare auth (`wrangler login`, or `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`). Deliberately not a make target: deploying is not an agent action to take unprompted.
+- Wrangler is pinned at 3.x and warns that 4.x is out.
+
+## Offline
+
+`make setup` needs network (`npm ci`). `make build`, `make check`, `make test`, `make run` work offline once `node_modules` exists. `make run` fetches live ESPN endpoints at runtime (`src/utils/getLeagueInfo.ts`, `getLeagueResults.ts`), so scoring needs network even though the dev server does not.

--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: commit-and-pr
+description: This repo's commit and PR conventions. Read before writing any git commit message, `gh pr create`/`gh pr edit` title, or PR body here. Header format, ticket key placement, scope vocabulary, PR template.
+---
+
+# Commits and pull requests
+
+- Commit subject + PR title, one format: `<type>(<scope>)?!?: [<issue>]? <imperative summary>`. Conventional Commits types. `!` = breaking.
+- Scope = module. `[<issue>]` = main ticket ID: `feat(auth): [YCOM-21] add device-code login`.
+- PR body: build from `.github/pull_request_template.md`, write over its comments. `--body`/`--body-file` skip prefill.
+- Commit body: only a why subject can't carry.
+- Enforced by `.claude/hooks/check_conventions.py`, `.github/workflows/pr-title.yml`.
+- No bypass. Rewrite text, don't work around hook.

--- a/.claude/skills/parallel-work/SKILL.md
+++ b/.claude/skills/parallel-work/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: parallel-work
+description: Which parts of this repo are safe to edit at the same time. Read before splitting work across parallel agents, git worktrees, or subagents here, and before a change touching more than one module. Independent modules, shared state forcing serialization, known collision hotspots.
+---
+
+# Parallel work
+
+Single build root, one `package.json`, one `package-lock.json`. No module boundaries to respect, so every collision here is file-level or port-level, not build-level.
+
+## Serialize these
+
+- **`package.json` + `package-lock.json`** — one lockfile for the whole repo. Two agents adding dependencies in separate worktrees both rewrite it; the merge is a conflict every time. One agent owns dependency changes per branch.
+- **`src/components/RakSadness.tsx`** (429 lines) — app root: week select, spreadsheet upload, `/api/picks/:week` fetch, score calc, XLSX export. Nearly every UI feature lands here. Two agents on unrelated UI work still collide. Split by giving one agent this file and the other a leaf component.
+- **`src/utils/getPlayerScores.ts`** (576 lines) — all scoring, knockout, and tiebreaker logic in one file. Same story: scoring changes serialize.
+- **Port 3000** — separate worktrees still contend for the same localhost port. Not a blocker: `make run PORT=3001` moves the dev server, so the second agent overrides instead of taking the default. `npm run pages:dev` occupies 3000 and 3001 together.
+
+## Watch, don't serialize
+
+- `src/setupTests.ts` is shared by every suite, but it holds one import line and rarely changes.
+- Each `*.test.*` file pairs with one source file, so test work splits the same way the source does. Two agents adding suites for different files do not collide.
+
+## Safe in parallel
+
+- Leaf components under `src/components/` (`footer/`, `navbar/`, `toaster/`, `table/explanation/`, `table/playerName/`) — each is its own `.tsx` + `.scss` pair, no cross-imports between them.
+- `src/utils/` files other than `getPlayerScores.ts`: `getLeagueInfo.ts`, `getLeagueResults.ts`, `buildSpreadsheetBuffer.ts`, `getClasses.ts`, `rangeWithPrefix.ts`.
+- `functions/api/picks/[week].ts` — Cloudflare Pages Function, touched by nothing in `src/` except the fetch URL.
+- `public/` static assets.
+
+## Cleared
+
+- No shared `build/`-style output across worktrees; each worktree gets its own `build/` and `node_modules/`.
+- No `.env` files, no docker-compose services, no shared database, no fixed host:port literals in config.
+- `~/.npm` cache is lock-safe under concurrent `npm ci`.
+
+## Note
+
+`src/types/` is imported by 5 files, but type files are append-mostly and rarely conflict. Watch it, don't serialize on it.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,10 +11,20 @@
     "plugin:import/recommended",
     "plugin:import/electron",
     "plugin:import/typescript",
+    "react-app",
+    "react-app/jest",
     "prettier"
   ],
   "parser": "@typescript-eslint/parser",
   "rules": {
     "@typescript-eslint/no-explicit-any": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.test.ts", "**/*.test.tsx"],
+      "rules": {
+        "testing-library/no-node-access": "off"
+      }
+    }
+  ]
 }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+<!--
+This title and every commit subject share the Conventional Commits 1.0.0 format:
+https://www.conventionalcommits.org/en/v1.0.0/
+
+  <type>(<scope>)?!?: [<issue>]? <imperative summary>
+
+  types    build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+  (scope)  the module changed, in parentheses. Optional
+  !        optional, marks a breaking change
+  [issue]  the main ticket ID in brackets. Omit when there is no ticket
+  :        required, followed by one space
+
+  feat(auth): [YCOM-21] add device-code login
+  refactor(api)!: drop v1 response envelope
+
+Shortest body a reviewer can review from. Bullets, not paragraphs. Every line must
+change how they read the diff. No restating the diff, no process narration.
+No em-dashes, no semicolons. Short sentences instead, one idea each. Plain words
+a reader takes in once. Delete sections that don't apply. Leave no empty headings.
+-->
+
+## What
+
+<!-- What changed and where. Link every ticket this belongs to (Jira, Linear), the one in the title first. -->
+
+## Why
+
+<!-- The problem. Skip if What covers it. -->
+
+## Changes
+
+<!--
+One bullet per substantive change: the design decisions a reviewer would otherwise reverse-engineer, and what is
+deliberately out of scope. Skip the mechanical ones.
+-->
+
+## Verification
+
+<!-- Only checks CI can't show: a manual repro, a one-off check. Never the standard build, test, lint, or hooks. Else delete. -->
+
+## Notes / Follow-ups
+
+<!-- Only what a reviewer or merger would be wrong not to know: a gap this PR doesn't fix, merge ordering, a dependent PR. Else delete. -->

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,55 @@
+# Fails a PR whose title is not a Conventional Commit.
+# Spec: https://www.conventionalcommits.org/en/v1.0.0/
+#
+# The title arrives via env, never interpolated into the shell: a title holding
+# shell metacharacters cannot inject commands.
+# Adding a type: extend `pattern` here and the template's type list.
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-commit-title:
+    # Bots title PRs their own way (Renovate's default is prose), configured in the
+    # bot rather than by a contributor. Humans cannot set this field.
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          # <type>(<scope>)?!?: [<issue>]? <imperative summary>, matched
+          # case-insensitively: the spec treats the units as case-insensitive, only
+          # BREAKING CHANGE must be upper. The bracketed ticket ID is part of the
+          # summary, so `.+` already accepts it, and whether a PR has a ticket is not
+          # knowable here. The hook checks that half.
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^()[:space:]]+\))?!?: .+'
+          if printf '%s' "$TITLE" | grep -qEi "$pattern"; then
+            echo "OK: $TITLE"
+            exit 0
+          fi
+          cat >&2 <<'MSG'
+          This title and every commit subject share the Conventional Commits 1.0.0 format:
+          https://www.conventionalcommits.org/en/v1.0.0/
+
+            <type>(<scope>)?!?: [<issue>]? <imperative summary>
+
+          types    build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+          (scope)  the module changed, in parentheses. Optional
+          !        optional, marks a breaking change
+          [issue]  the main ticket ID in brackets. Omit when there is no ticket
+          :        required, followed by one space
+
+            feat(auth): [YCOM-21] add device-code login
+            refactor(api)!: drop v1 response envelope
+
+          MSG
+          echo "Got: $TITLE" >&2
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Personal Claude Code settings (never checked in)
+**/.claude/settings.local.json
+
+# Python bytecode caches, the checked-in Claude Code hooks' included
+__pycache__/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "cloudflare-docs": {
+      "type": "http",
+      "url": "https://docs.mcp.cloudflare.com/mcp"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}

--- a/AGENTIFY_RECOMMENDATIONS.md
+++ b/AGENTIFY_RECOMMENDATIONS.md
@@ -4,16 +4,15 @@ What is left. Everything below was recommended but not applied, with the reason.
 
 ## Build
 
-### The deploy path has not been exercised against `wrangler.toml`
+### `pages:deploy` has not been run against `wrangler.toml`
 
-`wrangler.toml` now declares `name = "rak-sadness"`, `compatibility_date`, and the `RAK_SADNESS_BUCKET` binding on the `rak-sadness` bucket. Local dev is verified: wrangler reports the binding, the Pages Function runs, `/` serves 200.
+`wrangler.toml` declares `name = "rak-sadness"`, `compatibility_date`, and the `RAK_SADNESS_BUCKET` binding on the `rak-sadness` bucket. Local dev is verified: wrangler reports the binding, the Pages Function runs, `/` serves 200. The `Cloudflare Pages` check also passed on the PR that added the file, so the git-triggered build tolerates it.
 
-It deliberately omits `pages_build_output_dir`, because that key makes `pages:dev` fail with `Specify either a directory OR a proxy command, not both` and hot reload is worth more than the key. That choice is unverified against two things this environment cannot reach:
+What is still untested is `npm run pages:deploy` from a laptop. It is auth-gated and production-affecting, and `wrangler *` sits in `ask`, so it was not run.
 
-- `npm run pages:deploy` — auth-gated, production-affecting, and `wrangler *` sits in `ask`, so it was not run.
-- The Cloudflare-side git build. The project has `Git Provider: Yes`, so pushes trigger a build on Cloudflare, which previously ran with no `wrangler.toml` at all.
+The file omits `pages_build_output_dir` on purpose: that key makes `pages:dev` fail with `Specify either a directory OR a proxy command, not both`, and hot reload is worth more.
 
-**Suggested action:** watch the first deploy after this file lands. If the Cloudflare build complains about a missing `pages_build_output_dir`, add `pages_build_output_dir = "build"` and change `pages:dev` to `npm run build && wrangler pages dev --port 3000`, giving up hot reload.
+**Suggested action:** if a Cloudflare build ever does ask for that key, add `pages_build_output_dir = "build"` and change `pages:dev` to `npm run build && wrangler pages dev --port 3000`, giving up hot reload.
 
 To make `/api/picks/:week` return a real spreadsheet locally: `wrangler r2 object put rak-sadness/picks/1.xlsx --file <path> --local`.
 
@@ -52,9 +51,9 @@ Documented in `.claude/skills/parallel-work/SKILL.md`. One advisory item remains
 
 ## Contrib
 
-### Actions is not enabled for this repo
+### Nothing outstanding
 
-`.github/workflows/pr-title.yml` is checked in and kept at your request, but it will not run until GitHub Actions is enabled. Until then, PR titles are enforced for agents only, by `.claude/hooks/check_conventions.py`.
+`.github/workflows/pr-title.yml` runs. It reported as `conventional-commit-title` on the PR that added it, so Actions is enabled and the gate is live for everyone. `.claude/hooks/check_conventions.py` covers agents before they reach the gate.
 
 ### Existing history does not follow Conventional Commits
 

--- a/AGENTIFY_RECOMMENDATIONS.md
+++ b/AGENTIFY_RECOMMENDATIONS.md
@@ -1,0 +1,78 @@
+# Agentify recommendations
+
+What is left. Everything below was recommended but not applied, with the reason.
+
+## Build
+
+### The deploy path has not been exercised against `wrangler.toml`
+
+`wrangler.toml` now declares `name = "rak-sadness"`, `compatibility_date`, and the `RAK_SADNESS_BUCKET` binding on the `rak-sadness` bucket. Local dev is verified: wrangler reports the binding, the Pages Function runs, `/` serves 200.
+
+It deliberately omits `pages_build_output_dir`, because that key makes `pages:dev` fail with `Specify either a directory OR a proxy command, not both` and hot reload is worth more than the key. That choice is unverified against two things this environment cannot reach:
+
+- `npm run pages:deploy` — auth-gated, production-affecting, and `wrangler *` sits in `ask`, so it was not run.
+- The Cloudflare-side git build. The project has `Git Provider: Yes`, so pushes trigger a build on Cloudflare, which previously ran with no `wrangler.toml` at all.
+
+**Suggested action:** watch the first deploy after this file lands. If the Cloudflare build complains about a missing `pages_build_output_dir`, add `pages_build_output_dir = "build"` and change `pages:dev` to `npm run build && wrangler pages dev --port 3000`, giving up hot reload.
+
+To make `/api/picks/:week` return a real spreadsheet locally: `wrangler r2 object put rak-sadness/picks/1.xlsx --file <path> --local`.
+
+### `pages:dev` uses a deprecated wrangler form
+
+Verified working, but wrangler 3.114 warns that `pages dev -- <command>` is deprecated and will be removed. Wrangler 4 is out.
+
+**Suggested action:** when you upgrade to wrangler 4, switch to `wrangler pages dev ./build` against a built directory. That loses hot reload, so it is a different workflow, not a drop-in swap.
+
+### 34 npm vulnerabilities need a breaking upgrade
+
+`npm audit fix` was run and fixed nothing. The remaining 34 (9 low, 7 moderate, 18 high) are all transitive through `react-scripts` 5, which is unmaintained. `npm audit fix --force` would replace it.
+
+**Suggested action:** migrating off `react-scripts` to Vite is the real fix. That is a project, not a chore. It would also clear the deprecated-wrangler and Sass `legacy-js-api` warnings.
+
+### Test coverage gaps
+
+67 tests now cover the scoring logic, the toast queue, the explanation table, and the `RakSadness` flows. Still untested:
+
+- The XLSX parsing and player-ranking half of `getPlayerScores` — needs a fixture workbook plus a stubbed `getLeagueResults`.
+- `buildSpreadsheetBuffer` — needs assertions against a generated workbook.
+- `getLeagueInfo` / `getLeagueResults` — need recorded ESPN responses.
+- `ScoresTable`, `Navbar`, `Footer`, `Toaster` in isolation. `Toaster` and `ScoresTable` are exercised indirectly through the `RakSadness` suite.
+
+**Suggested action:** worth doing if the knockout or tiebreaker rules change, or before a Vite migration, so the migration has a safety net.
+
+## Boundaries
+
+Documented in `.claude/skills/parallel-work/SKILL.md`. One advisory item remains.
+
+### Two chokepoint files serialize most parallel work
+
+`src/components/RakSadness.tsx` and `src/utils/getPlayerScores.ts` (~580 lines of scoring). Almost any two feature branches touch one of them.
+
+**Suggested action:** advisory only. Extracting the upload/fetch flow out of `RakSadness.tsx` into a hook, and splitting `getPlayerScores.ts` by concern, would let more work run in parallel. Not worth doing for its own sake.
+
+## Contrib
+
+### Actions is not enabled for this repo
+
+`.github/workflows/pr-title.yml` is checked in and kept at your request, but it will not run until GitHub Actions is enabled. Until then, PR titles are enforced for agents only, by `.claude/hooks/check_conventions.py`.
+
+### Existing history does not follow Conventional Commits
+
+0 of the last 100 commit subjects conform. Published history is never rewritten to fit a convention, so nothing to do — the convention starts with the next commit.
+
+## Config
+
+### Deliberately left prompting
+
+- `npm run pages:deploy`, `wrangler *`, `npx wrangler *` are in `ask`. They deploy to production or mutate Cloudflare state, so they should never fire unattended.
+- `git push --force` / `-f` are in `deny`, even though everyday `git` and `gh` are allowed.
+
+### Activation prerequisites
+
+- Project `allow` rules and the three checked-in hooks only take effect after you accept the workspace trust dialog for this repo.
+- An org policy of `allowManagedHooksOnly` would disable the project hooks entirely.
+- `.mcp.json` servers need per-user approval on first run; both currently show `⏸ Pending approval`.
+
+## MCP
+
+`cloudflare-docs` and `playwright` are in `.mcp.json`; the `yahoo-connectors` gateway was removed at your request. Neither needs an environment variable. `playwright` downloads a browser on first use.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# rak-sadness-web
+
+Auto-scoring web app for the Rak Madness football pool. Create React App + TypeScript, MUI Joy, SCSS. Scores an uploaded weekly picks spreadsheet against ESPN game results, exports XLSX. Deployed to Cloudflare Pages (`wrangler`); `functions/api/picks/[week].ts` is the Pages Function serving stored picks.
+
+## Subdirectories
+
+- [`public/`](public/CLAUDE.md) — CRA static shell and PWA assets
+- [`src/`](src/CLAUDE.md) — application source
+
+## Maintaining this tree
+
+Navigation index. Changed a dir: update its CLAUDE.md summary and the parent's
+link. New meaningful dir: add a CLAUDE.md, link it. Pointer <= 70 chars.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+.DEFAULT_GOAL := help
+.PHONY: help setup build run test check lint typecheck format
+
+# Override to run a second dev server alongside the first, e.g. make run PORT=3001
+PORT ?= 3000
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "%-12s %s\n", $$1, $$2}'
+
+setup: ## Install dependencies from the lockfile (idempotent)
+	@command -v node >/dev/null || { echo "Missing node. Install $$(cat .nvmrc): brew install node@20"; exit 1; }
+	@req=$$(sed 's/^v//' .nvmrc | cut -d. -f1); cur=$$(node -v | sed 's/^v//' | cut -d. -f1); \
+	  [ "$$req" = "$$cur" ] || { echo "Node major $$cur found, .nvmrc requires $$req. Run: nvm install && nvm use"; exit 1; }
+	npm ci
+
+build: ## Production build into ./build (what pages:deploy uploads)
+	npm run build
+
+run: ## Start the CRA dev server (PORT=3000 by default)
+	PORT=$(PORT) npm start
+
+test: ## Run the Jest suite once (no watch mode)
+	CI=true npm test -- --watchAll=false
+
+check: lint typecheck test ## Lint, typecheck, test, and format-check everything
+	npm run prettier
+
+lint: ## ESLint over .ts/.tsx
+	npm run lint
+
+typecheck: ## tsc --noEmit for src/ and functions/ separately
+	npx tsc --noEmit
+	npx tsc --noEmit -p functions/tsconfig.json
+
+format: ## Apply eslint --fix, then prettier (formatter runs last, so it wins)
+	npm run format

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rak Sadness
 
-Simple auto-scoring web application for [Rak Madness](https://rakmadness.net/). The [public site](https://rak.cullenrombach.com/) is hosted on CloudFlare Pages.
+Simple auto-scoring web application for [Rak Madness](https://rakmadness.net/). The [public site](https://rak.cullenrombach.com/) is hosted on [CloudFlare Pages](https://developers.cloudflare.com/pages/).
 
 Results are viewable on the web and can be exported to an XLSX spreadsheet.
 
@@ -11,3 +11,24 @@ Here is a [spreadsheet for team abbreviations](https://docs.google.com/spreadshe
 Here is a link to [the Google Drive folder containing historical picks and scores spreadsheets](https://drive.google.com/drive/folders/1oHVWKoAbDtT2vJLU3yBP9ofEOPEzNrqi?usp=sharing).
 
 This was thrown together using KISS principles for a small, family-and-friends football pool. It is not intended for public (or at-scale) use and, as such, should not be judged too harshly.
+
+## Development
+
+Requires Node `v20.8` (`.nvmrc`). Run `nvm use` first.
+
+```
+make setup   # install dependencies from the lockfile
+make run     # dev server on http://localhost:3000 (make run PORT=3001 to move it)
+make build   # production build into ./build
+make test    # Jest, once, no watch mode
+make check   # lint, typecheck, test, prettier
+make format  # eslint --fix, then prettier
+```
+
+`make help` lists every target.
+
+`npm run pages:dev` runs the full Pages stack instead: wrangler proxies on port 3000 with the dev server behind it on 3001. The `/api/picks/:week` route is a Cloudflare Pages Function reading `picks/<week>.xlsx` from the `RAK_SADNESS_BUCKET` binding declared in `wrangler.toml`. Locally that bucket is simulated and starts empty, so the route returns 404 and the app falls back to manual spreadsheet upload. Seed it with:
+
+```
+npx wrangler r2 object put rak-sadness/picks/1.xlsx --file <path> --local
+```

--- a/functions/api/picks/[week].ts
+++ b/functions/api/picks/[week].ts
@@ -10,6 +10,9 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   console.log(`Fetching picks for week ${week} from ${filePath}`);
   try {
     const spreadsheet = await context.env.RAK_SADNESS_BUCKET.get(filePath);
+    if (!spreadsheet) {
+      return new Response("Not Found", { status: 404 });
+    }
 
     // Create an identity TransformStream (a.k.a. a pipe).
     // The readable side will become our new response body.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "xlsx-js-style": "^1.2.0"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@cloudflare/workers-types": "^4.20240919.0",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
@@ -61,24 +62,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -87,28 +76,28 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
-      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
-      "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/helper-compilation-targets": "^7.25.2",
-        "@babel/helper-module-transforms": "^7.25.2",
-        "@babel/helpers": "^7.25.0",
-        "@babel/parser": "^7.25.0",
-        "@babel/template": "^7.25.0",
-        "@babel/traverse": "^7.25.2",
-        "@babel/types": "^7.25.2",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -170,14 +159,15 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
-      "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dependencies": {
-        "@babel/types": "^7.25.6",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -207,13 +197,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
-      "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dependencies": {
-        "@babel/compat-data": "^7.25.2",
-        "@babel/helper-validator-option": "^7.24.8",
-        "browserslist": "^4.23.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -296,6 +286,14 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
@@ -309,26 +307,25 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
-      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
-      "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-simple-access": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "@babel/traverse": "^7.25.2"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -349,9 +346,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
-      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -413,25 +410,25 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
-      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -450,23 +447,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -647,9 +644,17 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1320,14 +1325,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.0.tgz",
-      "integrity": "sha512-YPJfjQPDXxyQWg/0+jHKj1llnY5f/R6a0p/vP4lPymxLu7Lvl4k2WMitqi08yxwQcCVUUdG9LCUj4TNEgAp3Jw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.8.tgz",
+      "integrity": "sha512-6iSnEK0zlkLKU4heofK/AdmRD4e2SHVpJMtrwnTCzhnaM98ria4rTrOXBBi45BTTYnJtO8txnPsX4fChYXkmeA==",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.25.0",
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "@babel/traverse": "^7.25.0"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1908,6 +1913,17 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/preset-env/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -1980,42 +1996,42 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
-      "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.6",
-        "@babel/parser": "^7.25.6",
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.6",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3606,9 +3622,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4929,30 +4945,27 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4972,9 +4985,9 @@
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -6091,14 +6104,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -6187,9 +6192,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -6693,133 +6698,133 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@webassemblyjs/ast": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA=="
     },
     "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ=="
     },
     "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA=="
     },
     "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA=="
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ=="
     },
     "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-opt": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1",
-        "@webassemblyjs/wast-printer": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -6880,14 +6885,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -6953,9 +6950,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6984,9 +6981,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7691,6 +7688,17 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -7742,9 +7750,9 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "dependencies": {
         "bytes": "~3.1.2",
         "content-type": "~1.0.5",
@@ -7754,7 +7762,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -7830,9 +7838,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7855,9 +7863,9 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "node_modules/browserslist": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7873,10 +7881,11 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -8010,9 +8019,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001663",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
-      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -9073,9 +9082,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true
     },
     "node_modules/delayed-stream": {
@@ -9377,9 +9386,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.27",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.27.tgz",
-      "integrity": "sha512-o37j1vZqCoEgBuWWXLHQgTN/KDKe7zwpiY5CPeq2RvUqOyJw9xnrULzZAEVQ5p4h+zjMk7hgtOoPdnLxr7m/jw=="
+      "version": "1.5.403",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
+      "integrity": "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -9414,12 +9423,12 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -9573,9 +9582,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -10462,13 +10471,13 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -10487,7 +10496,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -10567,9 +10576,19 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -10659,17 +10678,17 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -10776,14 +10795,14 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -10990,14 +11009,14 @@
       }
     },
     "node_modules/form-data": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
-      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
+      "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35"
       },
       "engines": {
@@ -11253,7 +11272,8 @@
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
     },
     "node_modules/global-modules": {
       "version": "2.0.0",
@@ -11441,9 +11461,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -11675,9 +11695,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
@@ -11773,9 +11793,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw=="
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -15836,9 +15856,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -15892,14 +15922,14 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -15950,19 +15980,19 @@
       }
     },
     "node_modules/jsonpath": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
-      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.3.0.tgz",
+      "integrity": "sha512-0kjkYHJBkAy50Z5QzArZ7udmvxrJzkpKYW27fiF//BrMY7TQibYLl+FYIXN2BiYmwMIVzSfD8aDRj6IzgBX2/w==",
       "dependencies": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.12.1"
+        "esprima": "1.2.5",
+        "static-eval": "2.1.1",
+        "underscore": "1.13.6"
       }
     },
     "node_modules/jsonpath/node_modules/esprima": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-      "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+      "integrity": "sha512-S9VbPDU0adFErpDai3qDkjq8+G05ONtKzcyNrPKg/ZKa+tf879nX2KexNU95b31UoTJjRLInNBHHHjFPoCd7lQ==",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -16042,12 +16072,12 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.9.1.tgz",
-      "integrity": "sha512-Gcnl4Bd+hRO9P9icCP/RVVT2o8SFlPXofuCxvA2SaZuH45whSvf5p8x5oih5ftLiVhEI4sp5xDY+R+b3zJBh5w==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "dependencies": {
-        "picocolors": "^1.0.0",
-        "shell-quote": "^1.8.1"
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/leven": {
@@ -16083,14 +16113,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
-    "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
-      "engines": {
-        "node": ">=6.11.5"
-      }
-    },
     "node_modules/loader-utils": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
@@ -16119,9 +16141,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -16428,9 +16450,9 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -16444,6 +16466,65 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/minipass": {
@@ -16502,9 +16583,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -16551,9 +16632,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -16564,9 +16645,12 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -17014,9 +17098,9 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -17043,9 +17127,9 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -17204,9 +17288,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -17222,8 +17306,8 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -17705,14 +17789,17 @@
       }
     },
     "node_modules/postcss-load-config/node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/postcss-loader": {
@@ -18361,6 +18448,14 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
     },
+    "node_modules/postcss-svgo/node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/postcss-svgo/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -18370,16 +18465,16 @@
       }
     },
     "node_modules/postcss-svgo/node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.3.tgz",
+      "integrity": "sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==",
       "dependencies": {
-        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
         "picocolors": "^1.0.0",
+        "sax": "^1.5.0",
         "stable": "^0.1.8"
       },
       "bin": {
@@ -18581,11 +18676,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -19288,9 +19384,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -19586,9 +19682,9 @@
       }
     },
     "node_modules/schema-utils": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
-      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -19596,7 +19692,7 @@
         "ajv-keywords": "^5.1.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 10.13.0"
       },
       "funding": {
         "type": "opencollective",
@@ -19604,9 +19700,9 @@
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19893,21 +19989,24 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -19919,12 +20018,12 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -20170,88 +20269,11 @@
       }
     },
     "node_modules/static-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.1.tgz",
+      "integrity": "sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA==",
       "dependencies": {
-        "escodegen": "^1.8.1"
-      }
-    },
-    "node_modules/static-eval/node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/static-eval/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
+        "escodegen": "^2.1.0"
       }
     },
     "node_modules/statuses": {
@@ -20574,9 +20596,9 @@
       }
     },
     "node_modules/sucrase/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -20609,11 +20631,11 @@
       }
     },
     "node_modules/sucrase/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -20761,9 +20783,9 @@
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "node_modules/svgo/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -20822,11 +20844,15 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/temp-dir": {
@@ -20898,15 +20924,14 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
-      "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.20",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
-        "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.1",
-        "terser": "^5.26.0"
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -20919,32 +20944,42 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
         "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
           "optional": true
         },
         "esbuild": {
           "optional": true
         },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
         "uglify-js": {
           "optional": true
         }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terser/node_modules/commander": {
@@ -21272,9 +21307,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/undici": {
       "version": "5.29.0",
@@ -21384,9 +21419,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -21402,8 +21437,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -21545,11 +21580,10 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -21578,33 +21612,30 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.94.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
-      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
+      "version": "5.109.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
+      "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
       "dependencies": {
-        "@types/estree": "^1.0.5",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.16.0",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.1",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.24.4",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
+        "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.10",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.2.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "watchpack": "^2.5.2",
+        "webpack-sources": "^3.5.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -21703,9 +21734,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -21758,34 +21789,36 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
       "engines": {
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
+    "node_modules/webpack/node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "bin": {
+        "acorn": "bin/acorn"
       },
       "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
@@ -22039,9 +22072,9 @@
       }
     },
     "node_modules/workbox-build/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22275,9 +22308,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "3.114.16",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.16.tgz",
-      "integrity": "sha512-ve/ULRjrquu5BHNJ+1T0ipJJlJ6pD7qLmhwRkk0BsUIxatNe4HP4odX/R4Mq/RHG6LOnVAFs7SMeSHlz/1mNlQ==",
+      "version": "3.114.17",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
+      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.3.4",
@@ -22427,9 +22460,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -22498,9 +22531,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "engines": {
         "node": ">= 6"
       }

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "pages:dev": "wrangler pages dev --compatibility-date=2023-10-30 --port 3000 -- npm start",
+    "pages:dev": "PORT=3001 wrangler pages dev --port 3000 -- npm start",
     "pages:deploy": "npm run build && wrangler pages deploy ./build",
     "lint": "eslint --ext .ts,.tsx .",
     "lint:fix": "npm run lint -- --fix",
     "prettier": "npx prettier . --check",
     "prettier:fix": "npm run prettier -- --write",
-    "format": "npm run prettier:fix && npm run lint:fix"
+    "format": "npm run lint:fix && npm run prettier:fix"
   },
   "dependencies": {
     "@emotion/react": "^11.13.3",
@@ -37,6 +37,7 @@
     "xlsx-js-style": "^1.2.0"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@cloudflare/workers-types": "^4.20240919.0",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
@@ -55,12 +56,6 @@
     "prettier": "^3.3.3",
     "typescript": "^4.9.5",
     "wrangler": "^3.78.8"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
   },
   "browserslist": {
     "production": [

--- a/public/CLAUDE.md
+++ b/public/CLAUDE.md
@@ -1,0 +1,3 @@
+# public
+
+CRA static assets: index.html shell (#root, %PUBLIC_URL%), manifest.json PWA metadata, favicon.ico/logo192.png/logo512.png icons, robots.txt (allow-all).

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,9 @@
+# src
+
+`index.tsx`: React 18 `createRoot` mount into `#root`, wraps `RakSadness` + `Toaster` in MUI Joy `CssVarsProvider` and `ToastContextProvider`. `theme.ts`: Joy `extendTheme` light/dark primary palette. `index.scss`: global resets. `context/ToastContext.tsx` (single file, no CLAUDE.md).
+
+## Subdirectories
+
+- [`components/`](components/CLAUDE.md) — React UI, app root `RakSadness`
+- [`types/`](types/CLAUDE.md) — ESPN, league, and scoring type declarations
+- [`utils/`](utils/CLAUDE.md) — score computation, ESPN fetching, spreadsheet export

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -1,0 +1,10 @@
+# components
+
+`RakSadness`: root app component. Week select, picks spreadsheet upload/fetch (`/api/picks/:week`), score calc, results export (.xlsx).
+
+## Subdirectories
+
+- [`footer/`](footer/CLAUDE.md) — bottom links bar
+- [`navbar/`](navbar/CLAUDE.md) — top nav bar
+- [`table/`](table/CLAUDE.md) — shared table styles and score/explanation table pieces
+- [`toaster/`](toaster/CLAUDE.md) — toast notification renderer

--- a/src/components/RakSadness.test.tsx
+++ b/src/components/RakSadness.test.tsx
@@ -1,0 +1,365 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { ToastContextProvider } from "../context/ToastContext";
+import { League, LeagueInfo, SeasonType, WeekInfo } from "../types/League";
+import { RakMadnessScores } from "../types/RakMadnessScores";
+import RakSadness from "./RakSadness";
+import Toaster from "./toaster/Toaster";
+
+jest.mock("../utils/getLeagueInfo");
+jest.mock("../utils/getPlayerScores");
+jest.mock("../utils/buildSpreadsheetBuffer");
+
+/* eslint-disable import/first */
+import getLeagueInfo from "../utils/getLeagueInfo";
+import { getPlayerScores, readFileToBuffer } from "../utils/getPlayerScores";
+import buildSpreadsheetBuffer from "../utils/buildSpreadsheetBuffer";
+/* eslint-enable import/first */
+
+const getLeagueInfoMock = getLeagueInfo as jest.MockedFunction<
+  typeof getLeagueInfo
+>;
+const getPlayerScoresMock = getPlayerScores as jest.MockedFunction<
+  typeof getPlayerScores
+>;
+const readFileToBufferMock = readFileToBuffer as jest.MockedFunction<
+  typeof readFileToBuffer
+>;
+const buildSpreadsheetBufferMock =
+  buildSpreadsheetBuffer as jest.MockedFunction<typeof buildSpreadsheetBuffer>;
+
+const CURRENT_WEEK = 3;
+
+function week(value: number): WeekInfo {
+  return {
+    value,
+    label: `Week ${value}`,
+    startDate: new Date(2024, 8, value),
+    endDate: new Date(2024, 8, value + 6),
+  };
+}
+
+const weeks = [week(1), week(2), week(3), week(4), week(5)];
+
+const leagueInfo: LeagueInfo = {
+  league: League.PRO,
+  activeCalendar: {
+    seasonType: SeasonType.REGULAR,
+    startDate: new Date(2024, 8, 1),
+    endDate: new Date(2025, 0, 1),
+    weeks,
+  },
+  // Same object as the matching entry in `weeks`, which is what the week Select
+  // compares against.
+  activeWeek: weeks[CURRENT_WEEK - 1],
+  calendars: [],
+};
+
+const scores: RakMadnessScores = {
+  tiebreaker: 47,
+  scores: [
+    {
+      name: "Alice",
+      score: { total: 5, college: 2, pro: 3, proAgainstTheSpread: 3 },
+      tiebreaker: { pick: 45, distance: 2 },
+      college: [
+        {
+          pick: "MICH",
+          status: "yes",
+          explanation: { header: "C1", message: "won" },
+        },
+      ],
+      pro: [
+        {
+          pick: "BUF",
+          status: "yes",
+          explanation: { header: "P1", message: "won" },
+        },
+      ],
+      status: { hasNoPicks: false, isKnockedOut: false },
+    },
+  ],
+};
+
+/** Mirrors index.tsx: toasts only appear if Toaster is mounted beside the app. */
+function mountApp() {
+  const user = userEvent.setup();
+  render(
+    <ToastContextProvider>
+      <RakSadness />
+      <Toaster />
+    </ToastContextProvider>,
+  );
+  return user;
+}
+
+/** The app only renders its controls once the ESPN week lookup resolves. */
+async function mountLoadedApp() {
+  const user = mountApp();
+  await screen.findByText("Use Local Spreadsheet");
+  return user;
+}
+
+function fileInput(): HTMLInputElement {
+  // The input is hidden behind a button, so target it directly.
+  return document.querySelector("input[type=file]") as HTMLInputElement;
+}
+
+async function uploadSpreadsheet(user: ReturnType<typeof userEvent.setup>) {
+  const file = new File(["picks"], "picks.xlsx", {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+  await user.upload(fileInput(), file);
+}
+
+/** Scoreboard, Explanation, Refresh, in the order RakSadness renders them. */
+function scoresHeaderButtons(): Array<HTMLElement> {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(".home__scores-header-button"),
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getLeagueInfoMock.mockResolvedValue(leagueInfo);
+  getPlayerScoresMock.mockResolvedValue(scores);
+  readFileToBufferMock.mockResolvedValue(new ArrayBuffer(8));
+  buildSpreadsheetBufferMock.mockResolvedValue(new ArrayBuffer(8));
+  global.fetch = jest.fn();
+  window.URL.createObjectURL = jest.fn(() => "blob:fake");
+  jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  jest.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("RakSadness, first load", () => {
+  it("asks ESPN for the pro league calendar", async () => {
+    await mountLoadedApp();
+    expect(getLeagueInfoMock).toHaveBeenCalledWith(League.PRO);
+  });
+
+  it("hides the controls until the week lookup resolves", () => {
+    let resolve: (info: LeagueInfo) => void = () => undefined;
+    getLeagueInfoMock.mockReturnValue(
+      new Promise<LeagueInfo>((r) => {
+        resolve = r;
+      }),
+    );
+    mountApp();
+    expect(screen.queryByText("Use Local Spreadsheet")).not.toBeInTheDocument();
+    resolve(leagueInfo);
+  });
+
+  it("defaults to the active week", async () => {
+    await mountLoadedApp();
+    expect(screen.getByRole("combobox")).toHaveTextContent(
+      `Week ${CURRENT_WEEK}`,
+    );
+  });
+
+  it("offers only weeks up to the current one, newest first", async () => {
+    const user = await mountLoadedApp();
+    await user.click(screen.getByRole("combobox"));
+    const options = screen
+      .getAllByRole("option")
+      .map((option) => option.textContent);
+    expect(options).toEqual(["Week 3", "Week 2", "Week 1"]);
+  });
+
+  it("shows the app title in the navbar", async () => {
+    await mountLoadedApp();
+    expect(screen.getByText("Rak Madness Scoreboard")).toBeInTheDocument();
+  });
+});
+
+describe("RakSadness, automatic picks fetch", () => {
+  it("skips the API on localhost and invites a local spreadsheet", async () => {
+    await mountLoadedApp();
+    await waitFor(() => {
+      expect(screen.getByText("Missing Picks")).toBeInTheDocument();
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(
+        `The picks spreadsheet for week ${CURRENT_WEEK} is not yet in the database, but you can use a local spreadsheet if you have one.`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not score anything when no picks were fetched", async () => {
+    await mountLoadedApp();
+    await waitFor(() => {
+      expect(screen.getByText("Missing Picks")).toBeInTheDocument();
+    });
+    expect(getPlayerScoresMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves the results buttons disabled with no scores", async () => {
+    await mountLoadedApp();
+    await waitFor(() => {
+      expect(screen.getByText("Missing Picks")).toBeInTheDocument();
+    });
+    expect(screen.getByText("View Results")).toBeDisabled();
+    expect(screen.getByText("Export Results")).toBeDisabled();
+  });
+
+  it("re-fetches when the week changes", async () => {
+    const user = await mountLoadedApp();
+    await waitFor(() => {
+      expect(screen.getByText("Missing Picks")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: "Week 1" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "The picks spreadsheet for week 1 is not yet in the database, but you can use a local spreadsheet if you have one.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("RakSadness, manual spreadsheet upload", () => {
+  it("scores the uploaded file for the selected week", async () => {
+    const user = await mountLoadedApp();
+    await uploadSpreadsheet(user);
+    await waitFor(() => {
+      expect(getPlayerScoresMock).toHaveBeenCalledTimes(1);
+    });
+    expect(getPlayerScoresMock.mock.calls[0][0]).toEqual(week(CURRENT_WEEK));
+  });
+
+  it("confirms success with a toast", async () => {
+    const user = await mountLoadedApp();
+    await uploadSpreadsheet(user);
+    await waitFor(() => {
+      expect(
+        screen.getByText("Generated results from picks spreadsheet"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("enables the results buttons once scores exist", async () => {
+    const user = await mountLoadedApp();
+    await uploadSpreadsheet(user);
+    await waitFor(() => {
+      expect(screen.getByText("View Results")).toBeEnabled();
+    });
+    expect(screen.getByText("Export Results")).toBeEnabled();
+  });
+
+  it("reports an aborted selection when no file is chosen", async () => {
+    await mountLoadedApp();
+    // userEvent.upload with an empty list fires no change event, which is what
+    // a cancelled file dialog looks like to the DOM. Fire it directly.
+    fireEvent.change(fileInput(), { target: { files: [] } });
+    await waitFor(() => {
+      expect(
+        screen.getByText("Aborted picks shreadsheet selection"),
+      ).toBeInTheDocument();
+    });
+    expect(getPlayerScoresMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("RakSadness, results views", () => {
+  async function mountWithScores() {
+    const user = await mountLoadedApp();
+    await uploadSpreadsheet(user);
+    await waitFor(() => {
+      expect(screen.getByText("View Results")).toBeEnabled();
+    });
+    return user;
+  }
+
+  it("opens the scoreboard view", async () => {
+    const user = await mountWithScores();
+    await user.click(screen.getByText("View Results"));
+    expect(screen.getByText("MNF Points Pick")).toBeInTheDocument();
+    expect(screen.queryByText("Use Local Spreadsheet")).not.toBeInTheDocument();
+  });
+
+  it("switches to the explanation view and back", async () => {
+    const user = await mountWithScores();
+    await user.click(screen.getByText("View Results"));
+
+    const [scoreboard, explanation] = scoresHeaderButtons();
+    await user.click(explanation);
+    expect(screen.getByText("College Score")).toBeInTheDocument();
+    expect(screen.queryByText("MNF Points Pick")).not.toBeInTheDocument();
+
+    await user.click(scoreboard);
+    expect(screen.getByText("MNF Points Pick")).toBeInTheDocument();
+  });
+
+  it("returns home from the logo button", async () => {
+    const user = await mountWithScores();
+    await user.click(screen.getByText("View Results"));
+    const logo = document.querySelector(".logo-button") as HTMLElement;
+    await user.click(logo);
+    expect(screen.getByText("Use Local Spreadsheet")).toBeInTheDocument();
+  });
+
+  it("recalculates on refresh", async () => {
+    const user = await mountWithScores();
+    await user.click(screen.getByText("View Results"));
+    expect(getPlayerScoresMock).toHaveBeenCalledTimes(1);
+
+    await user.click(scoresHeaderButtons()[2]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Results successfully updated"),
+      ).toBeInTheDocument();
+    });
+    expect(getPlayerScoresMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports a scoring failure instead of crashing", async () => {
+    const user = await mountWithScores();
+    await user.click(screen.getByText("View Results"));
+    getPlayerScoresMock.mockRejectedValueOnce(new Error("bad spreadsheet"));
+
+    await user.click(scoresHeaderButtons()[2]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          `Failed to calculate scores for week ${CURRENT_WEEK}.`,
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("RakSadness, export", () => {
+  it("builds and downloads a spreadsheet for the selected week", async () => {
+    const user = await mountLoadedApp();
+    await uploadSpreadsheet(user);
+    await waitFor(() => {
+      expect(screen.getByText("Export Results")).toBeEnabled();
+    });
+
+    const click = jest.spyOn(HTMLAnchorElement.prototype, "click");
+    await user.click(screen.getByText("Export Results"));
+
+    await waitFor(() => {
+      expect(buildSpreadsheetBufferMock).toHaveBeenCalledWith(
+        scores,
+        CURRENT_WEEK,
+      );
+    });
+    expect(click).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(
+        screen.getByText("Exported results spreadsheet"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/RakSadness.tsx
+++ b/src/components/RakSadness.tsx
@@ -68,7 +68,7 @@ export default function RakSadness() {
     getLeagueInfoAsync();
   }, []);
 
-  const fetchPicksBuffer = async () => {
+  const fetchPicksBuffer = useCallback(async () => {
     setPicksLoading(true);
     try {
       // Hack to disable this feature on localhost.
@@ -103,27 +103,30 @@ export default function RakSadness() {
       setScoresLoading(false);
       setPicksLoading(false);
     }
-  };
+  }, [selectedWeek, showToast]);
 
-  const calculateScores = async (picksBuffer: ArrayBuffer) => {
-    setScoresLoading(true);
-    try {
-      setScores(await getPlayerScores(selectedWeek, picksBuffer));
-    } catch (error) {
-      // If the scores failed to calculate, fail gracefully and log a message.
-      console.error("Failed to calculate scores", error);
-      setScores(null);
-      showToast(
-        new Toast(
-          "danger",
-          "Error",
-          `Failed to calculate scores for week ${selectedWeek.value}.`,
-        ),
-      );
-    } finally {
-      setScoresLoading(false);
-    }
-  };
+  const calculateScores = useCallback(
+    async (picksBuffer: ArrayBuffer) => {
+      setScoresLoading(true);
+      try {
+        setScores(await getPlayerScores(selectedWeek, picksBuffer));
+      } catch (error) {
+        // If the scores failed to calculate, fail gracefully and log a message.
+        console.error("Failed to calculate scores", error);
+        setScores(null);
+        showToast(
+          new Toast(
+            "danger",
+            "Error",
+            `Failed to calculate scores for week ${selectedWeek.value}.`,
+          ),
+        );
+      } finally {
+        setScoresLoading(false);
+      }
+    },
+    [selectedWeek, showToast],
+  );
 
   // When the week changes, attempt to fetch the picks spreadsheet from the API.
   useEffect(() => {
@@ -137,7 +140,7 @@ export default function RakSadness() {
       };
       getDataAsync();
     }
-  }, [selectedWeek, isWeekInfoLoading]);
+  }, [selectedWeek, isWeekInfoLoading, fetchPicksBuffer, calculateScores]);
 
   // When a user manually uploads a picks spreadsheet, parse and score it.
   const handleFileUpload: ChangeEventHandler<HTMLInputElement> = useCallback(
@@ -183,23 +186,26 @@ export default function RakSadness() {
 
       scoreSpreadsheetAsync();
     },
-    [selectedWeek],
+    [selectedWeek, showToast],
   );
 
   // Refresh the score data. Throttle so user can't spam clicks.
   // Wrapped by handleRefresh to avoid sending multiple requests
   // if first one is taking a long time.
-  const doRefreshThrottled = useCallback(
-    throttle(async () => {
-      refreshButtonRef.current?.classList.add("--spinning");
-      clearToasts();
-      await calculateScores(picksBuffer);
-      showToast(
-        new Toast("success", "Success", "Results successfully updated"),
-      );
-      refreshButtonRef.current?.classList.remove("--spinning");
-    }, 500),
-    [picksBuffer],
+  // useMemo, not useCallback: the value is throttle()'s wrapper, not the
+  // function literal, so useCallback cannot see its dependencies.
+  const doRefreshThrottled = useMemo(
+    () =>
+      throttle(async () => {
+        refreshButtonRef.current?.classList.add("--spinning");
+        clearToasts();
+        await calculateScores(picksBuffer);
+        showToast(
+          new Toast("success", "Success", "Results successfully updated"),
+        );
+        refreshButtonRef.current?.classList.remove("--spinning");
+      }, 500),
+    [picksBuffer, calculateScores, clearToasts, showToast],
   );
   const handleRefresh = useCallback(async () => {
     // Short-circuit if scores are already loading.
@@ -236,7 +242,7 @@ export default function RakSadness() {
       );
     };
     exportResultsAsync();
-  }, [scores, selectedWeek]);
+  }, [scores, selectedWeek, showToast]);
 
   const navbarLeft = useMemo(() => {
     <>
@@ -291,7 +297,7 @@ export default function RakSadness() {
         </Button>
       </>
     ) : null;
-  }, [showScores, scores]);
+  }, [showScores, scores, handleRefresh]);
 
   return (
     <div

--- a/src/components/footer/CLAUDE.md
+++ b/src/components/footer/CLAUDE.md
@@ -1,0 +1,4 @@
+# footer
+
+`Footer`: fixed-bottom links to Standings (rakmadness.net), GitHub repo, Donate (translifeline.org).
+Hidden below 460px viewport height.

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -4,17 +4,26 @@ import "./Footer.scss";
 export default function Footer() {
   return (
     <div className="footer">
-      <a href="https://rakmadness.net/standings-pickem" target="_blank">
+      <a
+        href="https://rakmadness.net/standings-pickem"
+        target="_blank"
+        rel="noreferrer"
+      >
         🏆 Standings
       </a>
       |
-      <a href="https://github.com/crombach/rak-sadness-web" target="_blank">
+      <a
+        href="https://github.com/crombach/rak-sadness-web"
+        target="_blank"
+        rel="noreferrer"
+      >
         🖥️ GitHub
       </a>
       |
       <a
         href="https://give.translifeline.org/give/461718/#!/donation/checkout"
         target="_blank"
+        rel="noreferrer"
       >
         🏳️‍⚧️ Donate
       </a>

--- a/src/components/navbar/CLAUDE.md
+++ b/src/components/navbar/CLAUDE.md
@@ -1,0 +1,7 @@
+# navbar
+
+`Navbar`: MUI Joy `Sheet`, `left`/`right` `ReactElement` slots.
+
+## Subdirectories
+
+- [`LogoButton/`](LogoButton/CLAUDE.md) — logo button used in navbar left slot

--- a/src/components/navbar/LogoButton/CLAUDE.md
+++ b/src/components/navbar/LogoButton/CLAUDE.md
@@ -1,0 +1,3 @@
+# LogoButton
+
+MUI Joy `Button` wrapping `logo192.png`, `onClick` prop. White drop-shadow filter on logo.

--- a/src/components/navbar/LogoButton/LogoButton.tsx
+++ b/src/components/navbar/LogoButton/LogoButton.tsx
@@ -9,7 +9,7 @@ export default function LogoButton({ onClick }: { onClick: () => void }) {
       onClick={onClick}
       className="logo-button"
     >
-      <img className="logo-button__logo" src="/logo192.png" />
+      <img className="logo-button__logo" src="/logo192.png" alt="" />
     </Button>
   );
 }

--- a/src/components/table/CLAUDE.md
+++ b/src/components/table/CLAUDE.md
@@ -1,0 +1,8 @@
+# table
+
+Table.scss: shared `.table` styles (sticky header/player col, pick status colors, striped rows).
+
+## Subdirectories
+
+- [`explanation/`](explanation/CLAUDE.md) — explanation-view table with pick toasts
+- [`playerName/`](playerName/CLAUDE.md) — player name cell with knocked-out icon

--- a/src/components/table/explanation/CLAUDE.md
+++ b/src/components/table/explanation/CLAUDE.md
@@ -1,0 +1,4 @@
+# explanation
+
+`ExplanationTable`: college/pro pick grid with per-pick explanation toast on click.
+Renders `PlayerName` per row, headers via `rangeWithPrefix` (C1..., P1...), uses `ToastContext`.

--- a/src/components/table/explanation/ExplanationTable.test.tsx
+++ b/src/components/table/explanation/ExplanationTable.test.tsx
@@ -1,0 +1,223 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import {
+  PickResult,
+  PlayerScore,
+  RakMadnessScores,
+  Status,
+} from "../../../types/RakMadnessScores";
+import { Toast, useToastContext } from "../../../context/ToastContext";
+import ExplanationTable from "./ExplanationTable";
+
+const showToast = jest.fn();
+const clearToasts = jest.fn();
+
+jest.mock("../../../context/ToastContext", () => {
+  const actual = jest.requireActual("../../../context/ToastContext");
+  return { ...actual, useToastContext: jest.fn() };
+});
+
+function pick(
+  label: string,
+  status: Status = "yes",
+  explanation = { header: `${label} header`, message: `${label} message` },
+): PickResult {
+  return { pick: label, status, explanation };
+}
+
+function player({
+  name,
+  college = [pick("C1 pick")],
+  pro = [pick("P1 pick")],
+  isKnockedOut = false,
+}: {
+  name: string;
+  college?: Array<PickResult>;
+  pro?: Array<PickResult>;
+  isKnockedOut?: boolean;
+}): PlayerScore {
+  return {
+    name,
+    score: { total: 3, college: 1, pro: 2, proAgainstTheSpread: 2 },
+    tiebreaker: { pick: 45, distance: 2 },
+    college,
+    pro,
+    status: {
+      hasNoPicks: false,
+      isKnockedOut,
+      explanation: isKnockedOut ? `${name} is out` : undefined,
+    },
+  };
+}
+
+const scores: RakMadnessScores = {
+  tiebreaker: 47,
+  scores: [
+    player({
+      name: "Alice",
+      college: [pick("MICH"), pick("OSU", "no")],
+      pro: [pick("BUF"), pick("KC", "incomplete"), pick("MIA", "error")],
+    }),
+    player({ name: "Bob", isKnockedOut: true }),
+  ],
+};
+
+beforeEach(() => {
+  showToast.mockClear();
+  clearToasts.mockClear();
+  (useToastContext as jest.Mock).mockReturnValue({
+    toasts: [],
+    showToast,
+    removeToast: jest.fn(),
+    clearToasts,
+  });
+});
+
+describe("ExplanationTable, empty states", () => {
+  it("renders nothing without scores", () => {
+    const { container } = render(<ExplanationTable />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when scores are null", () => {
+    const { container } = render(<ExplanationTable scores={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("ExplanationTable, headers", () => {
+  it("labels one column per pick, C-prefixed then P-prefixed", () => {
+    render(<ExplanationTable scores={scores} />);
+    const headers = screen
+      .getAllByRole("columnheader")
+      .map((header) => header.textContent);
+    expect(headers).toEqual([
+      "Rank",
+      "Player",
+      "C1",
+      "C2",
+      "College Score",
+      "P1",
+      "P2",
+      "P3",
+      "Pro Score",
+      "Total Score",
+    ]);
+  });
+
+  it("takes the column count from the first player", () => {
+    const uneven: RakMadnessScores = {
+      tiebreaker: 47,
+      scores: [
+        player({ name: "Alice", college: [pick("MICH")], pro: [pick("BUF")] }),
+        player({
+          name: "Bob",
+          college: [pick("OSU"), pick("PSU")],
+          pro: [pick("KC")],
+        }),
+      ],
+    };
+    render(<ExplanationTable scores={uneven} />);
+    const headers = screen
+      .getAllByRole("columnheader")
+      .map((header) => header.textContent);
+    expect(headers).toContain("C1");
+    expect(headers).not.toContain("C2");
+  });
+});
+
+describe("ExplanationTable, rows", () => {
+  it("ranks players by their position in the list", () => {
+    render(<ExplanationTable scores={scores} />);
+    const firstRow = screen.getByText("Alice").closest("tr");
+    expect(firstRow).toHaveTextContent("1");
+    const secondRow = screen.getByText("Bob").closest("tr");
+    expect(secondRow).toHaveTextContent("2");
+  });
+
+  it("shows each pick's text", () => {
+    render(<ExplanationTable scores={scores} />);
+    expect(screen.getByText("MICH")).toBeInTheDocument();
+    expect(screen.getByText("OSU")).toBeInTheDocument();
+    expect(screen.getByText("BUF")).toBeInTheDocument();
+  });
+
+  it("shows N/A for a pick with no text", () => {
+    const blank: RakMadnessScores = {
+      tiebreaker: 47,
+      scores: [player({ name: "Alice", college: [pick("")], pro: [pick("")] })],
+    };
+    render(<ExplanationTable scores={blank} />);
+    expect(screen.getAllByText("N/A")).toHaveLength(2);
+  });
+
+  it("tags each pick cell with its status", () => {
+    render(<ExplanationTable scores={scores} />);
+    expect(screen.getByText("MICH")).toHaveClass("--yes");
+    expect(screen.getByText("OSU")).toHaveClass("--no");
+    expect(screen.getByText("KC")).toHaveClass("--incomplete");
+    expect(screen.getByText("MIA")).toHaveClass("--error");
+  });
+
+  it("shows the college, pro, and total score per player", () => {
+    render(<ExplanationTable scores={scores} />);
+    const row = screen.getByText("Alice").closest("tr");
+    expect(row).toHaveTextContent("1");
+    expect(row).toHaveTextContent("2");
+    expect(row).toHaveTextContent("3");
+  });
+});
+
+describe("ExplanationTable, pick explanations", () => {
+  it("clears existing toasts before showing a new one", async () => {
+    const user = userEvent.setup();
+    render(<ExplanationTable scores={scores} />);
+    await user.click(screen.getByText("MICH"));
+    expect(clearToasts).toHaveBeenCalledTimes(1);
+    expect(showToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the clicked pick's explanation header", async () => {
+    const user = userEvent.setup();
+    render(<ExplanationTable scores={scores} />);
+    await user.click(screen.getByText("OSU"));
+    const toast: Toast = showToast.mock.calls[0][0];
+    expect(toast.header).toBe("OSU header");
+    expect(toast.type).toBe("neutral");
+  });
+
+  it("shows an explanation for a pro pick too", async () => {
+    const user = userEvent.setup();
+    render(<ExplanationTable scores={scores} />);
+    await user.click(screen.getByText("BUF"));
+    expect(showToast.mock.calls[0][0].header).toBe("BUF header");
+  });
+
+  it("reports the newest click, not the first", async () => {
+    const user = userEvent.setup();
+    render(<ExplanationTable scores={scores} />);
+    await user.click(screen.getByText("MICH"));
+    await user.click(screen.getByText("KC"));
+    expect(showToast).toHaveBeenCalledTimes(2);
+    expect(showToast.mock.calls[1][0].header).toBe("KC header");
+  });
+});
+
+describe("PlayerName, rendered through the table", () => {
+  it("marks a knocked-out player", () => {
+    render(<ExplanationTable scores={scores} />);
+    expect(screen.getByText("Bob").closest("td")).toHaveClass("--knocked-out");
+    expect(screen.getByText("Alice").closest("td")).not.toHaveClass(
+      "--knocked-out",
+    );
+  });
+
+  it("explains a player's status on click", async () => {
+    const user = userEvent.setup();
+    render(<ExplanationTable scores={scores} />);
+    await user.click(screen.getByText("Bob"));
+    expect(clearToasts).toHaveBeenCalledTimes(1);
+    expect(showToast.mock.calls[0][0].header).toBe("Bob");
+    expect(showToast.mock.calls[0][0].message).toBe("Bob is out");
+  });
+});

--- a/src/components/table/explanation/ExplanationTable.tsx
+++ b/src/components/table/explanation/ExplanationTable.tsx
@@ -19,32 +19,35 @@ function leagueHeaders(count: number, prefix: string) {
 }
 
 function ExplanationTable({ scores }: { scores?: RakMadnessScores }) {
+  const { showToast, clearToasts } = useToastContext();
+
+  const handlePickResultClick = useCallback(
+    (result: PickResult) => {
+      clearToasts();
+      showToast(
+        new Toast(
+          "neutral",
+          result.explanation.header,
+          (
+            <>
+              {result.explanation.message}
+              {result.explanation.downDistanceText && <br />}
+              {result.explanation.downDistanceText}
+            </>
+          ),
+        ),
+      );
+    },
+    [clearToasts, showToast],
+  );
+
   if (scores == null) {
     return null;
   }
 
-  const { showToast, clearToasts } = useToastContext();
-
   const firstPlayer = scores.scores[0];
   const collegeHeaders = leagueHeaders(firstPlayer.college.length, "C");
   const proHeaders = leagueHeaders(firstPlayer.pro.length, "P");
-
-  const handlePickResultClick = useCallback((result: PickResult) => {
-    clearToasts();
-    showToast(
-      new Toast(
-        "neutral",
-        result.explanation.header,
-        (
-          <>
-            {result.explanation.message}
-            {result.explanation.downDistanceText && <br />}
-            {result.explanation.downDistanceText}
-          </>
-        ),
-      ),
-    );
-  }, []);
 
   return (
     <table className="table" cellSpacing="0">

--- a/src/components/table/playerName/CLAUDE.md
+++ b/src/components/table/playerName/CLAUDE.md
@@ -1,0 +1,4 @@
+# playerName
+
+`PlayerName`: table cell (`<td>`), player name + knocked-out status icon (`SentimentVeryDissatisfied`/`SentimentVerySatisfied`).
+Click shows status explanation via `ToastContext`.

--- a/src/components/toaster/CLAUDE.md
+++ b/src/components/toaster/CLAUDE.md
@@ -1,0 +1,3 @@
+# toaster
+
+`Toaster`: renders `ToastContext` toasts as MUI Joy `Alert`s, icon per type (info/warning/danger/success), dismiss button.

--- a/src/context/ToastContext.test.tsx
+++ b/src/context/ToastContext.test.tsx
@@ -1,0 +1,187 @@
+import { act, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { Toast, ToastContextProvider, useToastContext } from "./ToastContext";
+
+const TOAST_LIFETIME_MS = 5000;
+
+/** Exposes the whole context as buttons plus a rendered list of toast headers. */
+function Harness() {
+  const { toasts, showToast, removeToast, clearToasts } = useToastContext();
+  return (
+    <div>
+      <ul data-testid="toasts">
+        {toasts.map((toast) => (
+          <li key={toast.id}>{toast.header}</li>
+        ))}
+      </ul>
+      <button onClick={() => showToast(new Toast("neutral", "A", "a"))}>
+        show A
+      </button>
+      <button onClick={() => showToast(new Toast("neutral", "B", "b"))}>
+        show B
+      </button>
+      <button onClick={() => showToast(new Toast("neutral", "C", "c"))}>
+        show C
+      </button>
+      <button onClick={() => showToast(new Toast("neutral", "D", "d"))}>
+        show D
+      </button>
+      <button onClick={() => removeToast(toasts[0])} disabled={!toasts.length}>
+        remove first
+      </button>
+      <button onClick={clearToasts}>clear</button>
+    </div>
+  );
+}
+
+function mountHarness() {
+  // Advancing fake timers is what dismisses toasts, so user-event must not
+  // wait on the real clock.
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  render(
+    <ToastContextProvider>
+      <Harness />
+    </ToastContextProvider>,
+  );
+  return user;
+}
+
+function headers(): Array<string> {
+  return Array.from(screen.getByTestId("toasts").children).map(
+    (item) => item.textContent ?? "",
+  );
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe("Toast", () => {
+  it("gives every toast a distinct id", () => {
+    const first = new Toast("neutral", "A", "a");
+    const second = new Toast("neutral", "A", "a");
+    expect(first.id).not.toBe(second.id);
+  });
+
+  it("keeps the type, header, and message it was given", () => {
+    const toast = new Toast("danger", "Error", "it broke");
+    expect(toast.type).toBe("danger");
+    expect(toast.header).toBe("Error");
+    expect(toast.message).toBe("it broke");
+  });
+});
+
+describe("ToastContextProvider", () => {
+  it("starts with no toasts", () => {
+    mountHarness();
+    expect(headers()).toEqual([]);
+  });
+
+  it("shows toasts in the order they arrive", async () => {
+    const user = mountHarness();
+    await user.click(screen.getByText("show A"));
+    await user.click(screen.getByText("show B"));
+    expect(headers()).toEqual(["A", "B"]);
+  });
+
+  it("keeps only the newest three, dropping the oldest", async () => {
+    const user = mountHarness();
+    await user.click(screen.getByText("show A"));
+    await user.click(screen.getByText("show B"));
+    await user.click(screen.getByText("show C"));
+    await user.click(screen.getByText("show D"));
+    expect(headers()).toEqual(["B", "C", "D"]);
+  });
+
+  it("removes a toast by identity, not by position", async () => {
+    const user = mountHarness();
+    await user.click(screen.getByText("show A"));
+    await user.click(screen.getByText("show B"));
+    await user.click(screen.getByText("remove first"));
+    expect(headers()).toEqual(["B"]);
+  });
+
+  it("clears every toast at once", async () => {
+    const user = mountHarness();
+    await user.click(screen.getByText("show A"));
+    await user.click(screen.getByText("show B"));
+    await user.click(screen.getByText("clear"));
+    expect(headers()).toEqual([]);
+  });
+
+  it("auto-dismisses a toast after its lifetime", async () => {
+    const user = mountHarness();
+    await user.click(screen.getByText("show A"));
+    expect(headers()).toEqual(["A"]);
+
+    act(() => {
+      jest.advanceTimersByTime(TOAST_LIFETIME_MS - 1);
+    });
+    expect(headers()).toEqual(["A"]);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(headers()).toEqual([]);
+  });
+
+  it("auto-dismisses each toast on its own schedule", async () => {
+    const user = mountHarness();
+    await user.click(screen.getByText("show A"));
+
+    act(() => {
+      jest.advanceTimersByTime(TOAST_LIFETIME_MS / 2);
+    });
+    await user.click(screen.getByText("show B"));
+    expect(headers()).toEqual(["A", "B"]);
+
+    // A's lifetime is up, B's is not.
+    act(() => {
+      jest.advanceTimersByTime(TOAST_LIFETIME_MS / 2);
+    });
+    expect(headers()).toEqual(["B"]);
+
+    act(() => {
+      jest.advanceTimersByTime(TOAST_LIFETIME_MS / 2);
+    });
+    expect(headers()).toEqual([]);
+  });
+
+  it("does not resurrect a cleared toast when its timer fires", async () => {
+    const user = mountHarness();
+    await user.click(screen.getByText("show A"));
+    await user.click(screen.getByText("clear"));
+
+    act(() => {
+      jest.advanceTimersByTime(TOAST_LIFETIME_MS);
+    });
+    expect(headers()).toEqual([]);
+  });
+
+  it("dismisses the oldest toast even after it was pushed out by the cap", async () => {
+    const user = mountHarness();
+    await user.click(screen.getByText("show A"));
+    await user.click(screen.getByText("show B"));
+    await user.click(screen.getByText("show C"));
+    await user.click(screen.getByText("show D"));
+
+    act(() => {
+      jest.advanceTimersByTime(TOAST_LIFETIME_MS);
+    });
+    expect(headers()).toEqual([]);
+  });
+});
+
+describe("useToastContext outside a provider", () => {
+  it("falls back to no-ops rather than throwing", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<Harness />);
+    await user.click(screen.getByText("show A"));
+    expect(headers()).toEqual([]);
+  });
+});

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -51,6 +51,11 @@ const ToastContext = createContext<ToastContextData>({
 function useToastContextData(): ToastContextData {
   const [toasts, setToasts] = useState<Array<Toast>>([]);
 
+  // Declared before showToast, which schedules it.
+  const removeToast = useCallback((toast: Toast) => {
+    setToasts((oldToasts) => oldToasts.filter((it) => it.id !== toast.id));
+  }, []);
+
   const showToast = useCallback(
     (toast: Toast) => {
       // Limit to 3 toasts.
@@ -63,14 +68,7 @@ function useToastContextData(): ToastContextData {
         removeToast(toast);
       }, 5000);
     },
-    [toasts],
-  );
-
-  const removeToast = useCallback(
-    (toast: Toast) => {
-      setToasts((oldToasts) => oldToasts.filter((it) => it.id !== toast.id));
-    },
-    [toasts],
+    [removeToast],
   );
 
   const clearToasts = useCallback(() => {
@@ -84,7 +82,7 @@ function useToastContextData(): ToastContextData {
       removeToast,
       clearToasts,
     }),
-    [toasts],
+    [toasts, showToast, removeToast, clearToasts],
   );
 
   return contextData;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/src/types/CLAUDE.md
+++ b/src/types/CLAUDE.md
@@ -1,0 +1,3 @@
+# src/types
+
+ESPN scoreboard shapes (EspnEvent, EspnCompetitor, GameStatus); League/SeasonType/WeekInfo/LeagueInfo; LeagueResult/Possession; GameScore pick-scoring result; RakMadnessScores/PlayerScore/PickResult/Status.

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -1,0 +1,3 @@
+# src/utils
+
+getLeagueInfo/getLeagueResults: ESPN API fetch, calendar/week mapping. getPlayerScores: spread-adjusted pick scoring, knockout detection, tiebreaker logic. buildSpreadsheetBuffer: xlsx-js-style workbook export. getClasses: conditional className join. rangeWithPrefix: labeled index arrays (C1, C2…).

--- a/src/utils/buildSpreadsheetBuffer.ts
+++ b/src/utils/buildSpreadsheetBuffer.ts
@@ -65,7 +65,7 @@ function explanationCell(pick: string, isCorrect: Status) {
     cellColor = Color.GREEN;
   } else if (isCorrect === "no") {
     cellColor = Color.RED;
-  } else if (isCorrect == "error") {
+  } else if (isCorrect === "error") {
     cellColor = Color.YELLOW;
   }
 

--- a/src/utils/getLeagueResults.ts
+++ b/src/utils/getLeagueResults.ts
@@ -121,12 +121,12 @@ export async function getLeagueResults(
 
       // If the event isn't in the matchups for the week, skip it.
       const isInMatchups = matchups.some((teams) => {
-        if (teams.size == 2) {
+        if (teams.size === 2) {
           return (
             teams.has(home.team.abbreviation) &&
             teams.has(away.team.abbreviation)
           );
-        } else if (teams.size == 1) {
+        } else if (teams.size === 1) {
           return (
             teams.has(home.team.abbreviation) ||
             teams.has(away.team.abbreviation)

--- a/src/utils/getPickResults.test.ts
+++ b/src/utils/getPickResults.test.ts
@@ -1,0 +1,197 @@
+import { GameStatus, HomeAway } from "../types/ESPN";
+import { LeagueResult } from "../types/LeagueResult";
+import { getPickResults } from "./getPlayerScores";
+
+const NO_POSSESSION = {};
+
+/**
+ * A completed game. `by` is the winner's margin, which is what the spread is
+ * compared against, so it is stated explicitly rather than derived from scores.
+ */
+function finalGame({
+  home,
+  away,
+  homeScore,
+  awayScore,
+}: {
+  home: string;
+  away: string;
+  homeScore: number;
+  awayScore: number;
+}): LeagueResult {
+  const homeTeam = { name: home, abbreviation: home };
+  const awayTeam = { name: away, abbreviation: away };
+  const isTie = homeScore === awayScore;
+  const homeWon = homeScore > awayScore;
+  return {
+    name: `${away} at ${home}`,
+    shortName: `${away} @ ${home}`,
+    date: new Date("2024-10-06T17:00:00Z"),
+    status: GameStatus.FINAL,
+    detailMessage: "Final",
+    home: { team: homeTeam, score: homeScore },
+    away: { team: awayTeam, score: awayScore },
+    possession: NO_POSSESSION,
+    winner: {
+      team: isTie ? null : homeWon ? homeTeam : awayTeam,
+      homeAway: isTie ? null : homeWon ? HomeAway.HOME : HomeAway.AWAY,
+      by: Math.abs(homeScore - awayScore),
+    },
+    loser: {
+      team: isTie ? null : homeWon ? awayTeam : homeTeam,
+      homeAway: isTie ? null : homeWon ? HomeAway.AWAY : HomeAway.HOME,
+      by: Math.abs(homeScore - awayScore),
+    },
+    totalScore: homeScore + awayScore,
+  };
+}
+
+// BUF beat KC by 10.
+const bufBeatKcBy10 = finalGame({
+  home: "BUF",
+  away: "KC",
+  homeScore: 30,
+  awayScore: 20,
+});
+
+function scoreOf(pick: string, results = [bufBeatKcBy10]): number {
+  return getPickResults([pick], results)[0].pointValue;
+}
+
+describe("getPickResults, no spread", () => {
+  it("awards a point for picking the winner", () => {
+    expect(scoreOf("BUF")).toBe(1);
+  });
+
+  it("awards nothing for picking the loser", () => {
+    expect(scoreOf("KC")).toBe(0);
+  });
+
+  it("is case-insensitive", () => {
+    expect(scoreOf("buf")).toBe(1);
+  });
+
+  it("awards a point to both sides of a tie", () => {
+    const tie = finalGame({
+      home: "BUF",
+      away: "KC",
+      homeScore: 20,
+      awayScore: 20,
+    });
+    expect(scoreOf("BUF", [tie])).toBe(1);
+    expect(scoreOf("KC", [tie])).toBe(1);
+  });
+});
+
+describe("getPickResults, favored pick (negative spread)", () => {
+  it("awards a point when the favorite covers", () => {
+    expect(scoreOf("BUF -7")).toBe(1);
+  });
+
+  it("awards nothing when the favorite wins but fails to cover", () => {
+    expect(scoreOf("BUF -14")).toBe(0);
+  });
+
+  it("treats an exact-margin spread as a push and awards a point", () => {
+    expect(scoreOf("BUF -10")).toBe(1);
+  });
+
+  it("awards nothing when the favorite loses outright", () => {
+    expect(scoreOf("KC -7")).toBe(0);
+  });
+});
+
+describe("getPickResults, underdog pick (positive spread)", () => {
+  it("awards a point when the underdog wins outright", () => {
+    expect(
+      scoreOf("KC +7", [
+        finalGame({ home: "BUF", away: "KC", homeScore: 20, awayScore: 30 }),
+      ]),
+    ).toBe(1);
+  });
+
+  it("awards a point when the underdog loses by less than the spread", () => {
+    expect(scoreOf("KC +14")).toBe(1);
+  });
+
+  it("awards nothing when the underdog loses by more than the spread", () => {
+    expect(scoreOf("KC +7")).toBe(0);
+  });
+
+  it("treats an exact-margin spread as a push and awards a point", () => {
+    expect(scoreOf("KC +10")).toBe(1);
+  });
+});
+
+describe("getPickResults, spread parsing", () => {
+  it("accepts a half-point spread", () => {
+    expect(scoreOf("BUF -9.5")).toBe(1);
+    expect(scoreOf("BUF -10.5")).toBe(0);
+  });
+
+  it("accepts a spread with no space before the sign", () => {
+    expect(scoreOf("BUF-7")).toBe(1);
+  });
+
+  it("reports hasSpread only when a spread was given", () => {
+    expect(getPickResults(["BUF"], [bufBeatKcBy10])[0].hasSpread).toBe(false);
+    expect(getPickResults(["BUF -7"], [bufBeatKcBy10])[0].hasSpread).toBe(true);
+  });
+});
+
+describe("getPickResults, missing data", () => {
+  it("flags a pick whose game is absent", () => {
+    const result = getPickResults(["MIA"], [bufBeatKcBy10])[0];
+    expect(result.pointValue).toBe(0);
+    expect(result.wasNotFound).toBe(true);
+    expect(result.explanation.header).toBe("Missing Game");
+  });
+
+  it("flags an empty pick as a missing pick, not a missing game", () => {
+    const result = getPickResults(["undefined"], [bufBeatKcBy10])[0];
+    expect(result.pointValue).toBe(0);
+    expect(result.wasNotFound).toBe(true);
+    expect(result.explanation.header).toBe("Missing Pick");
+  });
+});
+
+describe("getPickResults, game state", () => {
+  it("marks a final game completed", () => {
+    const result = getPickResults(["BUF"], [bufBeatKcBy10])[0];
+    expect(result.isCompleted).toBe(true);
+    expect(result.explanation.header).toBe("Final Score");
+    expect(result.explanation.message).toBe("KC 20 - 30 BUF");
+  });
+
+  it("marks a live game incomplete and shows the possession arrow", () => {
+    const live: LeagueResult = {
+      ...bufBeatKcBy10,
+      status: GameStatus.LIVE,
+      detailMessage: "3rd Quarter",
+      possession: { homeAway: HomeAway.AWAY, downDistanceText: "2nd & 7" },
+    };
+    const result = getPickResults(["BUF"], [live])[0];
+    expect(result.isCompleted).toBe(false);
+    expect(result.explanation.header).toBe("Live Score | 3rd Quarter");
+    expect(result.explanation.message).toBe("▸ KC 20 - 30 BUF");
+    expect(result.explanation.downDistanceText).toBe("2nd & 7");
+  });
+
+  it("marks an upcoming game incomplete", () => {
+    const upcoming: LeagueResult = {
+      ...bufBeatKcBy10,
+      status: GameStatus.UPCOMING,
+    };
+    const result = getPickResults(["BUF"], [upcoming])[0];
+    expect(result.isCompleted).toBe(false);
+    expect(result.explanation.header).toBe("Upcoming");
+    expect(result.explanation.message).toContain("KC @ BUF begins at");
+  });
+});
+
+describe("getPickResults, ordering", () => {
+  it("returns one result per pick, in order", () => {
+    const results = getPickResults(["KC", "BUF"], [bufBeatKcBy10]);
+    expect(results.map((result) => result.pointValue)).toEqual([0, 1]);
+  });
+});

--- a/src/utils/getPlayerScores.ts
+++ b/src/utils/getPlayerScores.ts
@@ -42,7 +42,7 @@ function getStatus(score: GameScore): Status {
   return "no";
 }
 
-function getPickResults(
+export function getPickResults(
   picks: Array<string>,
   leagueResults: Array<LeagueResult>,
 ): Array<GameScore> {
@@ -445,7 +445,11 @@ export async function getPlayerScores(
               (sum, gameIndex) => {
                 const oppPick = oppScore.college[gameIndex].pick;
                 const activePick = activeScore.college[gameIndex].pick;
-                return oppPick != null && activePick!= null && oppPick !== activePick ? sum + 1 : sum;
+                return oppPick != null &&
+                  activePick != null &&
+                  oppPick !== activePick
+                  ? sum + 1
+                  : sum;
               },
               0,
             );
@@ -454,7 +458,11 @@ export async function getPlayerScores(
             remainingProIndices.forEach((gameIndex) => {
               const oppPick = oppScore.pro[gameIndex].pick;
               const activePick = activeScore.pro[gameIndex].pick;
-              if (oppPick != null && activePick != null && oppPick !== activePick) {
+              if (
+                oppPick != null &&
+                activePick != null &&
+                oppPick !== activePick
+              ) {
                 differentProPicks += 1;
                 if (parsePick(oppPick).spread !== 0) {
                   differentProPicksWithSpreads += 1;
@@ -514,7 +522,7 @@ export async function getPlayerScores(
               // If college games are done and players are tied, check pro against the spread tiebreaker.
               if (
                 collegeScoreDiff === 0 &&
-                remainingCollegeIndices.length == 0
+                remainingCollegeIndices.length === 0
               ) {
                 const proAgainstTheSpreadScoreDiff =
                   oppScore.score.proAgainstTheSpread -

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,9 @@
+name = "rak-sadness"
+compatibility_date = "2023-10-30"
+
+# Serves picks/<week>.xlsx to functions/api/picks/[week].ts.
+# Simulated locally by `wrangler pages dev`; seed it with
+# `wrangler r2 object put rak-sadness/picks/1.xlsx --file <path> --local`.
+[[r2_buckets]]
+binding = "RAK_SADNESS_BUCKET"
+bucket_name = "rak-sadness"


### PR DESCRIPTION
## What

Agent onboarding for the whole repo: a CLAUDE.md navigation tree, uniform make targets, checked-in Claude Code settings and skills, Conventional Commit enforcement, and the first test suite. No ticket.

## Why

Nothing in the repo described how to build, run, or test it. There were no tests and no automated gate, so every change relied on the author remembering the steps.

## Changes

* `make setup/build/run/check/lint/typecheck/format/test` is the contract. `run` honours `PORT`, so two dev servers can coexist.
* ESLint had two non-merging config surfaces. `react-scripts` prefers a project `.eslintrc` when one exists, so the `react-app` rules in `package.json` were reaching nothing. Merging them exposed 2 errors and 12 warnings, all fixed here rather than suppressed. Keeping lint warning-free matters because `CI=true` builds treat warnings as errors, and this project builds from git.
* `format` now runs `eslint --fix` before prettier. The old order left the tree prettier-dirty, so `check` failed right after `format`.
* `wrangler.toml` declares the `RAK_SADNESS_BUCKET` binding. It deliberately omits `pages_build_output_dir`, because that key makes `pages:dev` fail with "Specify either a directory OR a proxy command, not both", and hot reload is worth more.
* Three real bugs, each found by the tooling rather than hunted for: hooks called after an early return in `ExplanationTable`, a null dereference on an absent R2 object, and `target="_blank"` links with no `rel="noreferrer"`.
* 67 tests, all offline. `getPickResults` is now exported so the spread-scoring rules can be tested without a workbook or a network call.
* Out of scope: the react-scripts to Vite migration that the 34 transitive vulnerabilities actually need, and splitting the two files that serialise parallel work.

## Verification

Build and targets were verified from a clean `git worktree`, not the working tree. `make run` was probed live for a 200. `npm run pages:dev` was probed with the Pages Function executing and wrangler reporting `RAK_SADNESS_BUCKET: rak-sadness [simulated locally]`.

## Notes / Follow-ups

* `pr-title.yml` is live on this PR as the `conventional-commit-title` check, so the gate applies to everyone from here on. The agent-side hook catches the same format earlier.
* The `Cloudflare Pages` check passed here, so the git-triggered build tolerates the new `wrangler.toml`. Running `pages:deploy` from a laptop against it is still untested.
* `AGENTIFY_RECOMMENDATIONS.md` records everything recommended but not applied, with reasons.
