### PR TITLE
test(scoring): cover a game every row picked the same way

### DIFF
--- a/.claude/skills/build-run-test/SKILL.md
+++ b/.claude/skills/build-run-test/SKILL.md
@@ -22,7 +22,7 @@ From a clean checkout: `make setup`, `make build`, `make run`, `make test`, `mak
 
 ## Tests
 
-204 cases, 16 suites, all offline. `npm test` is `vitest run`; `npm run test:watch` watches.
+205 cases, 16 suites, all offline. `npm test` is `vitest run`; `npm run test:watch` watches.
 
 - `src/utils/scoring/getPickResults.test.ts` — spread scoring (favorite covers / fails to cover, underdog, push, tie, half-point spread, missing pick vs missing game, live and upcoming state). Also pins the statuses `GameStatus` does not model: ESPN sends type ids for postponed and canceled, they land in the same branch as a live game, and a canceled game has no winner so every pick scores a point.
 - `src/utils/scoring/getPlayerScores.test.ts` — workbook parsing, matchup derivation, per-league scoring, tiebreaker distance, the whole sort order, every knockout branch. Builds a real workbook with `xlsx-js-style` and mocks `getLeagueResults`.

--- a/src/utils/scoring/getPlayerScores.test.ts
+++ b/src/utils/scoring/getPlayerScores.test.ts
@@ -129,6 +129,27 @@ describe("getPlayerScores, spreadsheet parsing", () => {
     ]);
   });
 
+  // A game everybody took the same side of names one team, and that is enough to
+  // find it. Without this, a sheet needs a made-up player holding the other side.
+  it("scores a game every row picked the same way", async () => {
+    withEverythingFinal();
+    const result = await getPlayerScores(
+      WEEK,
+      picksBuffer([
+        { Name: "Alice", C1: "OSU -3", P1: "BUF -7", P2: "DAL -3", Pts: 41 },
+        { Name: "Bob", C1: "OSU -3", P1: "KC +7", P2: "PHI +3", Pts: 45 },
+      ]),
+    );
+
+    expect(mockGetLeagueResults).toHaveBeenCalledWith(League.COLLEGE, WEEK, [
+      new Set(["OSU"]),
+    ]);
+    expect(result.scores.map((score) => score.college[0].status)).toEqual([
+      "yes",
+      "yes",
+    ]);
+  });
+
   it("reads the first sheet in the workbook, whatever it is named", async () => {
     const workbook = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(


### PR DESCRIPTION
## What

Pins the behavior that makes "Miami Fixinator" unnecessary. No ticket. Test only.

## Why

Week 18's `C1` column carries a made-up player whose only pick is the other side of a game every real player took the same way. That row is not needed: the column names one team, and the matchup filter already accepts a one-team matchup, so the game is found either way.

Nothing covered that, which is how the workaround became habit. Now a change that breaks it fails here.

## Changes

* Score a workbook whose college column every row picked the same way, asserting the matchup goes out as one team and both rows score.

## Verification

`make check`, 205 cases. Probed against the real week 18 workbook pulled from production: `C1` is `MIA 10` on 56 rows, blank on 5, and `OSU -10` on the fake row. Dropping the fake row leaves `{MIA}`, which resolves to the game and scores.

## Notes / Follow-ups

* College results stay ordered latest game first. ESPN files the whole bowl season under week 1 of the postseason and only the start of the week is filtered on, so a team playing twice appears twice, and a one-sided pick lands on the later of the two. Naming both teams is still the only way to pin the earlier one. Deliberate, per the ordering being useful beyond bowl weeks.
* Nothing removes the fake row from the stored week 18 sheet. That week scores the same either way.
