### PR TITLE
style(table): stand the status icon as tall as the name beside it

### DIFF
--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -24,7 +24,11 @@
   --rak-table-no-border: 0 solid var(--rak-primary-800);
   // The status icon beside a player's name, in `PlayerName.scss`. Sized here
   // because the wireframe has to leave the same room without drawing one.
-  --rak-player-icon-size: 16px;
+  //
+  // One line of the cell's own text, so the icon stands as tall as the name it sits
+  // beside at every screen size. Resolved where it is used rather than here, which
+  // is what makes it follow the narrow-screen font below.
+  --rak-player-icon-size: 1lh;
   --rak-player-icon-gap: 8px;
 
   .table__header {


### PR DESCRIPTION
## What

`--rak-player-icon-size` becomes `1lh`, one line of the cell's own text, in place
of a flat 16px.

## Why

At 16px the icon was shorter than the text on a wide screen, where a line is 24px,
and taller than it on a phone, where a line is 19.2px.

## Changes

* Resolved where it is used, not where it is declared, so it follows the
  narrow-screen font on its own and needs no second value per breakpoint.
* `SkeletonTable` pads its player column by this plus the gap, so the wireframe
  leaves the same room without drawing an icon.
* Rows do not grow. A 24px icon plus the cell's 4px of padding is 28px against a
  32px row, and 23.2px against the narrow 28px row.

## Verification

Measured in Chrome against a standalone copy of the cell: the icon comes out 24px
at a 16px font and 19.19px at 12.8px, matching each line box. `lh` needs Chrome
120, Safari 16.4, or Firefox 120, and `Table.scss` already sizes its header with
it.