### PR TITLE
feat(app): call the app The Rakulator, and shape the wireframe like a real table

### DIFF
--- a/.claude/skills/build-run-test/SKILL.md
+++ b/.claude/skills/build-run-test/SKILL.md
@@ -16,7 +16,7 @@ description: How to build, run, and test this repo. Read before any npm, make, t
 
 ## Verified
 
-From a clean checkout: `make setup`, `make build`, `make run`, `make test`, `make check` all green. `make run` serves `http://localhost:3000`, HTTP 200, `<title>Rak Madness Calculator</title>`. `npm audit` reports 0 vulnerabilities.
+From a clean checkout: `make setup`, `make build`, `make run`, `make test`, `make check` all green. `make run` serves `http://localhost:3000`, HTTP 200, `<title>The Rakulator</title>`. `npm audit` reports 0 vulnerabilities.
 
 `npm run build` runs `npm run typecheck` first, so a type error fails the Cloudflare build too. The build does not lint. Lint reaches CI through the `check` workflow calling `make check`.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rak Madness Calculator
+# The Rakulator
 
 Simple auto-scoring web application for [Rak Madness](https://rakmadness.net/). The [public site](https://rak.cullenrombach.com/) is hosted on [CloudFlare Pages](https://developers.cloudflare.com/pages/).
 

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       user's mobile device or desktop. See https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest
     -->
     <link rel="manifest" href="/manifest.json" />
-    <title>Rak Madness Calculator</title>
+    <title>The Rakulator</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Rak Madness Scoreboard",
-  "name": "Rak Madness Scoreboard",
+  "short_name": "The Rakulator",
+  "name": "The Rakulator",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -482,6 +482,40 @@ describe("the app, week routes", () => {
     expect(await screen.findByText("MNF Points Pick")).toBeInTheDocument();
   });
 
+  it("crowns a player still standing at the end of the week", async () => {
+    fetchMock.mockResolvedValue(spreadsheetResponse());
+    await mountApp(`/week/${CURRENT_WEEK}/scoreboard`);
+
+    await screen.findByText("MNF Points Pick");
+    expect(screen.getByTestId("EmojiEventsIcon")).toBeInTheDocument();
+  });
+
+  it("holds the crown back while a game is still to finish", async () => {
+    getPlayerScoresMock.mockResolvedValue({
+      ...scores,
+      scores: [
+        {
+          ...scores.scores[0],
+          pro: [
+            {
+              pick: "BUF",
+              status: "incomplete",
+              explanation: { header: "P1", message: "in progress" },
+            },
+          ],
+        },
+      ],
+    });
+    fetchMock.mockResolvedValue(spreadsheetResponse());
+    await mountApp(`/week/${CURRENT_WEEK}/scoreboard`);
+
+    await screen.findByText("MNF Points Pick");
+    expect(
+      screen.getByTestId("SentimentVerySatisfiedIcon"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("EmojiEventsIcon")).not.toBeInTheDocument();
+  });
+
   it("shows a wireframe table until the results are ready", async () => {
     fetchMock.mockResolvedValue(spreadsheetResponse());
     mountApp(`/week/${CURRENT_WEEK}/scoreboard`);

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -205,7 +205,7 @@ describe("the app, first load", () => {
 
   it("shows the app title in the navbar", async () => {
     await mountLoadedApp();
-    expect(screen.getByText("Rak Madness Calculator")).toBeInTheDocument();
+    expect(screen.getByText("The Rakulator")).toBeInTheDocument();
   });
 });
 
@@ -534,28 +534,26 @@ describe("the app, week routes", () => {
     ).toHaveLength(24);
   });
 
-  it("widens the content area for the picks wireframe only", async () => {
+  it("gives the wireframe a row per player of a middling week", async () => {
     fetchMock.mockResolvedValue(spreadsheetResponse());
     mountApp(`/week/${CURRENT_WEEK}/picks`);
 
-    // The loaded picks table is wider than the content column, so its wireframe
-    // starts out that wide too.
-    expect(document.querySelector(".home__content")).toHaveClass(
-      "--full-width",
-    );
+    expect(
+      document.querySelectorAll(
+        ".table.--skeleton tbody tr:not(.table__last-row):not(.table__filler-row)",
+      ),
+    ).toHaveLength(61);
+  });
+
+  it("holds the content still while the week loads, keeping the scrollbar's room", async () => {
+    fetchMock.mockResolvedValue(spreadsheetResponse());
+    mountApp(`/week/${CURRENT_WEEK}/picks`);
+
+    expect(document.querySelector(".home__content")).toHaveClass("--frozen");
 
     await screen.findByText("College Score");
     expect(document.querySelector(".home__content")).not.toHaveClass(
-      "--full-width",
-    );
-  });
-
-  it("keeps the content area narrow for the scoreboard wireframe", async () => {
-    fetchMock.mockResolvedValue(spreadsheetResponse());
-    mountApp(`/week/${CURRENT_WEEK}/scoreboard`);
-
-    expect(document.querySelector(".home__content")).not.toHaveClass(
-      "--full-width",
+      "--frozen",
     );
   });
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -134,7 +134,7 @@ function notFoundResponse(): Response {
 }
 
 function htmlResponse(): Response {
-  return new Response("<!doctype html><title>Rak Madness Calculator</title>", {
+  return new Response("<!doctype html><title>The Rakulator</title>", {
     status: 200,
     headers: { "content-type": "text/html" },
   });

--- a/src/components/PageLayout.scss
+++ b/src/components/PageLayout.scss
@@ -57,11 +57,12 @@
     width: max-content;
   }
 
-  // `hidden` is still a scroll container, so `stable` keeps whatever room a
-  // scrollbar takes on this browser while nobody can scroll yet. Without it the
-  // wireframe would jump sideways the moment the real table brings scrolling back.
+  // The wireframe is the size of the table it stands in for, so the surest way to
+  // get the scrollbars it will need is to stay scrollable and let it ask for them
+  // itself. `hidden` plus `scrollbar-gutter` cannot: the gutter is only reserved
+  // on the vertical bar, so the horizontal one arrived with the real table and took
+  // its band out of the page. Refusing the pointer is what keeps this unscrollable.
   &.--frozen {
-    overflow: hidden;
-    scrollbar-gutter: stable;
+    pointer-events: none;
   }
 }

--- a/src/components/PageLayout.scss
+++ b/src/components/PageLayout.scss
@@ -31,10 +31,11 @@
     width: max-content;
   }
 
-  // 100% rather than 100vw, so a landscape notch's inset still holds the edges
-  // back. Wider than the usual column, which is what the picks table itself is
-  // once it loads.
-  &.--full-width {
-    width: 100%;
+  // `hidden` is still a scroll container, so `stable` keeps whatever room a
+  // scrollbar takes on this browser while nobody can scroll yet. Without it the
+  // wireframe would jump sideways the moment the real table brings scrolling back.
+  &.--frozen {
+    overflow: hidden;
+    scrollbar-gutter: stable;
   }
 }

--- a/src/components/PageLayout.scss
+++ b/src/components/PageLayout.scss
@@ -13,6 +13,32 @@
   flex-direction: column;
   align-items: center;
   overflow: hidden;
+  // Makes this a stacking context, which is what lets the tiles below sit above
+  // this element's own background and below everything on the page.
+  isolation: isolate;
+
+  // The tiled logo. Drawn here rather than on `.home` itself so it can be faded
+  // in: a background image cannot be, and the tiles arriving at full strength
+  // all at once is disorienting.
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background-image: var(--rak-background-tile);
+    opacity: 0;
+    transition: opacity 400ms ease-in;
+  }
+
+  &.--tiles-loaded::before {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home::before {
+    transition: none;
+  }
 }
 
 .home__content {

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -13,14 +13,17 @@ export default function PageLayout({
   navbarLeft,
   navbarRight,
   showingScores = false,
-  fillsWidth = false,
+  scrollable = true,
   children,
 }: PropsWithChildren<{
   navbarLeft: ReactNode;
   navbarRight?: ReactNode;
   showingScores?: boolean;
-  /** Widens the content area past its usual column, out to the whole screen. */
-  fillsWidth?: boolean;
+  /**
+   * Set false to hold the content still while keeping the room a scrollbar would
+   * take, so nothing shifts sideways when scrolling comes back.
+   */
+  scrollable?: boolean;
 }>) {
   return (
     <div className="home" style={BACKGROUND_STYLE}>
@@ -28,7 +31,7 @@ export default function PageLayout({
       <main
         className={`home__content ${getClasses({
           "--scores": showingScores,
-          "--full-width": fillsWidth,
+          "--frozen": !scrollable,
         })}`}
       >
         {children}

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -19,17 +19,28 @@ const BACKGROUND_STYLE = {
 } as CSSProperties;
 
 /**
+ * Sources that have finished loading once. Every route renders its own layout, so
+ * without this the fade would start over on each move between pages.
+ */
+const loadedSources = new Set<string>();
+
+/**
  * Whether the browser holds the image, so a background drawn from it can be faded
- * in rather than appear all at once.
+ * in rather than appear all at once. True from the first render once the image has
+ * been through here before, which is what keeps the fade to the first page.
  */
 function useImageLoaded(source: string): boolean {
-  const [isLoaded, setIsLoaded] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(() => loadedSources.has(source));
 
   useEffect(() => {
+    if (loadedSources.has(source)) return;
     const image = new Image();
     // Listen before asking, because an image already in the cache still fires
     // `load`, and it can fire as soon as the source is set.
-    image.onload = () => setIsLoaded(true);
+    image.onload = () => {
+      loadedSources.add(source);
+      setIsLoaded(true);
+    };
     image.src = source;
     return () => {
       image.onload = null;

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,12 +1,43 @@
-import { PropsWithChildren, ReactNode } from "react";
+import {
+  CSSProperties,
+  PropsWithChildren,
+  ReactNode,
+  useEffect,
+  useState,
+} from "react";
 import getClasses from "../utils/getClasses";
 import Navbar from "./navbar/Navbar";
 import "./PageLayout.scss";
 
+const BACKGROUND_TILE = "/logo512.png";
+
 const BACKGROUND_STYLE = {
-  backgroundImage: "url(/logo512.png)",
   backgroundColor: "#6eaad9",
-};
+  // Read by `PageLayout.scss`, so the file that loads the tile is also the one
+  // that names it.
+  "--rak-background-tile": `url(${BACKGROUND_TILE})`,
+} as CSSProperties;
+
+/**
+ * Whether the browser holds the image, so a background drawn from it can be faded
+ * in rather than appear all at once.
+ */
+function useImageLoaded(source: string): boolean {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const image = new Image();
+    // Listen before asking, because an image already in the cache still fires
+    // `load`, and it can fire as soon as the source is set.
+    image.onload = () => setIsLoaded(true);
+    image.src = source;
+    return () => {
+      image.onload = null;
+    };
+  }, [source]);
+
+  return isLoaded;
+}
 
 /** The chrome every page shares: the background, the navbar, and the main area. */
 export default function PageLayout({
@@ -25,8 +56,13 @@ export default function PageLayout({
    */
   scrollable?: boolean;
 }>) {
+  const areTilesLoaded = useImageLoaded(BACKGROUND_TILE);
+
   return (
-    <div className="home" style={BACKGROUND_STYLE}>
+    <div
+      className={`home ${getClasses({ "--tiles-loaded": areTilesLoaded })}`}
+      style={BACKGROUND_STYLE}
+    >
       <Navbar left={navbarLeft} right={navbarRight} />
       <main
         className={`home__content ${getClasses({

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -62,8 +62,8 @@ export default function PageLayout({
   navbarRight?: ReactNode;
   showingScores?: boolean;
   /**
-   * Set false to hold the content still while keeping the room a scrollbar would
-   * take, so nothing shifts sideways when scrolling comes back.
+   * Set false to refuse the pointer, so what is on screen cannot be scrolled or
+   * clicked. The content keeps whatever scrollbars it asks for either way.
    */
   scrollable?: boolean;
 }>) {

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -10,7 +10,6 @@
   padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
   text-align: center;
   color: #888888;
-  opacity: 0.75;
 
   > * {
     color: #888888;

--- a/src/components/icon/CLAUDE.md
+++ b/src/components/icon/CLAUDE.md
@@ -7,3 +7,7 @@ components drag `@mui/material` and emotion in behind them. `Icon.scss` holds th
 
 Each icon carries the `data-testid` its MUI counterpart had, which is how the
 toaster suite finds them.
+
+`SkullIcon` comes from Material Symbols, which `@mui/icons-material` does not
+carry. Same icon family and licence, drawn on a `0 -960 960 960` box, which is why
+`Icon` takes a `viewBox`.

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -80,6 +80,14 @@ export function RefreshIcon() {
   );
 }
 
+export function EmojiEventsIcon() {
+  return (
+    <Icon name="EmojiEventsIcon">
+      <path d="M19 5h-2V3H7v2H5c-1.1 0-2 .9-2 2v1c0 2.55 1.92 4.63 4.39 4.94.63 1.5 1.98 2.63 3.61 2.96V19H7v2h10v-2h-4v-3.1c1.63-.33 2.98-1.46 3.61-2.96C19.08 12.63 21 10.55 21 8V7c0-1.1-.9-2-2-2M5 8V7h2v3.82C5.84 10.4 5 9.3 5 8m14 0c0 1.3-.84 2.4-2 2.82V7h2z" />
+    </Icon>
+  );
+}
+
 export function SkullIcon() {
   return (
     <Icon name="SkullIcon" viewBox={SYMBOLS_VIEW_BOX}>

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -42,6 +42,14 @@ export function InfoIcon() {
   );
 }
 
+export function FactCheckIcon() {
+  return (
+    <Icon name="FactCheckIcon">
+      <path d="M20 3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2M10 17H5v-2h5zm0-4H5v-2h5zm0-4H5V7h5zm4.82 6L12 12.16l1.41-1.41 1.41 1.42L17.99 9l1.42 1.42z" />
+    </Icon>
+  );
+}
+
 export function LeaderboardIcon() {
   return (
     <Icon name="LeaderboardIcon">

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -9,12 +9,26 @@ import "./Icon.scss";
  * `@mui/material`'s `createSvgIcon`, which pulled `@mui/material` and emotion into
  * the bundle for the sake of ten shapes. The `<svg>` here carries the same box and
  * fill rules that `SvgIcon` applied, so nothing downstream had to be resized.
+ *
+ * One shape comes from Material Symbols instead, which that package does not
+ * carry. Same icons, same licence, drawn on a taller box, which is what `viewBox`
+ * is for.
  */
-function Icon({ name, children }: { name: string; children: ReactNode }) {
+const SYMBOLS_VIEW_BOX = "0 -960 960 960";
+
+function Icon({
+  name,
+  viewBox = "0 0 24 24",
+  children,
+}: {
+  name: string;
+  viewBox?: string;
+  children: ReactNode;
+}) {
   return (
     <svg
       className="icon"
-      viewBox="0 0 24 24"
+      viewBox={viewBox}
       aria-hidden="true"
       focusable="false"
       // The name `@mui/icons-material` put here, which the toaster suite looks an
@@ -66,12 +80,10 @@ export function RefreshIcon() {
   );
 }
 
-export function SentimentVeryDissatisfiedIcon() {
+export function SkullIcon() {
   return (
-    <Icon name="SentimentVeryDissatisfiedIcon">
-      <circle cx="15.5" cy="9.5" r="1.5" />
-      <circle cx="8.5" cy="9.5" r="1.5" />
-      <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8m0-6c-2.33 0-4.32 1.45-5.12 3.5h1.67c.69-1.19 1.97-2 3.45-2s2.75.81 3.45 2h1.67c-.8-2.05-2.79-3.5-5.12-3.5" />
+    <Icon name="SkullIcon" viewBox={SYMBOLS_VIEW_BOX}>
+      <path d="M240-80v-170q-39-17-68.5-45.5t-50-64.5q-20.5-36-31-77T80-520q0-158 112-259t288-101q176 0 288 101t112 259q0 42-10.5 83t-31 77q-20.5 36-50 64.5T720-250v170H240Zm80-80h40v-80h80v80h80v-80h80v80h40v-142q38-9 67.5-30t50-50q20.5-29 31.5-64t11-74q0-125-88.5-202.5T480-800q-143 0-231.5 77.5T160-520q0 39 11 74t31.5 64q20.5 29 50.5 50t67 30v142Zm100-200h120l-60-120-60 120Zm-80-80q33 0 56.5-23.5T420-520q0-33-23.5-56.5T340-600q-33 0-56.5 23.5T260-520q0 33 23.5 56.5T340-440Zm280 0q33 0 56.5-23.5T700-520q0-33-23.5-56.5T620-600q-33 0-56.5 23.5T540-520q0 33 23.5 56.5T620-440ZM480-160Z" />
     </Icon>
   );
 }

--- a/src/components/navbar/CLAUDE.md
+++ b/src/components/navbar/CLAUDE.md
@@ -1,7 +1,8 @@
 # navbar
 
 `Navbar`: `<header>` with `left`/`right` `ReactNode` slots, solid primary fill.
-Owns the narrow-screen padding for every button it contains.
+Owns the padding and the phone-sized touch target of every button it contains,
+trading its own padding for theirs on a narrow screen.
 `ScoresNavbar`: the scoreboard/picks switch plus the refresh button, for the
 results routes.
 

--- a/src/components/navbar/LogoButton/CLAUDE.md
+++ b/src/components/navbar/LogoButton/CLAUDE.md
@@ -1,3 +1,3 @@
 # LogoButton
 
-Shared `Button` wrapping `logo192.png`, `onClick` prop. White 1px outline from an inline SVG `feMorphology` dilate filter, which strokes the logo's alpha channel evenly on every side.
+Shared `Button` wrapping `logo192.png` and `APP_NAME`, which it exports, so the logo and the app name are one target. White 1px outline from an inline SVG `feMorphology` dilate filter, which strokes the logo's alpha channel evenly on every side.

--- a/src/components/navbar/LogoButton/LogoButton.scss
+++ b/src/components/navbar/LogoButton/LogoButton.scss
@@ -17,5 +17,8 @@
     font-size: 1rem;
     font-weight: bold;
     text-align: left;
+    // One line at every width. The navbar is sized for it, and a wrapped app name
+    // pushed the bar taller than the buttons standing next to it.
+    white-space: nowrap;
   }
 }

--- a/src/components/navbar/LogoButton/LogoButton.tsx
+++ b/src/components/navbar/LogoButton/LogoButton.tsx
@@ -5,7 +5,7 @@ const OUTLINE_FILTER_ID = "logo-button-outline";
 const OUTLINE_RADIUS_PX = 1;
 
 /** Shown in the navbar on every page, whichever view is open. */
-export const APP_NAME = "Rak Madness Calculator";
+export const APP_NAME = "The Rakulator";
 
 export default function LogoButton({ onClick }: { onClick: () => void }) {
   return (

--- a/src/components/navbar/Navbar.scss
+++ b/src/components/navbar/Navbar.scss
@@ -24,6 +24,9 @@
 
   @include narrow-screen {
     gap: 4px;
+    // Tighter than a desktop's, because on a phone the room is better spent on
+    // the buttons than around them.
+    padding: 6px 8px;
   }
 }
 
@@ -46,9 +49,8 @@
   }
 }
 
-// Two tiers, both there to keep the app name off a third line. 16px puts it
-// there around 420px, and 12px still does at 360px and below. Measured with the
-// name inside the logo button, so its own padding counts too.
+// Narrower than a desktop's, from the width the buttons lose their labels, so the
+// app name beside them keeps its one line.
 @include crowded-navbar {
   .navbar__content .button {
     padding-inline: 12px !important;
@@ -57,6 +59,7 @@
 
 @include narrow-screen {
   .navbar__content .button {
-    padding-inline: 6px !important;
+    // A finger's worth of button on a phone, where these are the only controls.
+    min-height: 44px;
   }
 }

--- a/src/components/navbar/Navbar.scss
+++ b/src/components/navbar/Navbar.scss
@@ -20,7 +20,7 @@
   justify-content: space-between;
   display: flex;
   gap: 12px;
-  padding: 12px 16px;
+  padding: 12px;
 
   @include narrow-screen {
     gap: 4px;

--- a/src/components/navbar/ScoresNavbar.tsx
+++ b/src/components/navbar/ScoresNavbar.tsx
@@ -1,4 +1,4 @@
-import { InfoIcon, LeaderboardIcon, RefreshIcon } from "../icon/Icon";
+import { FactCheckIcon, LeaderboardIcon, RefreshIcon } from "../icon/Icon";
 import getClasses from "../../utils/getClasses";
 import Button from "../button/Button";
 import "./ScoresNavbar.scss";
@@ -41,7 +41,7 @@ export default function ScoresNavbar({
           "--active": view === "Picks",
         })}`}
       >
-        <InfoIcon />
+        <FactCheckIcon />
         <span className="home__scores-header-label">Picks</span>
       </Button>
       <div className="home__scores-header-divider" />

--- a/src/components/results/ResultsLayout.tsx
+++ b/src/components/results/ResultsLayout.tsx
@@ -30,10 +30,10 @@ export default function ResultsLayout() {
 
   return (
     <PageLayout
-      showingScores={isReady}
-      // The loaded picks table is wider than the content column, so its
-      // wireframe spans the screen rather than snapping wider on arrival.
-      fillsWidth={!isReady && view === "Picks"}
+      // True while loading too: the wireframe is shaped like the table it stands
+      // in for, so it wants the same content area.
+      showingScores
+      scrollable={isReady}
       navbarLeft={<LogoButton onClick={() => navigate("/")} />}
       navbarRight={
         // Rendered while the week loads, so the navbar does not change shape

--- a/src/components/table/CLAUDE.md
+++ b/src/components/table/CLAUDE.md
@@ -14,8 +14,8 @@ carries a `data-skeleton-text` stand-in that the stylesheet draws invisibly, so 
 table's own `max-content` sizing gives the wireframe a real table's measurements at
 any font size, and no placeholder reaches the page's text. No stand-in for a value
 wraps, because no real value does either, so a wireframe row is one line tall like
-a real one. Its header wraps on its own, so it is as tall as the real header at
-whatever width the table is being drawn.
+a real one. Its header wraps on its own, with a floor of two lines so it still
+reads as a header where a real heading fits on one.
 
 ## Subdirectories
 

--- a/src/components/table/CLAUDE.md
+++ b/src/components/table/CLAUDE.md
@@ -12,7 +12,10 @@ colors, striped rows).
 worked out, shaped like the view it stands in for. Its cells hold no text: each
 carries a `data-skeleton-text` stand-in that the stylesheet draws invisibly, so the
 table's own `max-content` sizing gives the wireframe a real table's measurements at
-any font size, and no placeholder reaches the page's text.
+any font size, and no placeholder reaches the page's text. No stand-in for a value
+wraps, because no real value does either, so a wireframe row is one line tall like
+a real one. Its header wraps on its own, so it is as tall as the real header at
+whatever width the table is being drawn.
 
 ## Subdirectories
 

--- a/src/components/table/CLAUDE.md
+++ b/src/components/table/CLAUDE.md
@@ -9,7 +9,10 @@ holds the shared `.table` styles (sticky header and player column, pick status
 colors, striped rows).
 
 `SkeletonTable`: the pulsing wireframe shown while a week's results are being
-worked out. Nothing but filler rows, so the shell sizes it.
+worked out, shaped like the view it stands in for. Its cells hold no text: each
+carries a `data-skeleton-text` stand-in that the stylesheet draws invisibly, so the
+table's own `max-content` sizing gives the wireframe a real table's measurements at
+any font size, and no placeholder reaches the page's text.
 
 ## Subdirectories
 

--- a/src/components/table/CLAUDE.md
+++ b/src/components/table/CLAUDE.md
@@ -5,8 +5,10 @@ short table down to the bottom of the viewport, and the trailing row that keeps 
 last real row clear of a phone's rounded corners. `Table.scss` sizes that row from
 `env(safe-area-inset-bottom)`, so it has no height on a screen without an inset,
 publishes `--rak-table-row-height` for `useFillerRows` to measure against, and
-holds the shared `.table` styles (sticky header and player column, pick status
-colors, striped rows).
+holds the shared `.table` styles (sticky header and player column, the touch
+feedback both clickable cells share, striped rows). Every measurement the wireframe
+has to reproduce is a custom property on `.table`: cell padding, cell borders, and
+the size of the icon beside a player's name. Change one there, not in two files.
 
 `SkeletonTable`: the pulsing wireframe shown while a week's results are being
 worked out, shaped like the view it stands in for. Its cells hold no text: each

--- a/src/components/table/SkeletonTable.scss
+++ b/src/components/table/SkeletonTable.scss
@@ -39,8 +39,10 @@
   .skeleton__bar {
     position: absolute;
     top: 50%;
-    left: 6px;
-    right: 6px;
+    // Absolute insets run from the padding box, so the cell's own padding is what
+    // lands a bar on the content a real cell would hold.
+    left: var(--rak-table-cell-padding-x);
+    right: var(--rak-table-cell-padding-x);
     height: 0.7rem;
     transform: translateY(-50%);
     border-radius: 3px;
@@ -51,9 +53,9 @@
   // Two lines tall whatever the stand-in headings do, so the wireframe still reads
   // as a header at a width where a real heading fits on one line. `height` on a
   // table cell is a minimum, so a narrow screen can still stack a heading higher.
-  // The 4px is the cell's own vertical padding, which `border-box` counts in here.
+  // `border-box` counts the cell's own padding into that height.
   .table__header th {
-    height: calc(2lh + 4px);
+    height: calc(2lh + 2 * var(--rak-table-cell-padding-y));
   }
 
   .table__header .skeleton__bar {
@@ -64,13 +66,15 @@
   // A real table draws this edge from its sticky player column, which the
   // wireframe has no stand-in for, so the rank column would run into the next one.
   td:nth-child(2) {
-    border-left: 2px solid var(--rak-primary-800);
+    border-left: var(--rak-table-border);
 
-    // Room for the status icon that sits beside a real name: a 16px box and the
-    // 8px gap before it, both from `PlayerName.scss`. Without it this column comes
-    // out narrower than the one it stands in for.
+    // Room for the status icon that sits beside a real name, which this column has
+    // no stand-in for. Without it the column comes out narrower than the one it
+    // stands in for.
     &::before {
-      padding-right: 24px;
+      padding-right: calc(
+        var(--rak-player-icon-size) + var(--rak-player-icon-gap)
+      );
     }
   }
 }

--- a/src/components/table/SkeletonTable.scss
+++ b/src/components/table/SkeletonTable.scss
@@ -29,10 +29,11 @@
     }
   }
 
-  // Body text stands for a value, so it breaks only where the stand-in says. A
-  // header still wraps on its own, the way the real one does.
+  // No value in a real table wraps, so no stand-in for one does either, and every
+  // body row comes out a single line tall. A header still wraps on its own, the
+  // way the real one does.
   td::before {
-    white-space: pre;
+    white-space: nowrap;
   }
 
   .skeleton__bar {
@@ -56,6 +57,13 @@
   // wireframe has no stand-in for, so the rank column would run into the next one.
   td:nth-child(2) {
     border-left: 2px solid var(--rak-primary-800);
+
+    // Room for the status icon that sits beside a real name: a 16px box and the
+    // 8px gap before it, both from `PlayerName.scss`. Without it this column comes
+    // out narrower than the one it stands in for.
+    &::before {
+      padding-right: 24px;
+    }
   }
 }
 

--- a/src/components/table/SkeletonTable.scss
+++ b/src/components/table/SkeletonTable.scss
@@ -48,6 +48,14 @@
     animation: skeleton-pulse 1s ease-in-out infinite alternate;
   }
 
+  // Two lines tall whatever the stand-in headings do, so the wireframe still reads
+  // as a header at a width where a real heading fits on one line. `height` on a
+  // table cell is a minimum, so a narrow screen can still stack a heading higher.
+  // The 4px is the cell's own vertical padding, which `border-box` counts in here.
+  .table__header th {
+    height: calc(2lh + 4px);
+  }
+
   .table__header .skeleton__bar {
     // The header is already dark, so the bars read as light gaps in it.
     background-color: white;

--- a/src/components/table/SkeletonTable.scss
+++ b/src/components/table/SkeletonTable.scss
@@ -50,14 +50,6 @@
     animation: skeleton-pulse 1s ease-in-out infinite alternate;
   }
 
-  // Two lines tall whatever the stand-in headings do, so the wireframe still reads
-  // as a header at a width where a real heading fits on one line. `height` on a
-  // table cell is a minimum, so a narrow screen can still stack a heading higher.
-  // `border-box` counts the cell's own padding into that height.
-  .table__header th {
-    height: calc(2lh + 2 * var(--rak-table-cell-padding-y));
-  }
-
   .table__header .skeleton__bar {
     // The header is already dark, so the bars read as light gaps in it.
     background-color: white;

--- a/src/components/table/SkeletonTable.scss
+++ b/src/components/table/SkeletonTable.scss
@@ -12,8 +12,6 @@
   // a band above and below. Flush to the top instead, so the whole remainder is at
   // the bottom and the row count can claim it.
   margin-block: 0;
-  // The wireframe is decoration, so it never invites a click.
-  pointer-events: none;
 
   th,
   td {

--- a/src/components/table/SkeletonTable.scss
+++ b/src/components/table/SkeletonTable.scss
@@ -1,5 +1,3 @@
-@use "../../styles/breakpoints" as *;
-
 @keyframes skeleton-pulse {
   from {
     opacity: 0.45;
@@ -10,12 +8,6 @@
 }
 
 .table.--skeleton {
-  --rak-skeleton-header-lines: calc(2 * 1.5em + 4px);
-  // Spans the content column, where a real table is only as wide as its columns.
-  width: 100%;
-  // Honors the per-column widths the header cells carry, which is what gives the
-  // wireframe the shape of the table it stands in for.
-  table-layout: fixed;
   // `.table` centers itself vertically, which would split the leftover space into
   // a band above and below. Flush to the top instead, so the whole remainder is at
   // the bottom and the row count can claim it.
@@ -23,21 +15,36 @@
   // The wireframe is decoration, so it never invites a click.
   pointer-events: none;
 
+  th,
+  td {
+    // Containing block for the bar, which is taken out of flow so the invisible
+    // text below is what sizes the cell.
+    position: relative;
+
+    // Drawn from the attribute rather than written into the cell, so a placeholder
+    // never lands in the page's text for a screen reader or a query to find.
+    &::before {
+      content: attr(data-skeleton-text);
+      visibility: hidden;
+    }
+  }
+
+  // Body text stands for a value, so it breaks only where the stand-in says. A
+  // header still wraps on its own, the way the real one does.
+  td::before {
+    white-space: pre;
+  }
+
   .skeleton__bar {
-    display: block;
-    width: 100%;
+    position: absolute;
+    top: 50%;
+    left: 6px;
+    right: 6px;
     height: 0.7rem;
+    transform: translateY(-50%);
     border-radius: 3px;
     background-color: var(--rak-text-tertiary);
     animation: skeleton-pulse 1s ease-in-out infinite alternate;
-  }
-
-  .table__header th {
-    // A real header needs no height, since its own text gives it one, and that text
-    // wraps: two lines at any width below roughly 1100px, three once the columns
-    // are phone-narrow. The wireframe has no text to wrap, so it is handed the
-    // height that text would have made. Assumes the inherited line-height of 1.5.
-    height: var(--rak-skeleton-header-lines);
   }
 
   .table__header .skeleton__bar {
@@ -49,20 +56,6 @@
   // wireframe has no stand-in for, so the rank column would run into the next one.
   td:nth-child(2) {
     border-left: 2px solid var(--rak-primary-800);
-  }
-
-  td,
-  th {
-    // `min-width: max-content` measures an empty cell as nothing, and the columns
-    // then divide the table's width evenly. Overriding it also keeps the wireframe
-    // from being wider than a phone and scrolling sideways.
-    min-width: 0;
-  }
-}
-
-@include narrow-screen {
-  .table.--skeleton {
-    --rak-skeleton-header-lines: calc(3 * 1.5em + 4px);
   }
 }
 

--- a/src/components/table/SkeletonTable.tsx
+++ b/src/components/table/SkeletonTable.tsx
@@ -1,3 +1,5 @@
+import { memo } from "react";
+import rangeWithPrefix from "../../utils/rangeWithPrefix";
 import { ScoresView } from "../navbar/ScoresNavbar";
 import TableShell from "./TableShell";
 import "./SkeletonTable.scss";
@@ -42,8 +44,8 @@ const SCOREBOARD_COLUMNS: Array<Column> = [
 ];
 
 function leagueColumns(count: number, prefix: string): Array<Column> {
-  return Array.from({ length: count }, (_, game) => ({
-    header: `${prefix}${game + 1}`,
+  return rangeWithPrefix(count, prefix).map((header) => ({
+    header,
     cell: PICK,
     isPick: true,
   }));
@@ -64,8 +66,11 @@ const PICKS_COLUMNS: Array<Column> = [
  *
  * Shaped like the view it stands in for, down to the column count and the row
  * count, so the page does not rearrange itself once the week arrives.
+ *
+ * Memoized because it is well over a thousand cells and its route re-renders on
+ * every flag the week's loading sets, all of them while this is on screen.
  */
-export default function SkeletonTable({ view }: { view: ScoresView }) {
+function SkeletonTable({ view }: { view: ScoresView }) {
   const columns = view === "Picks" ? PICKS_COLUMNS : SCOREBOARD_COLUMNS;
 
   return (
@@ -102,3 +107,5 @@ export default function SkeletonTable({ view }: { view: ScoresView }) {
     </TableShell>
   );
 }
+
+export default memo(SkeletonTable);

--- a/src/components/table/SkeletonTable.tsx
+++ b/src/components/table/SkeletonTable.tsx
@@ -3,53 +3,105 @@ import TableShell from "./TableShell";
 import "./SkeletonTable.scss";
 
 /**
- * Column widths read off loaded tables, in pixels. Only the ratios matter: the
- * wireframe spreads them across whatever width it is given.
- */
-const SCOREBOARD_WIDTHS = [55, 242, 143, 178, 125, 93, 128, 103];
-const RANK_WIDTH = 55;
-const PLAYER_WIDTH = 156;
-const PICK_WIDTH = 91;
-const SCORE_WIDTH = 70;
-
-/**
- * A middling week. The real count comes from the picks, which have not been read
- * yet, and a bowl week is a single college game against sixteen pro ones.
+ * A middling week's shape, week 5's: six college games, thirteen pro, sixty-one
+ * players. The real numbers come from the picks, which have not been read yet.
  */
 const COLLEGE_COUNT = 6;
 const PRO_COUNT = 13;
+const PLAYER_COUNT = 61;
 
-const PICKS_WIDTHS = [
-  RANK_WIDTH,
-  PLAYER_WIDTH,
-  ...Array<number>(COLLEGE_COUNT).fill(PICK_WIDTH),
-  SCORE_WIDTH,
-  ...Array<number>(PRO_COUNT).fill(PICK_WIDTH),
-  SCORE_WIDTH,
-  SCORE_WIDTH,
+/**
+ * Stand-in text, each as long as the widest a real cell of that kind gets. The
+ * stylesheet draws it invisibly from `data-skeleton-text`, and the table's own
+ * `max-content` sizing measures it, so the wireframe comes out the size the loaded
+ * table will be at any font size without a single width being written down. It
+ * stays out of the DOM's text so nothing reads or matches a placeholder.
+ */
+const RANK = "10";
+/**
+ * Two lines, because a pool full of long names leaves the real player column two
+ * lines tall, and that is what sets the height of every row.
+ */
+const PLAYER = "Why is the Runn\nGone?";
+const PICK = "TCU -13.5";
+const SCORE = "10";
+
+type Column = {
+  header: string;
+  cell: string;
+  /** A game's column, which the real table centers and never wraps. */
+  isPick?: boolean;
+};
+
+const SCOREBOARD_COLUMNS: Array<Column> = [
+  { header: "Rank", cell: RANK },
+  { header: "Player", cell: PLAYER },
+  { header: "MNF Points Pick", cell: SCORE },
+  { header: "MNF Points Distance", cell: SCORE },
+  { header: "College Score", cell: SCORE },
+  { header: "Pro Score", cell: SCORE },
+  { header: "Pro Score ATS", cell: SCORE },
+  { header: "Total Score", cell: SCORE },
+];
+
+function leagueColumns(count: number, prefix: string): Array<Column> {
+  return Array.from({ length: count }, (_, game) => ({
+    header: `${prefix}${game + 1}`,
+    cell: PICK,
+    isPick: true,
+  }));
+}
+
+const PICKS_COLUMNS: Array<Column> = [
+  { header: "Rank", cell: RANK },
+  { header: "Player", cell: PLAYER },
+  ...leagueColumns(COLLEGE_COUNT, "C"),
+  { header: "College Score", cell: SCORE },
+  ...leagueColumns(PRO_COUNT, "P"),
+  { header: "Pro Score", cell: SCORE },
+  { header: "Total Score", cell: SCORE },
 ];
 
 /**
  * A wireframe of a results table, for while the real one is being worked out.
  *
- * Shaped like the view it stands in for, so the columns do not rearrange
- * themselves once the week arrives. Every row is a filler row, so the shell
- * carries it to the bottom of the viewport.
+ * Shaped like the view it stands in for, down to the column count and the row
+ * count, so the page does not rearrange itself once the week arrives.
  */
 export default function SkeletonTable({ view }: { view: ScoresView }) {
-  const widths = view === "Picks" ? PICKS_WIDTHS : SCOREBOARD_WIDTHS;
-  const total = widths.reduce((sum, width) => sum + width, 0);
+  const columns = view === "Picks" ? PICKS_COLUMNS : SCOREBOARD_COLUMNS;
 
   return (
     <TableShell
       className="--skeleton"
-      columnCount={widths.length}
-      header={widths.map((width, column) => (
-        <th key={column} style={{ width: `${(width / total) * 100}%` }}>
+      columnCount={columns.length}
+      header={columns.map((column, index) => (
+        // A game's header is sized by `table__pick-header`'s own minimum, the way
+        // the real one is, so it needs no stand-in text.
+        <th
+          key={index}
+          data-skeleton-text={column.isPick ? undefined : column.header}
+        >
+          {column.isPick && <span className="table__pick-header" />}
           <span className="skeleton__bar" />
         </th>
       ))}
-      fillerCellContent={<span className="skeleton__bar" />}
-    />
+    >
+      {Array.from({ length: PLAYER_COUNT }, (_, row) => (
+        <tr key={row}>
+          {columns.map((column, index) => (
+            <td
+              key={index}
+              className={
+                column.isPick ? "table__center table__pick" : undefined
+              }
+              data-skeleton-text={column.cell}
+            >
+              <span className="skeleton__bar" />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </TableShell>
   );
 }

--- a/src/components/table/SkeletonTable.tsx
+++ b/src/components/table/SkeletonTable.tsx
@@ -18,11 +18,8 @@ const PLAYER_COUNT = 61;
  * stays out of the DOM's text so nothing reads or matches a placeholder.
  */
 const RANK = "10";
-/**
- * Two lines, because a pool full of long names leaves the real player column two
- * lines tall, and that is what sets the height of every row.
- */
-const PLAYER = "Why is the Runn\nGone?";
+/** Twenty characters, the longest a real name gets before it is cut short. */
+const PLAYER = "Why is the Runn Gone";
 const PICK = "TCU -13.5";
 const SCORE = "10";
 

--- a/src/components/table/SkeletonTable.tsx
+++ b/src/components/table/SkeletonTable.tsx
@@ -32,15 +32,21 @@ type Column = {
   isPick?: boolean;
 };
 
-const SCOREBOARD_COLUMNS: Array<Column> = [
+/** Both views open on these and close on a total. */
+const RANK_AND_PLAYER: Array<Column> = [
   { header: "Rank", cell: RANK },
   { header: "Player", cell: PLAYER },
+];
+const TOTAL_SCORE: Column = { header: "Total Score", cell: SCORE };
+
+const SCOREBOARD_COLUMNS: Array<Column> = [
+  ...RANK_AND_PLAYER,
   { header: "MNF Points Pick", cell: SCORE },
   { header: "MNF Points Distance", cell: SCORE },
   { header: "College Score", cell: SCORE },
   { header: "Pro Score", cell: SCORE },
   { header: "Pro Score ATS", cell: SCORE },
-  { header: "Total Score", cell: SCORE },
+  TOTAL_SCORE,
 ];
 
 function leagueColumns(count: number, prefix: string): Array<Column> {
@@ -52,13 +58,12 @@ function leagueColumns(count: number, prefix: string): Array<Column> {
 }
 
 const PICKS_COLUMNS: Array<Column> = [
-  { header: "Rank", cell: RANK },
-  { header: "Player", cell: PLAYER },
+  ...RANK_AND_PLAYER,
   ...leagueColumns(COLLEGE_COUNT, "C"),
   { header: "College Score", cell: SCORE },
   ...leagueColumns(PRO_COUNT, "P"),
   { header: "Pro Score", cell: SCORE },
-  { header: "Total Score", cell: SCORE },
+  TOTAL_SCORE,
 ];
 
 /**

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -5,6 +5,18 @@
   // Read back by useFillerRows, which needs a row height to work out how many
   // rows fit below the real ones.
   --rak-table-row-height: 32px;
+  // The rest are read back by `SkeletonTable.scss`. The wireframe draws a table
+  // nobody has the numbers for yet, so every measurement it stands in for has to
+  // come from here rather than be written down twice.
+  --rak-table-cell-padding-x: 6px;
+  --rak-table-cell-padding-y: 2px;
+  --rak-table-header-padding-x: 8px;
+  --rak-table-border: 2px solid var(--rak-primary-800);
+  --rak-table-header-border: 2px solid var(--rak-primary-600);
+  // The status icon beside a player's name, in `PlayerName.scss`. Sized here
+  // because the wireframe has to leave the same room without drawing one.
+  --rak-player-icon-size: 16px;
+  --rak-player-icon-gap: 8px;
 
   .table__header {
     z-index: 20;
@@ -17,7 +29,7 @@
       color: white;
       background-color: var(--rak-primary-800);
       min-width: max-content;
-      padding: 2px 8px;
+      padding: var(--rak-table-cell-padding-y) var(--rak-table-header-padding-x);
       // Named even on the edges that carry no border, because a zero-width border
       // takes `currentColor`, which is white here. Dark Reader forces borders
       // visible and draws that white against the dividers below.
@@ -25,13 +37,13 @@
 
       // Add a border between header cells
       &:not(:last-child) {
-        border-right: 2px solid var(--rak-primary-600);
+        border-right: var(--rak-table-header-border);
       }
       &:first-child {
         border-right: none;
       }
       &:nth-child(2) {
-        border-left: 2px solid var(--rak-primary-600);
+        border-left: var(--rak-table-header-border);
       }
     }
   }
@@ -60,11 +72,12 @@
   }
 
   tbody {
-    // Style non-header player cells
-    .table__player-col {
+    // Both of these open a toast when tapped, so both answer to a touch the same
+    // way. The wireframe takes no clicks at all, so it never reaches this.
+    .table__player-col,
+    .table__pick {
       cursor: pointer;
       transition: filter 150ms;
-      border-left: 2px solid var(--rak-primary-800);
 
       &:hover {
         filter: brightness(0.85);
@@ -73,6 +86,11 @@
       &:active {
         filter: brightness(0.7);
       }
+    }
+
+    // Style non-header player cells
+    .table__player-col {
+      border-left: var(--rak-table-border);
 
       &.--knocked-out {
         background-color: #fac99e;
@@ -101,11 +119,11 @@
       font-family: monospace;
       min-width: max-content;
       height: var(--rak-table-row-height);
-      padding: 2px 6px;
-      border-bottom: 2px solid var(--rak-primary-800);
-      border-right: 2px solid var(--rak-primary-800);
+      padding: var(--rak-table-cell-padding-y) var(--rak-table-cell-padding-x);
+      border-bottom: var(--rak-table-border);
+      border-right: var(--rak-table-border);
       &:first-child {
-        border-left: 2px solid var(--rak-primary-800);
+        border-left: var(--rak-table-border);
         border-right: none;
       }
     }

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -5,9 +5,10 @@
   // Read back by useFillerRows, which needs a row height to work out how many
   // rows fit below the real ones.
   --rak-table-row-height: 32px;
-  // The rest are read back by `SkeletonTable.scss`. The wireframe draws a table
-  // nobody has the numbers for yet, so every measurement it stands in for has to
-  // come from here rather than be written down twice.
+  // The rest are the measurements the wireframe has to reproduce. It draws a
+  // table nobody has the numbers for yet, so it reaches them here, either through
+  // the selectors below that it shares or by name in `SkeletonTable.scss`. Either
+  // way none of them is written down twice.
   --rak-table-cell-padding-x: 6px;
   --rak-table-cell-padding-y: 2px;
   --rak-table-header-padding-x: 8px;

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -29,6 +29,11 @@
       color: white;
       background-color: var(--rak-primary-800);
       min-width: max-content;
+      // Two lines tall even where the headings fit on one. `height` on a table
+      // cell is a minimum, so a narrow screen still stacks them higher, and
+      // `border-box` counts the cell's own padding into this. The wireframe holds
+      // to the same floor, so the header does not jump when the week arrives.
+      height: calc(2lh + 2 * var(--rak-table-cell-padding-y));
       padding: var(--rak-table-cell-padding-y) var(--rak-table-header-padding-x);
       // Named even on the edges that carry no border, because a zero-width border
       // takes `currentColor`, which is white here. Dark Reader forces borders

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -36,6 +36,22 @@
     }
   }
 
+  // These three size a game's column, so the wireframe needs them as much as the
+  // picks table does. The pick colors stay in `PicksTable.scss`, which the
+  // wireframe has no use for.
+  .table__pick-header {
+    display: inline-block;
+    min-width: 64px;
+  }
+
+  .table__center {
+    text-align: center;
+  }
+
+  tbody .table__pick {
+    white-space: nowrap;
+  }
+
   // Stick the player column to the left side of the screen.
   .table__player-col {
     z-index: 10;

--- a/src/components/table/TableShell.tsx
+++ b/src/components/table/TableShell.tsx
@@ -15,14 +15,11 @@ export default function TableShell({
   columnCount,
   header,
   className = "",
-  fillerCellContent,
   children,
 }: {
   columnCount: number;
   header: ReactNode;
   className?: string;
-  /** Placed in every cell of every filler row. Empty cells without it. */
-  fillerCellContent?: ReactNode;
   children?: ReactNode;
 }) {
   const tableRef = useRef<HTMLTableElement>(null);
@@ -38,7 +35,7 @@ export default function TableShell({
         {Array.from({ length: fillerRows }, (_, row) => (
           <tr key={`filler-${row}`} className="table__filler-row">
             {Array.from({ length: columnCount }, (_, column) => (
-              <td key={column}>{fillerCellContent}</td>
+              <td key={column} />
             ))}
           </tr>
         ))}

--- a/src/components/table/picks/PicksTable.scss
+++ b/src/components/table/picks/PicksTable.scss
@@ -1,16 +1,6 @@
 .table {
-  .table__pick-header {
-    display: inline-block;
-    min-width: 64px;
-  }
-
-  .table__center {
-    text-align: center;
-  }
-
   tbody {
     .table__pick {
-      white-space: nowrap;
       cursor: pointer;
       transition: filter 150ms;
 

--- a/src/components/table/picks/PicksTable.scss
+++ b/src/components/table/picks/PicksTable.scss
@@ -1,17 +1,6 @@
 .table {
   tbody {
     .table__pick {
-      cursor: pointer;
-      transition: filter 150ms;
-
-      &:hover {
-        filter: brightness(0.85);
-      }
-
-      &:active {
-        filter: brightness(0.7);
-      }
-
       &.--yes {
         background-color: var(--rak-pick-yes);
       }

--- a/src/components/table/picks/PicksTable.tsx
+++ b/src/components/table/picks/PicksTable.tsx
@@ -1,11 +1,10 @@
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback } from "react";
 import {
   PickResult,
   PlayerScore,
   RakMadnessScores,
 } from "../../../types/RakMadnessScores";
 import rangeWithPrefix from "../../../utils/rangeWithPrefix";
-import isWeekDecided from "../../../utils/scoring/isWeekDecided";
 import PlayerName from "../playerName/PlayerName";
 import TableShell, { RankCell } from "../TableShell";
 import "./PicksTable.scss";
@@ -43,11 +42,6 @@ function PicksTable({ scores }: { scores?: RakMadnessScores | null }) {
     [clearToasts, showToast],
   );
 
-  const isDecided = useMemo(
-    () => scores != null && isWeekDecided(scores),
-    [scores],
-  );
-
   if (scores == null) {
     return null;
   }
@@ -76,7 +70,7 @@ function PicksTable({ scores }: { scores?: RakMadnessScores | null }) {
         return (
           <tr key={player.name}>
             <RankCell rank={index + 1} />
-            <PlayerName player={player} isWeekDecided={isDecided} />
+            <PlayerName player={player} />
             {player.college.map((result, index) => (
               <td
                 key={`${player.name}-C${index + 1}`}

--- a/src/components/table/picks/PicksTable.tsx
+++ b/src/components/table/picks/PicksTable.tsx
@@ -1,10 +1,11 @@
-import { memo, useCallback } from "react";
+import { memo, useCallback, useMemo } from "react";
 import {
   PickResult,
   PlayerScore,
   RakMadnessScores,
 } from "../../../types/RakMadnessScores";
 import rangeWithPrefix from "../../../utils/rangeWithPrefix";
+import isWeekDecided from "../../../utils/scoring/isWeekDecided";
 import PlayerName from "../playerName/PlayerName";
 import TableShell, { RankCell } from "../TableShell";
 import "./PicksTable.scss";
@@ -42,6 +43,11 @@ function PicksTable({ scores }: { scores?: RakMadnessScores | null }) {
     [clearToasts, showToast],
   );
 
+  const isDecided = useMemo(
+    () => scores != null && isWeekDecided(scores),
+    [scores],
+  );
+
   if (scores == null) {
     return null;
   }
@@ -70,7 +76,7 @@ function PicksTable({ scores }: { scores?: RakMadnessScores | null }) {
         return (
           <tr key={player.name}>
             <RankCell rank={index + 1} />
-            <PlayerName player={player} />
+            <PlayerName player={player} isWeekDecided={isDecided} />
             {player.college.map((result, index) => (
               <td
                 key={`${player.name}-C${index + 1}`}

--- a/src/components/table/playerName/CLAUDE.md
+++ b/src/components/table/playerName/CLAUDE.md
@@ -1,6 +1,6 @@
 # playerName
 
-`PlayerName`: table cell (`<td>`), player name + knocked-out status icon (`SentimentVeryDissatisfied`/`SentimentVerySatisfied`).
+`PlayerName`: table cell (`<td>`), player name + knocked-out status icon (`Skull`/`SentimentVerySatisfied`).
 Click shows status explanation via `ToastContext`.
 Name never wraps: cut short with an ellipsis past 20 characters, which the cell's
 monospace font makes exactly `20ch`. So every row is one line tall.

--- a/src/components/table/playerName/CLAUDE.md
+++ b/src/components/table/playerName/CLAUDE.md
@@ -2,3 +2,5 @@
 
 `PlayerName`: table cell (`<td>`), player name + knocked-out status icon (`SentimentVeryDissatisfied`/`SentimentVerySatisfied`).
 Click shows status explanation via `ToastContext`.
+Name never wraps: cut short with an ellipsis past 20 characters, which the cell's
+monospace font makes exactly `20ch`. So every row is one line tall.

--- a/src/components/table/playerName/PlayerName.scss
+++ b/src/components/table/playerName/PlayerName.scss
@@ -5,6 +5,17 @@
   justify-content: space-between;
   gap: 8px;
 
+  // The cell's font is monospace, so 20ch is exactly 20 characters. A longer name
+  // is cut short rather than wrapped, because a wrapped name would make its row
+  // taller than every other row in the table. The whole name is in the toast the
+  // cell opens.
+  .player-name__name {
+    max-width: 20ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .player-name__status-icon {
     display: flex;
     align-items: center;

--- a/src/components/table/playerName/PlayerName.scss
+++ b/src/components/table/playerName/PlayerName.scss
@@ -3,7 +3,9 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  // Both from `Table.scss`, so the wireframe can leave the same room for an icon
+  // it never draws.
+  gap: var(--rak-player-icon-gap);
 
   // The cell's font is monospace, so 20ch is exactly 20 characters. A longer name
   // is cut short rather than wrapped, because a wrapped name would make its row
@@ -23,8 +25,8 @@
 
     > svg {
       fill: black;
-      width: 16px;
-      height: 16px;
+      width: var(--rak-player-icon-size);
+      height: var(--rak-player-icon-size);
     }
   }
 }

--- a/src/components/table/playerName/PlayerName.tsx
+++ b/src/components/table/playerName/PlayerName.tsx
@@ -6,6 +6,7 @@ import {
   SentimentVerySatisfiedIcon,
   SkullIcon,
 } from "../../icon/Icon";
+import { useIsWeekDecided } from "../../../context/AppDataContext";
 import { useToastActions, Toast } from "../../../context/ToastContext";
 import "./PlayerName.scss";
 
@@ -17,15 +18,9 @@ function statusIcon(player: PlayerScore, isWeekDecided: boolean) {
   return isWeekDecided ? <EmojiEventsIcon /> : <SentimentVerySatisfiedIcon />;
 }
 
-function PlayerName({
-  player,
-  isWeekDecided = false,
-}: {
-  player: PlayerScore;
-  /** Every game scored and the tiebreaker settled, so nobody else can catch up. */
-  isWeekDecided?: boolean;
-}) {
+function PlayerName({ player }: { player: PlayerScore }) {
   const { showToast, clearToasts } = useToastActions();
+  const isWeekDecided = useIsWeekDecided();
 
   return (
     <td

--- a/src/components/table/playerName/PlayerName.tsx
+++ b/src/components/table/playerName/PlayerName.tsx
@@ -1,11 +1,30 @@
 import { memo } from "react";
 import { PlayerScore } from "../../../types/RakMadnessScores";
 import getClasses from "../../../utils/getClasses";
-import { SentimentVerySatisfiedIcon, SkullIcon } from "../../icon/Icon";
+import {
+  EmojiEventsIcon,
+  SentimentVerySatisfiedIcon,
+  SkullIcon,
+} from "../../icon/Icon";
 import { useToastActions, Toast } from "../../../context/ToastContext";
 import "./PlayerName.scss";
 
-function PlayerName({ player }: { player: PlayerScore }) {
+/** Still standing at the end of the week, which is what winning the week is. */
+function statusIcon(player: PlayerScore, isWeekDecided: boolean) {
+  if (player.status.isKnockedOut) {
+    return <SkullIcon />;
+  }
+  return isWeekDecided ? <EmojiEventsIcon /> : <SentimentVerySatisfiedIcon />;
+}
+
+function PlayerName({
+  player,
+  isWeekDecided = false,
+}: {
+  player: PlayerScore;
+  /** Every game scored and the tiebreaker settled, so nobody else can catch up. */
+  isWeekDecided?: boolean;
+}) {
   const { showToast, clearToasts } = useToastActions();
 
   return (
@@ -24,11 +43,7 @@ function PlayerName({ player }: { player: PlayerScore }) {
       <div className="player-name">
         <span className="player-name__name">{player.name}</span>
         <span className="player-name__status-icon">
-          {player.status.isKnockedOut ? (
-            <SkullIcon />
-          ) : (
-            <SentimentVerySatisfiedIcon />
-          )}
+          {statusIcon(player, isWeekDecided)}
         </span>
       </div>
     </td>

--- a/src/components/table/playerName/PlayerName.tsx
+++ b/src/components/table/playerName/PlayerName.tsx
@@ -1,10 +1,7 @@
 import { memo } from "react";
 import { PlayerScore } from "../../../types/RakMadnessScores";
 import getClasses from "../../../utils/getClasses";
-import {
-  SentimentVeryDissatisfiedIcon,
-  SentimentVerySatisfiedIcon,
-} from "../../icon/Icon";
+import { SentimentVerySatisfiedIcon, SkullIcon } from "../../icon/Icon";
 import { useToastActions, Toast } from "../../../context/ToastContext";
 import "./PlayerName.scss";
 
@@ -28,7 +25,7 @@ function PlayerName({ player }: { player: PlayerScore }) {
         <span className="player-name__name">{player.name}</span>
         <span className="player-name__status-icon">
           {player.status.isKnockedOut ? (
-            <SentimentVeryDissatisfiedIcon />
+            <SkullIcon />
           ) : (
             <SentimentVerySatisfiedIcon />
           )}

--- a/src/components/table/playerName/PlayerName.tsx
+++ b/src/components/table/playerName/PlayerName.tsx
@@ -25,7 +25,7 @@ function PlayerName({ player }: { player: PlayerScore }) {
       }}
     >
       <div className="player-name">
-        <span>{player.name}</span>
+        <span className="player-name__name">{player.name}</span>
         <span className="player-name__status-icon">
           {player.status.isKnockedOut ? (
             <SentimentVeryDissatisfiedIcon />

--- a/src/components/table/scores/ScoresTable.tsx
+++ b/src/components/table/scores/ScoresTable.tsx
@@ -1,11 +1,17 @@
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { PlayerScore, RakMadnessScores } from "../../../types/RakMadnessScores";
+import isWeekDecided from "../../../utils/scoring/isWeekDecided";
 import PlayerName from "../playerName/PlayerName";
 import TableShell, { RankCell } from "../TableShell";
 
 const COLUMN_COUNT = 8;
 
 function ScoresTable({ scores }: { scores?: RakMadnessScores | null }) {
+  const isDecided = useMemo(
+    () => scores != null && isWeekDecided(scores),
+    [scores],
+  );
+
   if (scores == null) {
     return null;
   }
@@ -29,7 +35,7 @@ function ScoresTable({ scores }: { scores?: RakMadnessScores | null }) {
       {scores.scores.map((player: PlayerScore, index: number) => (
         <tr key={player.name}>
           <RankCell rank={index + 1} />
-          <PlayerName player={player} />
+          <PlayerName player={player} isWeekDecided={isDecided} />
           <td>{player.tiebreaker.pick ?? "N/A"}</td>
           <td>{player.tiebreaker.distance ?? "N/A"}</td>
           <td>{player.score.college}</td>

--- a/src/components/table/scores/ScoresTable.tsx
+++ b/src/components/table/scores/ScoresTable.tsx
@@ -1,17 +1,11 @@
-import { memo, useMemo } from "react";
+import { memo } from "react";
 import { PlayerScore, RakMadnessScores } from "../../../types/RakMadnessScores";
-import isWeekDecided from "../../../utils/scoring/isWeekDecided";
 import PlayerName from "../playerName/PlayerName";
 import TableShell, { RankCell } from "../TableShell";
 
 const COLUMN_COUNT = 8;
 
 function ScoresTable({ scores }: { scores?: RakMadnessScores | null }) {
-  const isDecided = useMemo(
-    () => scores != null && isWeekDecided(scores),
-    [scores],
-  );
-
   if (scores == null) {
     return null;
   }
@@ -35,7 +29,7 @@ function ScoresTable({ scores }: { scores?: RakMadnessScores | null }) {
       {scores.scores.map((player: PlayerScore, index: number) => (
         <tr key={player.name}>
           <RankCell rank={index + 1} />
-          <PlayerName player={player} isWeekDecided={isDecided} />
+          <PlayerName player={player} />
           <td>{player.tiebreaker.pick ?? "N/A"}</td>
           <td>{player.tiebreaker.distance ?? "N/A"}</td>
           <td>{player.score.college}</td>

--- a/src/context/AppDataContext.tsx
+++ b/src/context/AppDataContext.tsx
@@ -10,7 +10,7 @@ import { useLocation } from "react-router";
 import useLeagueWeeks from "../hooks/useLeagueWeeks";
 import usePlayerScores from "../hooks/usePlayerScores";
 import { WeekInfo } from "../types/League";
-import isWeekSettled from "../utils/scoring/isWeekDecided";
+import isWeekDecided from "../utils/scoring/isWeekDecided";
 
 type AppData = ReturnType<typeof useLeagueWeeks> &
   ReturnType<typeof usePlayerScores> & {
@@ -66,8 +66,8 @@ export function AppDataContextProvider({
   );
 
   const { scores } = playerScores;
-  const isWeekDecided = useMemo(
-    () => scores != null && isWeekSettled(scores),
+  const weekDecided = useMemo(
+    () => scores != null && isWeekDecided(scores),
     [scores],
   );
 
@@ -78,7 +78,7 @@ export function AppDataContextProvider({
 
   return (
     <AppDataContext.Provider value={value}>
-      <WeekDecidedContext.Provider value={isWeekDecided}>
+      <WeekDecidedContext.Provider value={weekDecided}>
         {children}
       </WeekDecidedContext.Provider>
     </AppDataContext.Provider>

--- a/src/context/AppDataContext.tsx
+++ b/src/context/AppDataContext.tsx
@@ -20,11 +20,20 @@ type AppData = ReturnType<typeof useLeagueWeeks> &
      * reference, so a rebuilt one would leave it unable to show a selection.
      */
     findWeek: (value: number) => WeekInfo | undefined;
-    /** Whether the week on screen is over, so whoever is left standing has won. */
-    isWeekDecided: boolean;
   };
 
 const AppDataContext = createContext<AppData | undefined>(undefined);
+
+/**
+ * Whether the week on screen is over, so whoever is left standing has won.
+ *
+ * Its own context rather than a field on `AppData`, because every player cell
+ * reads it. On `AppData` they would each re-render on every loading flag the app
+ * data carries, which is the same reason the toast list and its actions are
+ * split. False with no provider above, so a table can still be rendered on its
+ * own with scores handed straight to it.
+ */
+const WeekDecidedContext = createContext(false);
 
 function weekFromPath(pathname: string): number | undefined {
   const match = /^\/week\/(\d+)/.exec(pathname);
@@ -63,12 +72,16 @@ export function AppDataContextProvider({
   );
 
   const value = useMemo(
-    () => ({ ...leagueWeeks, ...playerScores, findWeek, isWeekDecided }),
-    [leagueWeeks, playerScores, findWeek, isWeekDecided],
+    () => ({ ...leagueWeeks, ...playerScores, findWeek }),
+    [leagueWeeks, playerScores, findWeek],
   );
 
   return (
-    <AppDataContext.Provider value={value}>{children}</AppDataContext.Provider>
+    <AppDataContext.Provider value={value}>
+      <WeekDecidedContext.Provider value={isWeekDecided}>
+        {children}
+      </WeekDecidedContext.Provider>
+    </AppDataContext.Provider>
   );
 }
 
@@ -80,10 +93,6 @@ export function useAppData(): AppData {
   return value;
 }
 
-/**
- * Whether the week on screen is over. False with no provider above, so a table
- * can still be rendered on its own with scores handed straight to it.
- */
 export function useIsWeekDecided(): boolean {
-  return useContext(AppDataContext)?.isWeekDecided ?? false;
+  return useContext(WeekDecidedContext);
 }

--- a/src/context/AppDataContext.tsx
+++ b/src/context/AppDataContext.tsx
@@ -10,6 +10,7 @@ import { useLocation } from "react-router";
 import useLeagueWeeks from "../hooks/useLeagueWeeks";
 import usePlayerScores from "../hooks/usePlayerScores";
 import { WeekInfo } from "../types/League";
+import isWeekSettled from "../utils/scoring/isWeekDecided";
 
 type AppData = ReturnType<typeof useLeagueWeeks> &
   ReturnType<typeof usePlayerScores> & {
@@ -19,6 +20,8 @@ type AppData = ReturnType<typeof useLeagueWeeks> &
      * reference, so a rebuilt one would leave it unable to show a selection.
      */
     findWeek: (value: number) => WeekInfo | undefined;
+    /** Whether the week on screen is over, so whoever is left standing has won. */
+    isWeekDecided: boolean;
   };
 
 const AppDataContext = createContext<AppData | undefined>(undefined);
@@ -53,9 +56,15 @@ export function AppDataContextProvider({
     [weeks],
   );
 
+  const { scores } = playerScores;
+  const isWeekDecided = useMemo(
+    () => scores != null && isWeekSettled(scores),
+    [scores],
+  );
+
   const value = useMemo(
-    () => ({ ...leagueWeeks, ...playerScores, findWeek }),
-    [leagueWeeks, playerScores, findWeek],
+    () => ({ ...leagueWeeks, ...playerScores, findWeek, isWeekDecided }),
+    [leagueWeeks, playerScores, findWeek, isWeekDecided],
   );
 
   return (
@@ -69,4 +78,12 @@ export function useAppData(): AppData {
     throw new Error("useAppData needs an AppDataContextProvider above it");
   }
   return value;
+}
+
+/**
+ * Whether the week on screen is over. False with no provider above, so a table
+ * can still be rendered on its own with scores handed straight to it.
+ */
+export function useIsWeekDecided(): boolean {
+  return useContext(AppDataContext)?.isWeekDecided ?? false;
 }

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -11,4 +11,6 @@ entry point the app calls; everything else is a step it sequences.
 - `getTiebreakerScore`: the Monday night game's real total, once it is final
 - `scorePlayers`: per-player totals, sorted
 - `comparePlayerScores`: the rank order and every tiebreaker tier
+- `isWeekDecided`: whether every game and the tiebreaker are settled, which is when
+  whoever the knockouts left standing has won
 - `applyKnockouts`: who can still win, and why not

--- a/src/utils/scoring/isWeekDecided.test.ts
+++ b/src/utils/scoring/isWeekDecided.test.ts
@@ -42,15 +42,37 @@ describe("isWeekDecided", () => {
   it("holds off while a game is still to finish", () => {
     expect(
       isWeekDecided(
-        week([player("Alice", ["yes"]), player("Bob", ["incomplete"])], 41),
+        week(
+          [
+            player("Alice", ["yes", "incomplete"]),
+            player("Bob", ["no", "incomplete"]),
+          ],
+          41,
+        ),
       ),
     ).toBe(false);
   });
 
-  it("holds off when a pick could not be scored", () => {
-    expect(isWeekDecided(week([player("Alice", ["yes", "error"])], 41))).toBe(
-      false,
-    );
+  it("holds off when a game could not be scored for anyone", () => {
+    expect(
+      isWeekDecided(
+        week(
+          [player("Alice", ["yes", "error"]), player("Bob", ["no", "error"])],
+          41,
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("calls a week decided when one player alone left a pick blank", () => {
+    expect(
+      isWeekDecided(
+        week(
+          [player("Alice", ["yes", "no"]), player("Bob", ["yes", "error"])],
+          41,
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("holds off until the Monday night tiebreaker is settled", () => {

--- a/src/utils/scoring/isWeekDecided.test.ts
+++ b/src/utils/scoring/isWeekDecided.test.ts
@@ -1,0 +1,59 @@
+import {
+  PickResult,
+  PlayerScore,
+  RakMadnessScores,
+  Status,
+} from "../../types/RakMadnessScores";
+import isWeekDecided from "./isWeekDecided";
+
+function pickResult(status: Status): PickResult {
+  return {
+    pick: "TCU -13.5",
+    status,
+    explanation: { header: "Final Score", message: "" },
+  };
+}
+
+function player(name: string, statuses: Array<Status>): PlayerScore {
+  return {
+    name,
+    score: { total: 10, college: 5, pro: 5, proAgainstTheSpread: 5 },
+    tiebreaker: { pick: 40, distance: 1 },
+    college: statuses.map(pickResult),
+    pro: statuses.map(pickResult),
+    status: { hasNoPicks: false, isKnockedOut: false },
+  };
+}
+
+function week(
+  players: Array<PlayerScore>,
+  tiebreaker?: number,
+): RakMadnessScores {
+  return { tiebreaker, scores: players };
+}
+
+describe("isWeekDecided", () => {
+  it("calls a week decided once every pick is scored", () => {
+    expect(isWeekDecided(week([player("Alice", ["yes", "no"])], 41))).toBe(
+      true,
+    );
+  });
+
+  it("holds off while a game is still to finish", () => {
+    expect(
+      isWeekDecided(
+        week([player("Alice", ["yes"]), player("Bob", ["incomplete"])], 41),
+      ),
+    ).toBe(false);
+  });
+
+  it("holds off when a pick could not be scored", () => {
+    expect(isWeekDecided(week([player("Alice", ["yes", "error"])], 41))).toBe(
+      false,
+    );
+  });
+
+  it("holds off until the Monday night tiebreaker is settled", () => {
+    expect(isWeekDecided(week([player("Alice", ["yes"])]))).toBe(false);
+  });
+});

--- a/src/utils/scoring/isWeekDecided.ts
+++ b/src/utils/scoring/isWeekDecided.ts
@@ -1,20 +1,43 @@
-import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
+import {
+  PlayerScore,
+  RakMadnessScores,
+  Status,
+} from "../../types/RakMadnessScores";
+
+const LEAGUES = ["college", "pro"] as const;
+
+function isSettled(status: Status): boolean {
+  return status === "yes" || status === "no";
+}
 
 /**
- * Whether the week is over: every game scored cleanly, and the Monday night total
- * that settles the tiebreaker is in.
+ * Whether the week is over: every game settled, and the Monday night total that
+ * decides the tiebreaker is in.
  *
- * Whoever the knockouts left standing at that point has won, so nothing here
- * looks at a score. A game that could not be scored leaves the week undecided,
- * because the pick nobody could settle might be the one that decides it.
+ * Read a column at a time rather than a row at a time, because a row cannot tell
+ * the two kinds of unscoreable pick apart. A game the workbook described two ways,
+ * or one nobody has a result for, comes back unscoreable on every row and leaves
+ * the week open. A blank cell comes back the same way on one row alone, and one
+ * player's blank says nothing about whether the game finished.
+ *
+ * Whoever the knockouts left standing once the week is over has won it, so nothing
+ * here looks at a score.
  */
 export default function isWeekDecided(scores: RakMadnessScores): boolean {
   if (scores.tiebreaker == null) {
     return false;
   }
-  return scores.scores.every((player: PlayerScore) =>
-    [...player.college, ...player.pro].every(
-      (result) => result.status === "yes" || result.status === "no",
+  const [firstPlayer] = scores.scores;
+  if (firstPlayer == null) {
+    return false;
+  }
+  // Every row holds one pick per game in the same order, so the first row's
+  // length is the week's game count.
+  return LEAGUES.every((league) =>
+    firstPlayer[league].every((_, game) =>
+      scores.scores.some((player: PlayerScore) =>
+        isSettled(player[league][game].status),
+      ),
     ),
   );
 }

--- a/src/utils/scoring/isWeekDecided.ts
+++ b/src/utils/scoring/isWeekDecided.ts
@@ -1,0 +1,20 @@
+import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
+
+/**
+ * Whether the week is over: every game scored cleanly, and the Monday night total
+ * that settles the tiebreaker is in.
+ *
+ * Whoever the knockouts left standing at that point has won, so nothing here
+ * looks at a score. A game that could not be scored leaves the week undecided,
+ * because the pick nobody could settle might be the one that decides it.
+ */
+export default function isWeekDecided(scores: RakMadnessScores): boolean {
+  if (scores.tiebreaker == null) {
+    return false;
+  }
+  return scores.scores.every((player: PlayerScore) =>
+    [...player.college, ...player.pro].every(
+      (result) => result.status === "yes" || result.status === "no",
+    ),
+  );
+}


### PR DESCRIPTION
## Changes

* Call the app The Rakulator, in the home button, the browser tab, the README, and the installed-app name in `manifest.json`.
* Give the navbar buttons a 44px touch target on a phone, paid for out of the navbar's own padding. Trim the side padding on a larger screen too.
* Cut a player name short with an ellipsis past 20 characters instead of wrapping it. A wrapped name made its row taller than every other row, and the whole name is still in the toast the cell opens.
* Mark an eliminated player with a skull, and crown whoever the knockouts left standing once the week is over. A week is over when every game is settled and the Monday night tiebreaker is in, which `isWeekDecided` works out from the picks alone.
* Give the picks view a fact-check icon in place of the info glyph.
* Fade the tiled background in once its image loads, rather than flashing it in at full strength. Only on the first page load: the fade would otherwise start over on every move between routes.
* Show the footer links at full opacity.
* Size the loading wireframe from the table it stands in for. It was laid out in percentages, so on a phone its columns stretched across the screen instead of running off it the way a real table does.
* Leave the wireframe's container scrollable and refuse the pointer instead, so it asks for the same scrollbars the real table will. `scrollbar-gutter: stable` reserves the vertical bar only, so the horizontal one used to arrive with the real table and take a band out of the page.

## How the wireframe is sized

Every cell carries a stand-in string in `data-skeleton-text`, which the stylesheet
draws invisibly, and the table's own `max-content` sizing measures it. No width is
written down, so the wireframe matches at any font size. The strings describe a
middling week, week 5's: six college games, thirteen pro, sixty-one players.

Every other measurement the wireframe has to reproduce is a custom property on
`.table`: cell padding, cell borders, and the room the icon beside a player's name
takes. Change one on the real table and the wireframe follows.

Measured against real tables of the same shape, with classic scrollbars forced on,
nothing moves across the swap at either width: table width, column widths, header
height, first row position, and both scrollbar gutters all agree.

`table__pick-header`, `table__center`, and the pick cells' `nowrap` moved from
`PicksTable.scss` to `Table.scss`, because they size a game's column and the
wireframe needs them too. The touch feedback a pick and a player name both had
their own copy of moved there as well. The pick colors stayed behind.

## Deciding the week

A blank cell and a game nobody can score both come back as an error on the pick, so
reading one player's row cannot tell them apart. `isWeekDecided` reads a column at a
time instead. A game settles as soon as any row scored it, so one player's blank no
longer holds the week open, while a game the workbook contradicted itself about, or
one with no result, still does.

## Renders

`isWeekDecided` has its own context rather than a field on the app data, because
every player cell reads it and the app data changes on each loading flag a refresh
sets. Same reason the toast list and its actions are split. The wireframe is
memoized: its route re-renders on every one of those flags, and each one rebuilt
close to fifteen hundred cells that never change.

## Notes

* Below 360px the navbar overflows sideways by 26px, the cost of the bigger touch targets. Every phone in use is 360px or wider.
* `package.json` still carries `productName: Rak Madness Scoreboard`, and the npm name and R2 bucket are still `rak-madness-calculator`. Those are identifiers, not display text.
