### PR TITLE
style(table): read the table a point larger on a phone

### DIFF
--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -161,7 +161,11 @@
 
 @include narrow-screen {
   .table {
-    font-size: 0.8rem;
+    // 14px against the 16px a wide screen gets. A point smaller than this was hard
+    // to read on a phone.
+    font-size: 0.875rem;
     --rak-table-row-height: 28px;
+    // Grown with the text, so a knockout still reads at a glance beside a name.
+    --rak-player-icon-size: 18px;
   }
 }


### PR DESCRIPTION
## What

The narrow-screen table font goes from 0.8rem to 0.875rem, 12.8px to 14px. The
status icon beside a player's name goes from 16px to 18px, so it grows with the
text.

## Why

12.8px was hard to read on a phone.

## Changes

* Both values are the narrow-screen overrides on `.table`, so the wireframe picks
  them up through the same custom properties and still measures like the table it
  stands in for.
* Row height stays 28px. A 14px line plus the cell's padding comes to 25px, so the
  taller text still fits, and `height` on a cell is a minimum either way.

## Verification

Nothing automated: Vitest runs with `css: false`. Worth a look at a phone width
that the player column and the pick columns still hold their names on one line.