### PR TITLE
feat(results): add a path to victory calculator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,18 @@
 
 Auto-scoring web app for the Rak Madness football pool. Vite + React 19 + TypeScript, react-router, Base UI, SCSS. Vitest for tests, ESLint flat config. Scores an uploaded weekly picks spreadsheet against ESPN game results, exports XLSX. Home page at `/`, a week's results at `/:season/:week/scoreboard` and `/:season/:week/picks`, and `/scoreboard` and `/picks` redirect to the latest week worth showing. Deployed to Cloudflare Pages (`wrangler`); `functions/api/picks/index.ts` lists the seasons that have picks, and `functions/api/picks/[year]/[week].ts` serves one season's week.
 
+`public/` holds the static assets Vite copies to the build root, referenced by
+absolute path: `manifest.json` PWA metadata, the `favicon.ico` and `logo*.png`
+icons, and `robots.txt`, which disallows every crawler. The HTML shell is
+`index.html` at the repo root, not in there. It carries no `CLAUDE.md` of its own,
+because everything in it is published, and a note to Claude is not for the web.
+
 ## Subdirectories
 
-- [`public/`](public/CLAUDE.md) — static assets for the build root
 - [`src/`](src/CLAUDE.md) — application source
 
 ## Maintaining this tree
 
 Navigation index. Changed a dir: update its CLAUDE.md summary and the parent's
 link. New meaningful dir: add a CLAUDE.md, link it. Pointer <= 70 chars.
+`public/` is the exception: it is served as-is, so it is described above instead.

--- a/public/CLAUDE.md
+++ b/public/CLAUDE.md
@@ -1,5 +1,0 @@
-# public
-
-Vite copies these to the build root, referenced by absolute path: manifest.json PWA metadata,
-favicon.ico/logo192.png/logo512.png icons, robots.txt (disallows every crawler).
-The HTML shell lives at the repo root (`index.html`), not here.

--- a/src/App.picks.test.tsx
+++ b/src/App.picks.test.tsx
@@ -97,7 +97,30 @@ describe("the app, first load", () => {
     expect(screen.getByRole("combobox", { name: "Season" })).toHaveTextContent(
       `${SEASON - 1} Season`,
     );
-    expect(getLeagueInfoMock).not.toHaveBeenCalledWith(League.PRO, undefined);
+    // The season running now is looked up, so it can be offered below, but the
+    // calendar that gets fetched and scored is the one opened on.
+    expect(getLeagueInfoMock).toHaveBeenCalledWith(League.PRO, SEASON - 1);
+  });
+
+  it("offers the season running now even before it has any picks", async () => {
+    // ESPN answers with whichever season was asked for, and with the one running
+    // now when asked for none. That season has no picks in this list.
+    getLeagueInfoMock.mockImplementation(async (_league, season) => ({
+      ...leagueInfo,
+      season: season ?? SEASON,
+    }));
+    global.fetch = routedFetch(notFoundResponse, [SEASON - 1, SEASON - 2]);
+    const user = await mountLoadedApp();
+
+    await user.click(screen.getByRole("combobox", { name: "Season" }));
+    const options = (await screen.findAllByRole("option")).map(
+      (option) => option.textContent,
+    );
+    expect(options).toEqual([
+      `${SEASON} Season`,
+      `${SEASON - 1} Season`,
+      `${SEASON - 2} Season`,
+    ]);
   });
 
   it("offers the current season alone when the list cannot be had", async () => {

--- a/src/App.routes.test.tsx
+++ b/src/App.routes.test.tsx
@@ -1,5 +1,5 @@
 import { MockedFunction } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { League, LeagueInfo } from "./types/League";
 
 vi.mock("./utils/getLeagueInfo");
@@ -41,12 +41,17 @@ describe("the app, week routes", () => {
     expect(await screen.findByText("MNF Points Pick")).toBeInTheDocument();
   });
 
+  // Read inside the table, because the navbar's path to victory button carries
+  // the same trophy while a week that is still being played collapses it away.
+  const crown = () =>
+    within(screen.getByRole("table")).queryByTestId("EmojiEventsIcon");
+
   it("crowns a player still standing at the end of the week", async () => {
     fetchMock.mockResolvedValue(spreadsheetResponse());
     await mountApp(`/${SEASON}/${CURRENT_WEEK}/scoreboard`);
 
     await screen.findByText("MNF Points Pick");
-    expect(screen.getByTestId("EmojiEventsIcon")).toBeInTheDocument();
+    expect(crown()).toBeInTheDocument();
   });
 
   it("holds the crown back while a game is still to finish", async () => {
@@ -72,7 +77,7 @@ describe("the app, week routes", () => {
     expect(
       screen.getByTestId("SentimentVerySatisfiedIcon"),
     ).toBeInTheDocument();
-    expect(screen.queryByTestId("EmojiEventsIcon")).not.toBeInTheDocument();
+    expect(crown()).not.toBeInTheDocument();
   });
 
   it("shows a wireframe table until the results are ready", async () => {
@@ -85,12 +90,13 @@ describe("the app, week routes", () => {
     expect(document.querySelector(".table.--skeleton")).not.toBeInTheDocument();
   });
 
-  it("shows the view and refresh buttons disabled while the week loads", async () => {
+  it("shows every navbar button disabled while the week loads", async () => {
     fetchMock.mockResolvedValue(spreadsheetResponse());
     mountApp(`/${SEASON}/${CURRENT_WEEK}/scoreboard`);
 
+    // Scoreboard, picks, refresh, and path to victory.
     const loading = scoresHeaderButtons();
-    expect(loading).toHaveLength(3);
+    expect(loading).toHaveLength(4);
     loading.forEach((button) => expect(button).toBeDisabled());
 
     await screen.findByText("MNF Points Pick");

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -7,6 +7,6 @@
 - [`components/`](components/CLAUDE.md) — React UI, layout, routes
 - [`context/`](context/CLAUDE.md) — app data and toast providers
 - [`hooks/`](hooks/CLAUDE.md) — picks, scoring, export, route guard
-- [`styles/`](styles/CLAUDE.md) — Sass mixins: two breakpoints
+- [`styles/`](styles/CLAUDE.md) — Sass mixins: breakpoints, listbox shape
 - [`types/`](types/CLAUDE.md) — ESPN, league, and scoring types
 - [`utils/`](utils/CLAUDE.md) — scoring, ESPN, export, picks cache

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -11,6 +11,7 @@ Route components live in `home/` and `results/`; the routes themselves are in
 - [`home/`](home/CLAUDE.md) — home route: pickers, upload, export
 - [`icon/`](icon/CLAUDE.md) — SVG icons inlined from Material Design
 - [`navbar/`](navbar/CLAUDE.md) — top nav bar and view switch
+- [`pathToVictory/`](pathToVictory/CLAUDE.md) — what a player still has to win
 - [`results/`](results/CLAUDE.md) — results routes, layout, redirect
 - [`table/`](table/CLAUDE.md) — shared frame and the results tables
 - [`toaster/`](toaster/CLAUDE.md) — toast notification renderer

--- a/src/components/button/Button.scss
+++ b/src/components/button/Button.scss
@@ -80,6 +80,20 @@
         background-color: var(--rak-danger-700);
       }
     }
+
+    // The only solid color light enough that white on it fails to read, so it
+    // overrides the fill and the text both.
+    &.--gold {
+      background-color: var(--rak-gold-500);
+      color: var(--rak-primary-800);
+
+      &:hover {
+        background-color: var(--rak-gold-600);
+      }
+      &:active {
+        background-color: var(--rak-gold-700);
+      }
+    }
   }
 
   // Soft buttons inherit the surrounding tint, which is how the toast close

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 import getClasses from "../../utils/getClasses";
 import "./Button.scss";
 
-export type ButtonColor = "primary" | "success" | "danger";
+export type ButtonColor = "primary" | "success" | "danger" | "gold";
 
 export default function Button({
   children,

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -15,6 +15,7 @@ export default function Button({
   disabled = false,
   className = "",
   ariaLabel,
+  ariaExpanded,
 }: {
   children: ReactNode;
   onClick: () => void;
@@ -26,6 +27,8 @@ export default function Button({
   className?: string;
   /** The accessible name. Required of a button whose content is an icon alone. */
   ariaLabel?: string;
+  /** Set where the button opens and closes something below it. */
+  ariaExpanded?: boolean;
 }) {
   const modifiers = getClasses({
     [`--${variant}`]: true,
@@ -37,6 +40,7 @@ export default function Button({
     <BaseButton
       type="button"
       aria-label={ariaLabel}
+      aria-expanded={ariaExpanded}
       className={`button ${modifiers} ${className}`}
       disabled={disabled}
       onClick={onClick}

--- a/src/components/button/CLAUDE.md
+++ b/src/components/button/CLAUDE.md
@@ -2,7 +2,10 @@
 
 `Button`: the app's only button, icon-only buttons included. Wraps Base UI's
 unstyled `Button` and adds the `--solid`/`--soft` variants,
-`--primary`/`--success`/`--danger` colors, `--sm`, and `--icon`.
+`--primary`/`--success`/`--danger`/`--gold` colors, `--sm`, and `--icon`.
+
+`--gold` is the only solid fill light enough that white on it fails to read, so it
+sets its own text color rather than taking the one `--solid` gives the rest.
 
 Every color rule is scoped to `:not(:disabled)`. The variant selectors are more
 specific than `&:disabled`, so without that scoping a disabled button keeps its

--- a/src/components/home/HomePage.scss
+++ b/src/components/home/HomePage.scss
@@ -1,3 +1,5 @@
+@use "../../styles/listbox" as *;
+
 @keyframes slide {
   from {
     background-position: right, center;
@@ -50,35 +52,13 @@
 }
 
 .select__popup {
-  box-sizing: border-box;
-  min-width: var(--anchor-width);
+  @include listbox-popup;
+
   max-height: var(--available-height);
-  overflow-y: auto;
-  padding: 6px 0;
-  background-color: var(--rak-on-solid);
-  box-shadow: var(--rak-shadow-md);
 }
 
 .select__item {
-  display: flex;
-  align-items: center;
-  min-height: 36px;
-  padding: 4px 12px;
-  cursor: pointer;
-
-  &[data-highlighted] {
-    background-color: var(--rak-level1);
-  }
-
-  &[data-selected] {
-    background-color: var(--rak-neutral-200);
-  }
-
-  // A rule between rows rather than around them, so a long list reads down
-  // without a line closing the popup off from its own edge.
-  & + & {
-    border-top: 1px solid var(--rak-neutral-200);
-  }
+  @include listbox-item;
 }
 
 .home__controls {

--- a/src/components/home/HomePage.scss
+++ b/src/components/home/HomePage.scss
@@ -9,8 +9,6 @@
 // Base UI ships the select unstyled, so these rules carry its whole look.
 .select__trigger,
 .select__popup {
-  border: 1px solid var(--rak-border);
-  border-radius: var(--rak-radius-sm);
   color: var(--rak-text-secondary);
   font-size: 1rem;
 }
@@ -21,6 +19,8 @@
   justify-content: space-between;
   gap: 8px;
   padding: 3px 12px;
+  border: 1px solid var(--rak-border);
+  border-radius: var(--rak-radius-sm);
   background-color: var(--rak-surface);
   box-shadow: var(--rak-shadow-xs);
   font-family: inherit;

--- a/src/components/home/HomePage.scss
+++ b/src/components/home/HomePage.scss
@@ -73,6 +73,12 @@
   &[data-selected] {
     background-color: var(--rak-neutral-200);
   }
+
+  // A rule between rows rather than around them, so a long list reads down
+  // without a line closing the popup off from its own edge.
+  & + & {
+    border-top: 1px solid var(--rak-neutral-200);
+  }
 }
 
 .home__controls {

--- a/src/components/navbar/CLAUDE.md
+++ b/src/components/navbar/CLAUDE.md
@@ -3,11 +3,17 @@
 `Navbar`: `<header>` with `left`/`right` `ReactNode` slots, solid primary fill.
 Owns the padding and the phone-sized touch target of every button it contains,
 trading its own padding for theirs on a narrow screen.
-`ScoresNavbar`: the scoreboard/picks switch plus the refresh button, for the
-results routes. Clearing `canRefresh` collapses the refresh button and its divider,
-since rescoring cannot change a finished week. They fade and narrow out over
+`ScoresNavbar`: the scoreboard/picks switch plus the buttons a week still being
+played gets, for the results routes. Clearing `isWeekLive` collapses the refresh
+button, the gold path to victory button, and the divider before them, since
+rescoring cannot change a finished week and nobody has a route left to work out.
+They share one collapsing wrapper, fade and narrow out over
 `COLLAPSE_DURATION_MS`, then unmount, and cancel `Navbar`'s `--navbar-gap` with a
 negative margin so no gap is left where they were.
+
+The path button carries `EmojiEventsIcon`, the same trophy `PlayerName` crowns a
+winner with. They never share a screen except during that collapse, since one is
+for a week still being played and the other for a week that is over.
 
 ## Subdirectories
 

--- a/src/components/navbar/Navbar.scss
+++ b/src/components/navbar/Navbar.scss
@@ -26,7 +26,7 @@
     gap: 4px;
     // Tighter than a desktop's, because on a phone the room is better spent on
     // the buttons than around them.
-    padding: 6px 8px;
+    padding: 6px;
   }
 }
 

--- a/src/components/navbar/ScoresNavbar.scss
+++ b/src/components/navbar/ScoresNavbar.scss
@@ -43,6 +43,19 @@
   }
 }
 
+// Same idea, its own rule because the one above would repaint it in the navbar's
+// own blue and lose the accent that tells it apart from the buttons beside it.
+.button.--solid.home__scores-header-paths:disabled {
+  background-color: var(--rak-gold-500);
+  color: var(--rak-primary-800);
+}
+
+// The divider carries the space on its own side, so this is the only gap left to
+// set between the two buttons past it.
+.home__scores-header-paths {
+  margin-inline-start: 6px;
+}
+
 .home__scores-header-divider {
   width: 2px;
   height: 1.5rem;
@@ -50,11 +63,12 @@
   background-color: var(--rak-on-solid);
 }
 
-// The refresh button and its divider, collapsed together once the week is decided.
-// A grid column from `1fr` to `0fr` narrows them, because they measure whatever
-// their padding and the icon come to, and `auto` cannot be interpolated.
+// What a week still being played gets: the refresh and path to victory buttons,
+// and the divider before them, collapsed together once the week is decided. A grid
+// column from `1fr` to `0fr` narrows them, because they measure whatever their
+// padding and their icons come to, and `auto` cannot be interpolated.
 // `--collapse-duration` comes from `ScoresNavbar`, which unmounts this after it.
-.home__scores-header-refresh {
+.home__scores-header-live {
   display: grid;
   grid-template-columns: 1fr;
   transition-property: grid-template-columns, margin-inline-start, opacity;
@@ -69,15 +83,15 @@
     margin-inline-start: calc(-1 * var(--navbar-gap));
 
     // Only while collapsing. Expanded, this would clip the button's focus outline.
-    .home__scores-header-refresh-content {
+    .home__scores-header-live-content {
       overflow: hidden;
     }
   }
 }
 
-.home__scores-header-refresh-content {
+.home__scores-header-live-content {
   display: flex;
   align-items: center;
-  // So the column can narrow past what the divider and button measure.
+  // So the column can narrow past what the divider and buttons measure.
   min-width: 0;
 }

--- a/src/components/navbar/ScoresNavbar.test.tsx
+++ b/src/components/navbar/ScoresNavbar.test.tsx
@@ -6,11 +6,12 @@ const props = {
   view: "Scoreboard" as const,
   onViewChange: () => undefined,
   onRefresh: () => undefined,
+  onShowPaths: () => undefined,
   isRefreshing: false,
 };
 
-function refreshWrapper() {
-  return document.querySelector(".home__scores-header-refresh");
+function liveWrapper() {
+  return document.querySelector(".home__scores-header-live");
 }
 
 describe("ScoresNavbar", () => {
@@ -22,45 +23,51 @@ describe("ScoresNavbar", () => {
     vi.useRealTimers();
   });
 
-  it("offers refresh for a week that is still open", () => {
-    render(<ScoresNavbar {...props} canRefresh />);
+  it("offers refresh and a path to victory for a week that is still open", () => {
+    render(<ScoresNavbar {...props} isWeekLive />);
 
     expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
-    expect(refreshWrapper()).not.toHaveClass("--collapsed");
+    expect(
+      screen.getByRole("button", { name: "Path to Victory" }),
+    ).toBeInTheDocument();
+    expect(liveWrapper()).not.toHaveClass("--collapsed");
   });
 
-  it("marks refresh collapsed, and keeps it mounted, while it animates out", () => {
-    const { rerender } = render(<ScoresNavbar {...props} canRefresh />);
+  it("marks them collapsed, and keeps them mounted, while they animate out", () => {
+    const { rerender } = render(<ScoresNavbar {...props} isWeekLive />);
 
-    rerender(<ScoresNavbar {...props} canRefresh={false} />);
+    rerender(<ScoresNavbar {...props} isWeekLive={false} />);
 
     // Still painted, so the transition has something to run on, but out of reach of
     // pointer, keyboard, and screen reader.
-    expect(refreshWrapper()).toHaveClass("--collapsed");
-    expect(refreshWrapper()).toHaveAttribute("inert");
+    expect(liveWrapper()).toHaveClass("--collapsed");
+    expect(liveWrapper()).toHaveAttribute("inert");
     act(() => {
       vi.advanceTimersByTime(COLLAPSE_DURATION_MS - 1);
     });
-    expect(refreshWrapper()).toBeInTheDocument();
+    expect(liveWrapper()).toBeInTheDocument();
   });
 
-  it("drops refresh and its divider once the collapse has run", () => {
-    const { rerender } = render(<ScoresNavbar {...props} canRefresh />);
+  it("drops them and their divider once the collapse has run", () => {
+    const { rerender } = render(<ScoresNavbar {...props} isWeekLive />);
 
-    rerender(<ScoresNavbar {...props} canRefresh={false} />);
+    rerender(<ScoresNavbar {...props} isWeekLive={false} />);
     act(() => {
       vi.advanceTimersByTime(COLLAPSE_DURATION_MS);
     });
 
-    expect(refreshWrapper()).not.toBeInTheDocument();
+    expect(liveWrapper()).not.toBeInTheDocument();
     expect(
       document.querySelector(".home__scores-header-divider"),
     ).not.toBeInTheDocument();
   });
 
-  it("never renders refresh for a week that arrives decided", () => {
-    render(<ScoresNavbar {...props} canRefresh={false} />);
+  it("never renders them for a week that arrives decided", () => {
+    render(<ScoresNavbar {...props} isWeekLive={false} />);
 
-    expect(refreshWrapper()).not.toBeInTheDocument();
+    expect(liveWrapper()).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Path to Victory" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/navbar/ScoresNavbar.tsx
+++ b/src/components/navbar/ScoresNavbar.tsx
@@ -1,5 +1,10 @@
 import { CSSProperties, useEffect, useState } from "react";
-import { FactCheckIcon, LeaderboardIcon, RefreshIcon } from "../icon/Icon";
+import {
+  EmojiEventsIcon,
+  FactCheckIcon,
+  LeaderboardIcon,
+  RefreshIcon,
+} from "../icon/Icon";
 import getClasses from "../../utils/getClasses";
 import Button from "../button/Button";
 import "./ScoresNavbar.scss";
@@ -7,43 +12,45 @@ import "./ScoresNavbar.scss";
 export type ScoresView = "Scoreboard" | "Picks";
 
 /**
- * How long the refresh button takes to fade and narrow away. Held here because the
- * button has to stay mounted for exactly that long. The stylesheet reads it back as
+ * How long the live-week buttons take to fade and narrow away. Held here because
+ * they have to stay mounted for exactly that long. The stylesheet reads it back as
  * `--collapse-duration`, so the two cannot drift apart.
  */
 export const COLLAPSE_DURATION_MS = 300;
 
-/** The scoreboard/picks switch and the refresh button. */
+/** The scoreboard/picks switch, and the buttons a week still being played gets. */
 export default function ScoresNavbar({
   view,
   onViewChange,
   onRefresh,
+  onShowPaths,
   isRefreshing,
   disabled = false,
-  canRefresh = true,
+  isWeekLive = true,
 }: {
   view: ScoresView;
   onViewChange: (view: ScoresView) => void;
   onRefresh: () => void;
+  onShowPaths: () => void;
   isRefreshing: boolean;
   /** Set while a week is still loading, so the navbar keeps its shape. */
   disabled?: boolean;
-  /** Cleared once the week is over, when rescoring cannot change anything. */
-  canRefresh?: boolean;
+  /**
+   * Cleared once the week is over, when rescoring cannot change anything and
+   * nobody has a path to victory left to work out.
+   */
+  isWeekLive?: boolean;
 }) {
-  // A week arrives loading, so the button is usually on screen by the time it turns
-  // out to be decided. Kept mounted for the length of the collapse so it animates
-  // out, and a week already known to be decided never renders it at all.
-  const [isRefreshMounted, setRefreshMounted] = useState(canRefresh);
-  if (canRefresh && !isRefreshMounted) setRefreshMounted(true);
+  // A week arrives loading, so these are usually on screen by the time it turns
+  // out to be decided. Kept mounted for the length of the collapse so they animate
+  // out, and a week already known to be decided never renders them at all.
+  const [isLiveMounted, setLiveMounted] = useState(isWeekLive);
+  if (isWeekLive && !isLiveMounted) setLiveMounted(true);
   useEffect(() => {
-    if (canRefresh || !isRefreshMounted) return;
-    const timer = setTimeout(
-      () => setRefreshMounted(false),
-      COLLAPSE_DURATION_MS,
-    );
+    if (isWeekLive || !isLiveMounted) return;
+    const timer = setTimeout(() => setLiveMounted(false), COLLAPSE_DURATION_MS);
     return () => clearTimeout(timer);
-  }, [canRefresh, isRefreshMounted]);
+  }, [isWeekLive, isLiveMounted]);
 
   return (
     <>
@@ -69,10 +76,10 @@ export default function ScoresNavbar({
         <FactCheckIcon />
         <span className="home__scores-header-label">Picks</span>
       </Button>
-      {isRefreshMounted && (
+      {isLiveMounted && (
         <div
-          className={`home__scores-header-refresh ${getClasses({
-            "--collapsed": !canRefresh,
+          className={`home__scores-header-live ${getClasses({
+            "--collapsed": !isWeekLive,
           })}`}
           style={
             {
@@ -81,9 +88,9 @@ export default function ScoresNavbar({
           }
           // On its way out it is still painted, so it has to stop being reachable
           // by pointer, keyboard, and screen reader on its own.
-          inert={!canRefresh}
+          inert={!isWeekLive}
         >
-          <div className="home__scores-header-refresh-content">
+          <div className="home__scores-header-live-content">
             <div className="home__scores-header-divider" />
             <Button
               ariaLabel="Refresh"
@@ -94,6 +101,15 @@ export default function ScoresNavbar({
               })}`}
             >
               <RefreshIcon />
+            </Button>
+            <Button
+              ariaLabel="Path to Victory"
+              color="gold"
+              disabled={disabled}
+              onClick={onShowPaths}
+              className="home__scores-header-button home__scores-header-paths"
+            >
+              <EmojiEventsIcon />
             </Button>
           </div>
         </div>

--- a/src/components/navbar/ScoresNavbar.tsx
+++ b/src/components/navbar/ScoresNavbar.tsx
@@ -26,7 +26,7 @@ export default function ScoresNavbar({
   onShowPaths,
   isRefreshing,
   disabled = false,
-  isWeekLive = true,
+  isWeekLive,
 }: {
   view: ScoresView;
   onViewChange: (view: ScoresView) => void;
@@ -39,7 +39,7 @@ export default function ScoresNavbar({
    * Cleared once the week is over, when rescoring cannot change anything and
    * nobody has a path to victory left to work out.
    */
-  isWeekLive?: boolean;
+  isWeekLive: boolean;
 }) {
   // A week arrives loading, so these are usually on screen by the time it turns
   // out to be decided. Kept mounted for the length of the collapse so they animate

--- a/src/components/pathToVictory/CLAUDE.md
+++ b/src/components/pathToVictory/CLAUDE.md
@@ -1,0 +1,25 @@
+# pathToVictory
+
+What a player still has to do to win a week that is being played, opened from the
+navbar's gold trophy button.
+
+`PathToVictoryDialog`: a Base UI dialog holding a Base UI combobox over
+`eligiblePlayers`, and `VictorySummary` under it. Only the players who can still win
+are offered, since a knocked out one has no route to show. The search behind it is
+thousands of scenarios, so it runs on the player chosen rather than on every render
+around them. One dialog serves both shapes: `PathToVictoryDialog.scss` centers it as a modal and
+stands it on the bottom edge as a sheet below `compact-screen`, replacing both ends
+of the transition rather than the resting rule, since the sheet cannot inherit a
+centered transform. State comes off Base UI's `[data-open]`, `[data-starting-style]`,
+and `[data-highlighted]`, the same way the home page's select is styled.
+
+`VictorySummary`: the must-win games, the pool the rest come from, the games out of
+the player's hands, and the Monday night sentence, plus the eliminated, clinched,
+and too-many-games states. It renders `PathsToVictory` and works nothing out itself,
+which is why every case it can show is testable without a dialog around it.
+
+One suite here mounts one dialog, on purpose. Base UI hangs its scroll lock, focus
+guards, and inert markers off the document while a dialog is open, and mounting a
+second one leaves the previous set behind, so every other case in a file that mounts
+several types into an input those leftovers have put out of reach. The app never
+does this: `ResultsFrame` holds one dialog and toggles `open` on it.

--- a/src/components/pathToVictory/CLAUDE.md
+++ b/src/components/pathToVictory/CLAUDE.md
@@ -15,8 +15,11 @@ and `[data-highlighted]`, the same way the home page's select is styled.
 
 `VictorySummary`: the must-win games, the pool the rest come from, the games out of
 the player's hands, and the Monday night sentence, plus the eliminated, clinched,
-and too-many-games states. It renders `PathsToVictory` and works nothing out itself,
-which is why every case it can show is testable without a dialog around it.
+and too-many-games states. Must-win leads, and how the player stands closes, since
+the games to back are what the sheet is opened for. A list of routes stands five
+deep and unfolds on a click, keyed on the player so a new one starts folded again.
+It renders `PathsToVictory` and works nothing out itself, which is why every case it
+can show is testable without a dialog around it.
 
 One suite here mounts one dialog, on purpose. Base UI hangs its scroll lock, focus
 guards, and inert markers off the document while a dialog is open, and mounting a

--- a/src/components/pathToVictory/CLAUDE.md
+++ b/src/components/pathToVictory/CLAUDE.md
@@ -6,19 +6,22 @@ gold trophy button.
 `PathToVictoryDialog`: a Base UI dialog over a Base UI combobox, with
 `VictorySummary` under it. `playersMatching` names a knocked out player only where
 the letters typed reach nobody still standing, disabled, in
-`--rak-knocked-out-text` with the same skull the table gives them. The search is thousands of scenarios, so it runs on the player chosen
-rather than on every render. Only the search holds still: everything under the rule below it scrolls.
-`PathToVictoryDialog.scss`
-centers the one dialog as a modal and stands it on the bottom edge as a sheet below
-`compact-screen`, replacing both ends of the transition, since a sheet cannot inherit
-a centered transform.
+`--rak-knocked-out-text` with the same skull the table gives them. The search is
+thousands of scenarios, so it runs on the player chosen rather than on every
+render. Only the search holds still: everything under the rule below it scrolls.
+`PathToVictoryDialog.scss` centers the one dialog as a modal and stands it on the
+bottom edge as a sheet below `compact-screen`, replacing both ends of the
+transition, since a sheet cannot inherit a centered transform. Its popup list
+takes its shape from `styles/_listbox.scss`, which the home page selects share.
 
 `VictorySummary`: renders `PathsToVictory`, working out only what it takes to say
 it. The standing leads, from `Standing`, which reads the scores rather than the
-search. Picks sit in a grid rather than a wrapping row, so the same game holds the
-same column down every route. A must-win game carries a green line where a route
-carries gold. Routes stand four deep and unfold on a click, keyed on the player so
-a new one starts folded. A closing note counts the routes found past the ten kept.
+search, and names no leader until a pick is settled. Picks sit in a
+grid rather than a wrapping row, so the same game holds the same column down every
+route. A must-win game carries a red line where a route carries gold. Routes stand
+four deep and unfold on a click, keyed on the player so a new one starts folded. A
+closing note counts the routes found past the ten kept. A player picked always
+reads a sentence, down to the week resting on the tiebreaker alone.
 
 A tiebreaker every route shares is stated once under `MNF points`, and left off
 the routes themselves. Where they disagree each route carries its own, and that

--- a/src/components/pathToVictory/CLAUDE.md
+++ b/src/components/pathToVictory/CLAUDE.md
@@ -16,7 +16,8 @@ a centered transform.
 it. Must-win leads and the standing line closes. Picks sit in a grid rather than a
 wrapping row, so the same game holds the same column down every route. A must-win
 game carries a green line where a route carries gold. Routes stand four deep and
-unfold on a click, keyed on the player so a new one starts folded.
+unfold on a click, keyed on the player so a new one starts folded. A closing note
+counts the routes worked out past the ten kept.
 
 One suite here mounts one dialog, on purpose. Base UI leaves its scroll lock, focus
 guards, and inert markers on the document when a second one mounts, which puts the

--- a/src/components/pathToVictory/CLAUDE.md
+++ b/src/components/pathToVictory/CLAUDE.md
@@ -7,7 +7,8 @@ gold trophy button.
 `VictorySummary` under it. `playersMatching` names a knocked out player only where
 the letters typed reach nobody still standing, disabled, in
 `--rak-knocked-out-text` with the same skull the table gives them. The search is thousands of scenarios, so it runs on the player chosen
-rather than on every render. `PathToVictoryDialog.scss`
+rather than on every render. Only the search holds still: everything under the rule below it scrolls.
+`PathToVictoryDialog.scss`
 centers the one dialog as a modal and stands it on the bottom edge as a sheet below
 `compact-screen`, replacing both ends of the transition, since a sheet cannot inherit
 a centered transform.

--- a/src/components/pathToVictory/CLAUDE.md
+++ b/src/components/pathToVictory/CLAUDE.md
@@ -4,10 +4,9 @@ What a player still has to do to win a week being played, opened from the navbar
 gold trophy button.
 
 `PathToVictoryDialog`: a Base UI dialog over a Base UI combobox, with
-`VictorySummary` under it. `playersMatching` holds a knocked out player back while
-anyone still standing shares the letters typed, and offers them disabled when they
-are the only match, named in `--rak-knocked-out-text` with the same skull the table
-gives them. The search is thousands of scenarios, so it runs on the player chosen
+`VictorySummary` under it. `playersMatching` names a knocked out player only where
+the letters typed reach nobody still standing, disabled, in
+`--rak-knocked-out-text` with the same skull the table gives them. The search is thousands of scenarios, so it runs on the player chosen
 rather than on every render. `PathToVictoryDialog.scss`
 centers the one dialog as a modal and stands it on the bottom edge as a sheet below
 `compact-screen`, replacing both ends of the transition, since a sheet cannot inherit

--- a/src/components/pathToVictory/CLAUDE.md
+++ b/src/components/pathToVictory/CLAUDE.md
@@ -19,9 +19,10 @@ it. The standing leads, from `Standing`, which reads the scores rather than the
 search, and names no leader until a pick is settled. Picks sit in a
 grid rather than a wrapping row, so the same game holds the same column down every
 route. A must-win game carries a red line where a route carries gold. Routes stand
-four deep and unfold on a click, keyed on the player so a new one starts folded. A
-closing note counts the routes found past the ten kept. A player picked always
-reads a sentence, down to the week resting on the tiebreaker alone.
+four deep and unfold on a click, and the dialog's own key on the player is what
+starts a new one folded. A closing note counts the routes found past the ten kept.
+A player picked always reads a sentence, down to the week resting on the
+tiebreaker alone.
 
 A tiebreaker every route shares is stated once under `MNF points`, and left off
 the routes themselves. Where they disagree each route carries its own, and that

--- a/src/components/pathToVictory/CLAUDE.md
+++ b/src/components/pathToVictory/CLAUDE.md
@@ -13,11 +13,15 @@ centers the one dialog as a modal and stands it on the bottom edge as a sheet be
 a centered transform.
 
 `VictorySummary`: renders `PathsToVictory`, working out only what it takes to say
-it. Must-win leads and the standing line closes. Picks sit in a grid rather than a
-wrapping row, so the same game holds the same column down every route. A must-win
-game carries a green line where a route carries gold. Routes stand four deep and
-unfold on a click, keyed on the player so a new one starts folded. A closing note
-counts the routes worked out past the ten kept.
+it. The standing leads, from `Standing`, which reads the scores rather than the
+search. Picks sit in a grid rather than a wrapping row, so the same game holds the
+same column down every route. A must-win game carries a green line where a route
+carries gold. Routes stand four deep and unfold on a click, keyed on the player so
+a new one starts folded. A closing note counts the routes found past the ten kept.
+
+A tiebreaker every route shares is stated once under `MNF points`, and left off
+the routes themselves. Where they disagree each route carries its own, and that
+section does not render.
 
 One suite here mounts one dialog, on purpose. Base UI leaves its scroll lock, focus
 guards, and inert markers on the document when a second one mounts, which puts the

--- a/src/components/pathToVictory/CLAUDE.md
+++ b/src/components/pathToVictory/CLAUDE.md
@@ -5,16 +5,18 @@ gold trophy button.
 
 `PathToVictoryDialog`: a Base UI dialog over a Base UI combobox, with
 `VictorySummary` under it. `playersMatching` holds a knocked out player back while
-anyone still standing shares the letters typed, and offers them disabled in danger
-red with a skull when they are the only match. The search is thousands of scenarios,
-so it runs on the player chosen rather than on every render. `PathToVictoryDialog.scss`
+anyone still standing shares the letters typed, and offers them disabled when they
+are the only match, named in `--rak-knocked-out-text` with the same skull the table
+gives them. The search is thousands of scenarios, so it runs on the player chosen
+rather than on every render. `PathToVictoryDialog.scss`
 centers the one dialog as a modal and stands it on the bottom edge as a sheet below
 `compact-screen`, replacing both ends of the transition, since a sheet cannot inherit
 a centered transform.
 
-`VictorySummary`: renders `PathsToVictory` and works nothing out itself. Must-win
-leads and the standing line closes. Routes stand five deep and unfold on a click,
-keyed on the player so a new one starts folded.
+`VictorySummary`: renders `PathsToVictory`, working out only what it takes to say
+it. Must-win leads and the standing line closes. Picks sit in a grid rather than a
+wrapping row, so the same game holds the same column down every route. Routes stand
+five deep and unfold on a click, keyed on the player so a new one starts folded.
 
 One suite here mounts one dialog, on purpose. Base UI leaves its scroll lock, focus
 guards, and inert markers on the document when a second one mounts, which puts the

--- a/src/components/pathToVictory/CLAUDE.md
+++ b/src/components/pathToVictory/CLAUDE.md
@@ -14,8 +14,9 @@ a centered transform.
 
 `VictorySummary`: renders `PathsToVictory`, working out only what it takes to say
 it. Must-win leads and the standing line closes. Picks sit in a grid rather than a
-wrapping row, so the same game holds the same column down every route. Routes stand
-five deep and unfold on a click, keyed on the player so a new one starts folded.
+wrapping row, so the same game holds the same column down every route. A must-win
+game carries a green line where a route carries gold. Routes stand four deep and
+unfold on a click, keyed on the player so a new one starts folded.
 
 One suite here mounts one dialog, on purpose. Base UI leaves its scroll lock, focus
 guards, and inert markers on the document when a second one mounts, which puts the

--- a/src/components/pathToVictory/CLAUDE.md
+++ b/src/components/pathToVictory/CLAUDE.md
@@ -1,28 +1,21 @@
 # pathToVictory
 
-What a player still has to do to win a week that is being played, opened from the
-navbar's gold trophy button.
+What a player still has to do to win a week being played, opened from the navbar's
+gold trophy button.
 
-`PathToVictoryDialog`: a Base UI dialog holding a Base UI combobox over
-`eligiblePlayers`, and `VictorySummary` under it. Only the players who can still win
-are offered, since a knocked out one has no route to show. The search behind it is
-thousands of scenarios, so it runs on the player chosen rather than on every render
-around them. One dialog serves both shapes: `PathToVictoryDialog.scss` centers it as a modal and
-stands it on the bottom edge as a sheet below `compact-screen`, replacing both ends
-of the transition rather than the resting rule, since the sheet cannot inherit a
-centered transform. State comes off Base UI's `[data-open]`, `[data-starting-style]`,
-and `[data-highlighted]`, the same way the home page's select is styled.
+`PathToVictoryDialog`: a Base UI dialog over a Base UI combobox, with
+`VictorySummary` under it. `playersMatching` holds a knocked out player back while
+anyone still standing shares the letters typed, and offers them disabled in danger
+red with a skull when they are the only match. The search is thousands of scenarios,
+so it runs on the player chosen rather than on every render. `PathToVictoryDialog.scss`
+centers the one dialog as a modal and stands it on the bottom edge as a sheet below
+`compact-screen`, replacing both ends of the transition, since a sheet cannot inherit
+a centered transform.
 
-`VictorySummary`: the must-win games, the pool the rest come from, the games out of
-the player's hands, and the Monday night sentence, plus the eliminated, clinched,
-and too-many-games states. Must-win leads, and how the player stands closes, since
-the games to back are what the sheet is opened for. A list of routes stands five
-deep and unfolds on a click, keyed on the player so a new one starts folded again.
-It renders `PathsToVictory` and works nothing out itself, which is why every case it
-can show is testable without a dialog around it.
+`VictorySummary`: renders `PathsToVictory` and works nothing out itself. Must-win
+leads and the standing line closes. Routes stand five deep and unfold on a click,
+keyed on the player so a new one starts folded.
 
-One suite here mounts one dialog, on purpose. Base UI hangs its scroll lock, focus
-guards, and inert markers off the document while a dialog is open, and mounting a
-second one leaves the previous set behind, so every other case in a file that mounts
-several types into an input those leftovers have put out of reach. The app never
-does this: `ResultsFrame` holds one dialog and toggles `open` on it.
+One suite here mounts one dialog, on purpose. Base UI leaves its scroll lock, focus
+guards, and inert markers on the document when a second one mounts, which puts the
+input of every other case out of reach. The app holds one dialog and toggles `open`.

--- a/src/components/pathToVictory/PathToVictoryDialog.scss
+++ b/src/components/pathToVictory/PathToVictoryDialog.scss
@@ -161,17 +161,28 @@
   font-size: 0.875rem;
 }
 
-// Its height is set from what the summary inside measures, so the dialog grows
+// Its height is set from what the content inside measures, so the dialog grows
 // and shrinks with the answer. Shrinking is what makes it scroll, once the popup
-// has no more room to give.
+// has no more room to give. Measured without the padding and the rule, which
+// `content-box` keeps outside the height set on it.
 .path-to-victory__body {
+  box-sizing: content-box;
   flex: 0 1 auto;
   min-height: 0;
+  padding-top: 12px;
+  // Everything under here scrolls. Only the search above it holds still.
+  border-top: 1px solid var(--rak-border);
   overflow-y: auto;
 
   @media (prefers-reduced-motion: no-preference) {
     transition: height 220ms ease;
   }
+}
+
+.path-to-victory__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .path-to-victory__searching {

--- a/src/components/pathToVictory/PathToVictoryDialog.scss
+++ b/src/components/pathToVictory/PathToVictoryDialog.scss
@@ -143,6 +143,12 @@
     color: var(--rak-knocked-out-text);
     cursor: default;
   }
+
+  // As tall as the name beside it, which is the proportion the tables draw the
+  // same skull at.
+  > svg {
+    font-size: 1em;
+  }
 }
 
 .path-to-victory__empty {

--- a/src/components/pathToVictory/PathToVictoryDialog.scss
+++ b/src/components/pathToVictory/PathToVictoryDialog.scss
@@ -134,6 +134,10 @@
     background-color: var(--rak-neutral-200);
   }
 
+  & + & {
+    border-top: 1px solid var(--rak-neutral-200);
+  }
+
   // Only ever offered where nobody still standing shares the letters typed. Named
   // in the color the tables fill the same player's cell with, so it reads as the
   // answer rather than as a choice.

--- a/src/components/pathToVictory/PathToVictoryDialog.scss
+++ b/src/components/pathToVictory/PathToVictoryDialog.scss
@@ -1,0 +1,172 @@
+@use "../../styles/breakpoints" as *;
+
+// Base UI ships the dialog and the combobox unstyled, so these rules carry the
+// whole look of both. State comes off the data attributes they set, the same way
+// the select on the home page reads `[data-highlighted]`.
+.path-to-victory__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background-color: rgb(21 21 21 / 45%);
+  transition: opacity 200ms ease;
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+  }
+}
+
+.path-to-victory__popup {
+  position: fixed;
+  z-index: 1001;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  top: 50%;
+  left: 50%;
+  width: min(560px, calc(100vw - 32px));
+  max-height: min(680px, calc(100dvh - 64px));
+  padding: 20px;
+  border-radius: var(--rak-radius-lg);
+  background-color: var(--rak-surface);
+  box-shadow: var(--rak-shadow-md);
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 200ms ease,
+    transform 200ms ease;
+
+  &:focus-visible {
+    outline: none;
+  }
+
+  // Held apart from the resting rule above, so the sheet below can replace both
+  // ends of the transition without inheriting a centered transform.
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: translate(-50%, -46%);
+  }
+}
+
+.path-to-victory__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.path-to-victory__title {
+  margin: 0;
+  color: var(--rak-primary-700);
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.path-to-victory__search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 12px;
+  border: 1px solid var(--rak-border);
+  border-radius: var(--rak-radius-sm);
+  background-color: var(--rak-on-solid);
+  box-shadow: var(--rak-shadow-xs);
+
+  &:focus-within {
+    outline: 2px solid var(--rak-primary-500);
+    outline-offset: 2px;
+  }
+}
+
+.path-to-victory__input {
+  flex: 1;
+  min-width: 0;
+  padding: 3px 0;
+  border: 0 solid var(--rak-border);
+  background-color: transparent;
+  color: var(--rak-text-secondary);
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.path-to-victory__input-icon {
+  display: flex;
+  align-items: center;
+  color: var(--rak-text-tertiary);
+}
+
+.path-to-victory__positioner {
+  // Above the dialog it opens inside of, which the backdrop already sits under.
+  z-index: 1002;
+  max-height: var(--available-height);
+}
+
+.path-to-victory__list {
+  box-sizing: border-box;
+  min-width: var(--anchor-width);
+  max-height: min(240px, var(--available-height));
+  overflow-y: auto;
+  padding: 6px 0;
+  border: 1px solid var(--rak-border);
+  border-radius: var(--rak-radius-sm);
+  background-color: var(--rak-on-solid);
+  box-shadow: var(--rak-shadow-md);
+}
+
+.path-to-victory__option {
+  display: flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 4px 12px;
+  cursor: pointer;
+
+  &[data-highlighted] {
+    background-color: var(--rak-level1);
+  }
+
+  &[data-selected] {
+    background-color: var(--rak-neutral-200);
+  }
+}
+
+.path-to-victory__empty {
+  padding: 8px 12px;
+  color: var(--rak-text-tertiary);
+  font-size: 0.875rem;
+}
+
+.path-to-victory__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+@include compact-screen {
+  // A sheet on the bottom edge, where a centered window would leave no margin
+  // either side of it. The same dialog, told apart here rather than in the
+  // component, because every other screen split in the app is drawn this way.
+  .path-to-victory__popup {
+    top: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    max-height: 85dvh;
+    padding-bottom: calc(20px + env(safe-area-inset-bottom));
+    border-radius: var(--rak-radius-lg) var(--rak-radius-lg) 0 0;
+    transform: none;
+
+    &[data-starting-style],
+    &[data-ending-style] {
+      // Only the slide, so a sheet on its way in is not also faded. The travel
+      // reads as the whole animation at this size.
+      opacity: 1;
+      transform: translateY(100%);
+    }
+  }
+}

--- a/src/components/pathToVictory/PathToVictoryDialog.scss
+++ b/src/components/pathToVictory/PathToVictoryDialog.scss
@@ -134,15 +134,14 @@
     background-color: var(--rak-neutral-200);
   }
 
-  // Only ever offered where nobody still standing shares the letters typed, so it
-  // reads as the answer rather than as a choice.
-  &.--eliminated {
-    color: var(--rak-danger-600);
+  // Only ever offered where nobody still standing shares the letters typed. Named
+  // in the color the tables fill the same player's cell with, so it reads as the
+  // answer rather than as a choice.
+  &.--eliminated,
+  &.--eliminated[data-highlighted] {
+    background-color: transparent;
+    color: var(--rak-knocked-out-text);
     cursor: default;
-
-    &[data-highlighted] {
-      background-color: transparent;
-    }
   }
 }
 

--- a/src/components/pathToVictory/PathToVictoryDialog.scss
+++ b/src/components/pathToVictory/PathToVictoryDialog.scss
@@ -111,8 +111,6 @@
   @include listbox-popup;
 
   max-height: min(240px, var(--available-height));
-  border: 1px solid var(--rak-border);
-  border-radius: var(--rak-radius-sm);
 }
 
 .path-to-victory__option {

--- a/src/components/pathToVictory/PathToVictoryDialog.scss
+++ b/src/components/pathToVictory/PathToVictoryDialog.scss
@@ -137,8 +137,8 @@
   // Only ever offered where nobody still standing shares the letters typed. Named
   // in the color the tables fill the same player's cell with, so it reads as the
   // answer rather than as a choice.
-  &.--eliminated,
-  &.--eliminated[data-highlighted] {
+  &.--knocked-out,
+  &.--knocked-out[data-highlighted] {
     background-color: transparent;
     color: var(--rak-knocked-out-text);
     cursor: default;

--- a/src/components/pathToVictory/PathToVictoryDialog.scss
+++ b/src/components/pathToVictory/PathToVictoryDialog.scss
@@ -161,10 +161,38 @@
   font-size: 0.875rem;
 }
 
+// Its height is set from what the summary inside measures, so the dialog grows
+// and shrinks with the answer. Shrinking is what makes it scroll, once the popup
+// has no more room to give.
 .path-to-victory__body {
-  flex: 1;
+  flex: 0 1 auto;
   min-height: 0;
   overflow-y: auto;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: height 220ms ease;
+  }
+}
+
+.path-to-victory__searching {
+  display: flex;
+  justify-content: center;
+  padding: 24px 0;
+}
+
+.path-to-victory__spinner {
+  width: 24px;
+  height: 24px;
+  border: 3px solid var(--rak-neutral-200);
+  border-top-color: var(--rak-primary-500);
+  border-radius: 50%;
+  animation: path-to-victory-spin 700ms linear infinite;
+}
+
+@keyframes path-to-victory-spin {
+  to {
+    transform: rotate(1turn);
+  }
 }
 
 @include compact-screen {

--- a/src/components/pathToVictory/PathToVictoryDialog.scss
+++ b/src/components/pathToVictory/PathToVictoryDialog.scss
@@ -121,6 +121,7 @@
 .path-to-victory__option {
   display: flex;
   align-items: center;
+  gap: 8px;
   min-height: 36px;
   padding: 4px 12px;
   cursor: pointer;
@@ -131,6 +132,17 @@
 
   &[data-selected] {
     background-color: var(--rak-neutral-200);
+  }
+
+  // Only ever offered where nobody still standing shares the letters typed, so it
+  // reads as the answer rather than as a choice.
+  &.--eliminated {
+    color: var(--rak-danger-600);
+    cursor: default;
+
+    &[data-highlighted] {
+      background-color: transparent;
+    }
   }
 }
 

--- a/src/components/pathToVictory/PathToVictoryDialog.scss
+++ b/src/components/pathToVictory/PathToVictoryDialog.scss
@@ -1,4 +1,5 @@
 @use "../../styles/breakpoints" as *;
+@use "../../styles/listbox" as *;
 
 // Base UI ships the dialog and the combobox unstyled, so these rules carry the
 // whole look of both. State comes off the data attributes they set, the same way
@@ -107,36 +108,17 @@
 }
 
 .path-to-victory__list {
-  box-sizing: border-box;
-  min-width: var(--anchor-width);
+  @include listbox-popup;
+
   max-height: min(240px, var(--available-height));
-  overflow-y: auto;
-  padding: 6px 0;
   border: 1px solid var(--rak-border);
   border-radius: var(--rak-radius-sm);
-  background-color: var(--rak-on-solid);
-  box-shadow: var(--rak-shadow-md);
 }
 
 .path-to-victory__option {
-  display: flex;
-  align-items: center;
+  @include listbox-item;
+
   gap: 8px;
-  min-height: 36px;
-  padding: 4px 12px;
-  cursor: pointer;
-
-  &[data-highlighted] {
-    background-color: var(--rak-level1);
-  }
-
-  &[data-selected] {
-    background-color: var(--rak-neutral-200);
-  }
-
-  & + & {
-    border-top: 1px solid var(--rak-neutral-200);
-  }
 
   // Only ever offered where nobody still standing shares the letters typed. Named
   // in the color the tables fill the same player's cell with, so it reads as the
@@ -169,7 +151,7 @@
   box-sizing: content-box;
   flex: 0 1 auto;
   min-height: 0;
-  padding-top: 12px;
+  padding-top: 16px;
   // Everything under here scrolls. Only the search above it holds still.
   border-top: 1px solid var(--rak-border);
   overflow-y: auto;
@@ -179,10 +161,12 @@
   }
 }
 
+// The standing reads as a title over what follows, so it sits the same distance
+// from it as a section title sits from its own contents.
 .path-to-victory__content {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 8px;
 }
 
 .path-to-victory__searching {

--- a/src/components/pathToVictory/PathToVictoryDialog.scss
+++ b/src/components/pathToVictory/PathToVictoryDialog.scss
@@ -24,7 +24,7 @@
   gap: 16px;
   top: 50%;
   left: 50%;
-  width: min(560px, calc(100vw - 32px));
+  width: min(640px, calc(100vw - 32px));
   max-height: min(680px, calc(100dvh - 64px));
   padding: 20px;
   border-radius: var(--rak-radius-lg);

--- a/src/components/pathToVictory/PathToVictoryDialog.test.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.test.tsx
@@ -5,7 +5,10 @@ import {
   PlayerScore,
   RakMadnessScores,
 } from "../../types/RakMadnessScores";
-import PathToVictoryDialog, { eligiblePlayers } from "./PathToVictoryDialog";
+import PathToVictoryDialog, {
+  playerOptions,
+  playersMatching,
+} from "./PathToVictoryDialog";
 
 function proPick(pick: string): PickResult {
   return {
@@ -43,13 +46,30 @@ const scores: RakMadnessScores = {
   ],
 };
 
-describe("eligiblePlayers", () => {
-  it("offers everyone who can still win the week", () => {
-    expect(eligiblePlayers(scores)).toEqual(["Alice", "Bob"]);
+describe("playersMatching", () => {
+  const options = playerOptions(scores);
+
+  it("holds a knocked out player back while anyone standing matches", () => {
+    expect(playersMatching(options, "Bob")).toEqual([
+      { name: "Bob", isKnockedOut: false },
+    ]);
+  });
+
+  it("offers the knocked out player where they are the only match", () => {
+    expect(playersMatching(options, "Bobby")).toEqual([
+      { name: "Bobby", isKnockedOut: true },
+    ]);
+  });
+
+  it("offers everyone still standing before anything is typed", () => {
+    expect(playersMatching(options, "").map((it) => it.name)).toEqual([
+      "Alice",
+      "Bob",
+    ]);
   });
 
   it("has nobody to offer before a week is scored", () => {
-    expect(eligiblePlayers(undefined)).toEqual([]);
+    expect(playersMatching(playerOptions(undefined), "")).toEqual([]);
   });
 });
 

--- a/src/components/pathToVictory/PathToVictoryDialog.test.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.test.tsx
@@ -68,6 +68,13 @@ describe("playersMatching", () => {
     ]);
   });
 
+  it("names nobody knocked out before anything is typed", () => {
+    const allOut = playerOptions({
+      scores: [player("Bobby", 0, "DEN +3", true)],
+    });
+    expect(playersMatching(allOut, "")).toEqual([]);
+  });
+
   it("has nobody to offer before a week is scored", () => {
     expect(playersMatching(playerOptions(undefined), "")).toEqual([]);
   });

--- a/src/components/pathToVictory/PathToVictoryDialog.test.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.test.tsx
@@ -98,7 +98,12 @@ describe("PathToVictoryDialog", () => {
 
     expect(screen.getByText("Pick a player")).toBeInTheDocument();
 
-    await user.type(screen.getByRole("combobox", { name: "Player" }), "Ali");
+    const search = screen.getByRole("combobox", { name: "Player" });
+    await user.type(search, "zzz");
+    expect(await screen.findByText("No matching players")).toBeInTheDocument();
+
+    await user.clear(search);
+    await user.type(search, "Ali");
     await user.click(await screen.findByRole("option", { name: "Alice" }));
 
     const mustWin = screen.getByRole("heading", { name: "Must win" });

--- a/src/components/pathToVictory/PathToVictoryDialog.test.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.test.tsx
@@ -103,8 +103,6 @@ describe("PathToVictoryDialog", () => {
       />,
     );
 
-    expect(screen.getByText("Pick a player")).toBeInTheDocument();
-
     const search = screen.getByRole("combobox", { name: "Player" });
     await user.type(search, "zzz");
     expect(await screen.findByText("No matching players")).toBeInTheDocument();
@@ -113,7 +111,8 @@ describe("PathToVictoryDialog", () => {
     await user.type(search, "Ali");
     await user.click(await screen.findByRole("option", { name: "Alice" }));
 
-    const mustWin = screen.getByRole("heading", { name: "Must win" });
+    // The search runs a frame after the spinner it replaces.
+    const mustWin = await screen.findByRole("heading", { name: "Must win" });
     const pick = within(mustWin.parentElement as HTMLElement).getByRole(
       "listitem",
     );

--- a/src/components/pathToVictory/PathToVictoryDialog.test.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  PickResult,
+  PlayerScore,
+  RakMadnessScores,
+} from "../../types/RakMadnessScores";
+import PathToVictoryDialog, { eligiblePlayers } from "./PathToVictoryDialog";
+
+function proPick(pick: string): PickResult {
+  return {
+    pick,
+    status: "incomplete",
+    explanation: { header: "", message: "" },
+  };
+}
+
+function player(
+  name: string,
+  total: number,
+  pick: string,
+  isKnockedOut = false,
+): PlayerScore {
+  return {
+    name,
+    score: { total, college: 0, pro: total, proAgainstTheSpread: 0 },
+    tiebreaker: {},
+    college: [],
+    pro: [proPick(pick)],
+    status: { hasNoPicks: false, isKnockedOut },
+  };
+}
+
+/**
+ * Two players level on points with one game left, which they picked opposite
+ * ways, and a third already out of it.
+ */
+const scores: RakMadnessScores = {
+  scores: [
+    player("Alice", 3, "KC -3"),
+    player("Bob", 3, "DEN +3"),
+    player("Bobby", 0, "DEN +3", true),
+  ],
+};
+
+describe("eligiblePlayers", () => {
+  it("offers everyone who can still win the week", () => {
+    expect(eligiblePlayers(scores)).toEqual(["Alice", "Bob"]);
+  });
+
+  it("has nobody to offer before a week is scored", () => {
+    expect(eligiblePlayers(undefined)).toEqual([]);
+  });
+});
+
+/*
+ * One mounted dialog for the whole file, on purpose.
+ *
+ * Base UI hangs its scroll lock, focus guards, and inert markers off the document
+ * while a dialog is open, and mounting a second one leaves the previous set behind.
+ * Every other case in a file that mounts several then types into an input those
+ * leftovers have put out of reach. The app never does this: `ResultsFrame` holds
+ * one dialog and toggles `open` on it.
+ *
+ * So this covers the wiring once, and what each result reads like is covered
+ * against `VictorySummary` instead.
+ */
+describe("PathToVictoryDialog", () => {
+  it("works out the route of the player picked from the search", async () => {
+    const user = userEvent.setup();
+    render(
+      <PathToVictoryDialog
+        open
+        onOpenChange={() => undefined}
+        scores={scores}
+      />,
+    );
+
+    expect(screen.getByText("Pick a player")).toBeInTheDocument();
+
+    await user.type(screen.getByRole("combobox", { name: "Player" }), "Ali");
+    await user.click(await screen.findByRole("option", { name: "Alice" }));
+
+    const mustWin = screen.getByRole("heading", { name: "Must win" });
+    const pick = within(mustWin.parentElement as HTMLElement).getByRole(
+      "listitem",
+    );
+    expect(pick).toHaveTextContent("P1");
+    expect(pick).toHaveTextContent("KC -3");
+  });
+});

--- a/src/components/pathToVictory/PathToVictoryDialog.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.tsx
@@ -128,7 +128,7 @@ export default function PathToVictoryDialog({
                         value={option}
                         disabled={option.isKnockedOut}
                         className={`path-to-victory__option ${getClasses({
-                          "--eliminated": option.isKnockedOut,
+                          "--knocked-out": option.isKnockedOut,
                         })}`}
                       >
                         {option.name}

--- a/src/components/pathToVictory/PathToVictoryDialog.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.tsx
@@ -1,6 +1,7 @@
 import { Combobox } from "@base-ui-components/react/combobox";
 import { Dialog } from "@base-ui-components/react/dialog";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { PathsToVictory } from "../../types/PathsToVictory";
 import { RakMadnessScores } from "../../types/RakMadnessScores";
 import getClasses from "../../utils/getClasses";
 import getPathsToVictory from "../../utils/scoring/getPathsToVictory";
@@ -55,20 +56,53 @@ export default function PathToVictoryDialog({
 }) {
   const [player, setPlayer] = useState<PlayerOption>();
   const [query, setQuery] = useState("");
+  const [found, setFound] = useState<{
+    scores: RakMadnessScores;
+    name: string;
+    paths?: PathsToVictory;
+  }>();
 
   // Held still between renders, since the combobox reads the chosen player back
   // off this list by identity.
   const options = useMemo(() => playerOptions(scores), [scores]);
   const standing = useMemo(() => playersMatching(options, ""), [options]);
-  // The search is thousands of scenarios, so it runs on the player chosen rather
-  // than on every render of the dialog around them.
-  const result = useMemo(
-    () =>
-      scores != null && player != null
-        ? getPathsToVictory(scores, player.name)
-        : undefined,
-    [scores, player],
-  );
+
+  // The search is thousands of scenarios and holds the thread while it runs, so
+  // it waits for the spinner beside it to paint first.
+  useEffect(() => {
+    if (scores == null || player == null) return;
+    let timer = 0;
+    const frame = requestAnimationFrame(() => {
+      timer = window.setTimeout(() =>
+        setFound({
+          scores,
+          name: player.name,
+          paths: getPathsToVictory(scores, player.name),
+        }),
+      );
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      window.clearTimeout(timer);
+    };
+  }, [scores, player]);
+
+  const isCurrent = found?.scores === scores && found?.name === player?.name;
+  const isSearching = player != null && !isCurrent;
+  const result = isCurrent ? found?.paths : undefined;
+
+  const body = useRef<HTMLDivElement>(null);
+  // The dialog grows to what the answer measures rather than jumping to it. Only
+  // the wrapper carries a height, so the summary inside is laid out as usual.
+  // Hung off the node itself, since the portal holding it mounts after this.
+  const measure = useCallback((content: HTMLDivElement) => {
+    const observer = new ResizeObserver(([entry]) => {
+      if (body.current == null) return;
+      body.current.style.height = `${entry.contentRect.height}px`;
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -146,8 +180,22 @@ export default function PathToVictoryDialog({
             </Combobox.Portal>
           </Combobox.Root>
 
-          <div className="path-to-victory__body">
-            <VictorySummary result={result} />
+          <div className="path-to-victory__body" ref={body}>
+            <div ref={measure}>
+              {isSearching ? (
+                <div
+                  className="path-to-victory__searching"
+                  role="status"
+                  aria-label="Working out the routes"
+                >
+                  <span className="path-to-victory__spinner" />
+                </div>
+              ) : (
+                // Keyed on the player, so the answer to a new one plays in rather
+                // than replacing the last one in place.
+                <VictorySummary key={player?.name} result={result} />
+              )}
+            </div>
           </div>
         </Dialog.Popup>
       </Dialog.Portal>

--- a/src/components/pathToVictory/PathToVictoryDialog.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.tsx
@@ -21,8 +21,8 @@ export function playerOptions(scores?: RakMadnessScores): Array<PlayerOption> {
 }
 
 /**
- * The players a query offers. A knocked out one is held back while anyone still
- * standing answers to the same letters, since their only answer is "no".
+ * The players a query offers. A knocked out one is named only where the letters
+ * typed reach nobody still standing, since their only answer is "no".
  */
 export function playersMatching(
   options: Array<PlayerOption>,
@@ -33,7 +33,8 @@ export function playersMatching(
     option.name.toLowerCase().includes(needle),
   );
   const standing = matches.filter((option) => !option.isKnockedOut);
-  return standing.length > 0 ? standing : matches;
+  if (needle.length === 0 || standing.length > 0) return standing;
+  return matches;
 }
 
 /**

--- a/src/components/pathToVictory/PathToVictoryDialog.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.tsx
@@ -119,7 +119,7 @@ export default function PathToVictoryDialog({
               >
                 <Combobox.Popup className="path-to-victory__list">
                   <Combobox.Empty className="path-to-victory__empty">
-                    No player by that name.
+                    No matching players
                   </Combobox.Empty>
                   <Combobox.List>
                     {(option: PlayerOption) => (

--- a/src/components/pathToVictory/PathToVictoryDialog.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.tsx
@@ -180,15 +180,14 @@ export default function PathToVictoryDialog({
             </Combobox.Portal>
           </Combobox.Root>
 
-          <Standing scores={scores} player={player?.name} />
-
           <div className="path-to-victory__body" ref={body}>
-            <div ref={measure}>
+            <div className="path-to-victory__content" ref={measure}>
+              <Standing scores={scores} player={player?.name} />
               {isSearching ? (
                 <div
                   className="path-to-victory__searching"
                   role="status"
-                  aria-label="Working out the routes"
+                  aria-label="Working out the paths"
                 >
                   <span className="path-to-victory__spinner" />
                 </div>

--- a/src/components/pathToVictory/PathToVictoryDialog.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.tsx
@@ -59,6 +59,7 @@ export default function PathToVictoryDialog({
   // Held still between renders, since the combobox reads the chosen player back
   // off this list by identity.
   const options = useMemo(() => playerOptions(scores), [scores]);
+  const standing = useMemo(() => playersMatching(options, ""), [options]);
   // The search is thousands of scenarios, so it runs on the player chosen rather
   // than on every render of the dialog around them.
   const result = useMemo(
@@ -89,7 +90,10 @@ export default function PathToVictoryDialog({
           </header>
 
           <Combobox.Root
-            items={options}
+            // Only the players still standing, since the combobox falls back to
+            // this list whole once a name has been chosen, rather than to the
+            // filtered one below.
+            items={standing}
             filteredItems={playersMatching(options, query)}
             itemToStringLabel={(option: PlayerOption) => option.name}
             // The combobox keeps the choice itself. Naming it here as well would

--- a/src/components/pathToVictory/PathToVictoryDialog.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.tsx
@@ -7,7 +7,7 @@ import getClasses from "../../utils/getClasses";
 import getPathsToVictory from "../../utils/scoring/getPathsToVictory";
 import Button from "../button/Button";
 import { CloseRoundedIcon, SkullIcon, UnfoldMoreIcon } from "../icon/Icon";
-import VictorySummary from "./VictorySummary";
+import VictorySummary, { Standing } from "./VictorySummary";
 import "./PathToVictoryDialog.scss";
 
 export type PlayerOption = { name: string; isKnockedOut: boolean };
@@ -179,6 +179,8 @@ export default function PathToVictoryDialog({
               </Combobox.Positioner>
             </Combobox.Portal>
           </Combobox.Root>
+
+          <Standing scores={scores} player={player?.name} />
 
           <div className="path-to-victory__body" ref={body}>
             <div ref={measure}>

--- a/src/components/pathToVictory/PathToVictoryDialog.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.tsx
@@ -1,0 +1,123 @@
+import { Combobox } from "@base-ui-components/react/combobox";
+import { Dialog } from "@base-ui-components/react/dialog";
+import { useMemo, useState } from "react";
+import { RakMadnessScores } from "../../types/RakMadnessScores";
+import getPathsToVictory from "../../utils/scoring/getPathsToVictory";
+import Button from "../button/Button";
+import { CloseRoundedIcon, UnfoldMoreIcon } from "../icon/Icon";
+import VictorySummary from "./VictorySummary";
+import "./PathToVictoryDialog.scss";
+
+/**
+ * The players worth asking about: the ones who can still win it.
+ *
+ * A knocked out player has no route to offer, so listing them would only ever be
+ * offering an answer of "no".
+ */
+export function eligiblePlayers(scores?: RakMadnessScores): Array<string> {
+  return (
+    scores?.scores
+      .filter((player) => !player.status.isKnockedOut)
+      .map((player) => player.name) ?? []
+  );
+}
+
+/**
+ * What a player still has to do to win the week on screen.
+ *
+ * A centered modal by default and a sheet up from the bottom edge on a phone. Both
+ * are the one Base UI dialog, told apart in the stylesheet, because that is where
+ * the rest of the app draws the same line.
+ */
+export default function PathToVictoryDialog({
+  open,
+  onOpenChange,
+  scores,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  scores?: RakMadnessScores;
+}) {
+  const [player, setPlayer] = useState<string | null>(null);
+
+  const names = useMemo(() => eligiblePlayers(scores), [scores]);
+  // The search is thousands of scenarios, so it runs on the player chosen rather
+  // than on every render of the dialog around them.
+  const result = useMemo(
+    () =>
+      scores != null && player != null
+        ? getPathsToVictory(scores, player)
+        : undefined,
+    [scores, player],
+  );
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="path-to-victory__backdrop" />
+        <Dialog.Popup className="path-to-victory__popup">
+          <header className="path-to-victory__header">
+            <Dialog.Title className="path-to-victory__title">
+              Path to Victory
+            </Dialog.Title>
+            <Button
+              ariaLabel="Close"
+              variant="soft"
+              iconOnly
+              onClick={() => onOpenChange(false)}
+            >
+              <CloseRoundedIcon />
+            </Button>
+          </header>
+
+          <Combobox.Root
+            items={names}
+            value={player}
+            onValueChange={setPlayer}
+            // The list is short and already on screen, so the first match being
+            // highlighted saves an arrow key before Enter.
+            autoHighlight
+          >
+            <div className="path-to-victory__search">
+              <Combobox.Input
+                placeholder="Search players..."
+                aria-label="Player"
+                className="path-to-victory__input"
+              />
+              <Combobox.Icon className="path-to-victory__input-icon">
+                <UnfoldMoreIcon />
+              </Combobox.Icon>
+            </div>
+            <Combobox.Portal>
+              <Combobox.Positioner
+                className="path-to-victory__positioner"
+                sideOffset={4}
+              >
+                <Combobox.Popup className="path-to-victory__list">
+                  <Combobox.Empty className="path-to-victory__empty">
+                    No player by that name.
+                  </Combobox.Empty>
+                  <Combobox.List>
+                    {(name: string) => (
+                      <Combobox.Item
+                        key={name}
+                        value={name}
+                        className="path-to-victory__option"
+                      >
+                        {name}
+                      </Combobox.Item>
+                    )}
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>
+
+          <div className="path-to-victory__body">
+            <VictorySummary result={result} />
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/pathToVictory/PathToVictoryDialog.tsx
+++ b/src/components/pathToVictory/PathToVictoryDialog.tsx
@@ -2,24 +2,38 @@ import { Combobox } from "@base-ui-components/react/combobox";
 import { Dialog } from "@base-ui-components/react/dialog";
 import { useMemo, useState } from "react";
 import { RakMadnessScores } from "../../types/RakMadnessScores";
+import getClasses from "../../utils/getClasses";
 import getPathsToVictory from "../../utils/scoring/getPathsToVictory";
 import Button from "../button/Button";
-import { CloseRoundedIcon, UnfoldMoreIcon } from "../icon/Icon";
+import { CloseRoundedIcon, SkullIcon, UnfoldMoreIcon } from "../icon/Icon";
 import VictorySummary from "./VictorySummary";
 import "./PathToVictoryDialog.scss";
 
-/**
- * The players worth asking about: the ones who can still win it.
- *
- * A knocked out player has no route to offer, so listing them would only ever be
- * offering an answer of "no".
- */
-export function eligiblePlayers(scores?: RakMadnessScores): Array<string> {
+export type PlayerOption = { name: string; isKnockedOut: boolean };
+
+export function playerOptions(scores?: RakMadnessScores): Array<PlayerOption> {
   return (
-    scores?.scores
-      .filter((player) => !player.status.isKnockedOut)
-      .map((player) => player.name) ?? []
+    scores?.scores.map((player) => ({
+      name: player.name,
+      isKnockedOut: player.status.isKnockedOut,
+    })) ?? []
   );
+}
+
+/**
+ * The players a query offers. A knocked out one is held back while anyone still
+ * standing answers to the same letters, since their only answer is "no".
+ */
+export function playersMatching(
+  options: Array<PlayerOption>,
+  query: string,
+): Array<PlayerOption> {
+  const needle = query.trim().toLowerCase();
+  const matches = options.filter((option) =>
+    option.name.toLowerCase().includes(needle),
+  );
+  const standing = matches.filter((option) => !option.isKnockedOut);
+  return standing.length > 0 ? standing : matches;
 }
 
 /**
@@ -38,15 +52,18 @@ export default function PathToVictoryDialog({
   onOpenChange: (open: boolean) => void;
   scores?: RakMadnessScores;
 }) {
-  const [player, setPlayer] = useState<string | null>(null);
+  const [player, setPlayer] = useState<PlayerOption>();
+  const [query, setQuery] = useState("");
 
-  const names = useMemo(() => eligiblePlayers(scores), [scores]);
+  // Held still between renders, since the combobox reads the chosen player back
+  // off this list by identity.
+  const options = useMemo(() => playerOptions(scores), [scores]);
   // The search is thousands of scenarios, so it runs on the player chosen rather
   // than on every render of the dialog around them.
   const result = useMemo(
     () =>
       scores != null && player != null
-        ? getPathsToVictory(scores, player)
+        ? getPathsToVictory(scores, player.name)
         : undefined,
     [scores, player],
   );
@@ -71,9 +88,16 @@ export default function PathToVictoryDialog({
           </header>
 
           <Combobox.Root
-            items={names}
-            value={player}
-            onValueChange={setPlayer}
+            items={options}
+            filteredItems={playersMatching(options, query)}
+            itemToStringLabel={(option: PlayerOption) => option.name}
+            // The combobox keeps the choice itself. Naming it here as well would
+            // hand it a value it started without, which it reads as a controlled
+            // input arriving late.
+            onValueChange={(chosen: PlayerOption | null) =>
+              setPlayer(chosen ?? undefined)
+            }
+            onInputValueChange={setQuery}
             // The list is short and already on screen, so the first match being
             // highlighted saves an arrow key before Enter.
             autoHighlight
@@ -98,13 +122,17 @@ export default function PathToVictoryDialog({
                     No player by that name.
                   </Combobox.Empty>
                   <Combobox.List>
-                    {(name: string) => (
+                    {(option: PlayerOption) => (
                       <Combobox.Item
-                        key={name}
-                        value={name}
-                        className="path-to-victory__option"
+                        key={option.name}
+                        value={option}
+                        disabled={option.isKnockedOut}
+                        className={`path-to-victory__option ${getClasses({
+                          "--eliminated": option.isKnockedOut,
+                        })}`}
                       >
-                        {name}
+                        {option.name}
+                        {option.isKnockedOut && <SkullIcon />}
                       </Combobox.Item>
                     )}
                   </Combobox.List>

--- a/src/components/pathToVictory/VictorySummary.scss
+++ b/src/components/pathToVictory/VictorySummary.scss
@@ -41,7 +41,7 @@
 // One pick reads as a chip of two halves: which game, then what to back in it.
 .victory__pick {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 6px;
   padding: 4px 8px;
   border-radius: var(--rak-radius-sm);
@@ -53,7 +53,6 @@
 
 .victory__pick-label {
   color: var(--rak-text-tertiary);
-  font-size: 0.75rem;
   font-weight: 700;
 }
 

--- a/src/components/pathToVictory/VictorySummary.scss
+++ b/src/components/pathToVictory/VictorySummary.scss
@@ -1,13 +1,10 @@
+// Whatever the answer turns out to be, it plays in under a dialog already growing
+// to hold it.
 .victory {
   display: flex;
   flex-direction: column;
   gap: 16px;
-}
 
-// Whichever of the two the answer turns out to be, it plays in under a dialog
-// already growing to hold it.
-.victory,
-.victory__message {
   @media (prefers-reduced-motion: no-preference) {
     animation: victory-in 220ms ease both;
   }
@@ -20,10 +17,11 @@
   }
 }
 
-.victory__standing {
+.victory__note {
   margin: 0;
   color: var(--rak-text-tertiary);
   font-size: 0.875rem;
+  font-style: italic;
 }
 
 .victory__section {
@@ -32,6 +30,7 @@
   gap: 8px;
 }
 
+.victory__standing,
 .victory__section-title {
   margin: 0;
   color: var(--rak-text-tertiary);
@@ -87,9 +86,6 @@
 
 .victory__route,
 .victory__must-win {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
   padding: 8px 10px;
   // Drawn on the left alone, so a stack of routes reads as a list of alternatives
   // rather than as a stack of boxes.
@@ -97,10 +93,16 @@
   background-color: var(--rak-level1);
 }
 
-// Green against the routes' gold, since these games are what has to happen
-// rather than one way among several of getting there.
+.victory__route {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+// Red against the routes' gold, since these games are what has to happen rather
+// than one way among several of getting there.
 .victory__must-win {
-  border-inline-start-color: var(--rak-success-500);
+  border-inline-start-color: var(--rak-danger-500);
 }
 
 // A soft button takes the color around it, so the gold is set here rather than by
@@ -126,16 +128,8 @@
   font-size: 0.875rem;
 }
 
-// No padding of its own, so it starts where a summary of routes would.
 .victory__message {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-}
-
-.victory__heading {
-  margin: 0;
-  color: var(--rak-text);
-  font-size: 0.9375rem;
-  font-weight: 600;
+  gap: 8px;
 }

--- a/src/components/pathToVictory/VictorySummary.scss
+++ b/src/components/pathToVictory/VictorySummary.scss
@@ -77,8 +77,12 @@
   background-color: var(--rak-level1);
 }
 
+// A soft button takes the color around it, so the gold is set here rather than by
+// the color prop, which only paints a solid fill.
 .victory__more {
   align-self: flex-start;
+  color: var(--rak-gold-700);
+  font-weight: 700;
 }
 
 .victory__help {

--- a/src/components/pathToVictory/VictorySummary.scss
+++ b/src/components/pathToVictory/VictorySummary.scss
@@ -4,6 +4,22 @@
   gap: 16px;
 }
 
+// Whichever of the two the answer turns out to be, it plays in under a dialog
+// already growing to hold it.
+.victory,
+.victory__message {
+  @media (prefers-reduced-motion: no-preference) {
+    animation: victory-in 220ms ease both;
+  }
+}
+
+@keyframes victory-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+
 .victory__standing {
   margin: 0;
   color: var(--rak-text-tertiary);
@@ -69,7 +85,8 @@
   list-style: none;
 }
 
-.victory__route {
+.victory__route,
+.victory__must-win {
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -78,6 +95,12 @@
   // rather than as a stack of boxes.
   border-inline-start: var(--rak-border-width) solid var(--rak-gold-500);
   background-color: var(--rak-level1);
+}
+
+// Green against the routes' gold, since these games are what has to happen
+// rather than one way among several of getting there.
+.victory__must-win {
+  border-inline-start-color: var(--rak-success-500);
 }
 
 // A soft button takes the color around it, so the gold is set here rather than by

--- a/src/components/pathToVictory/VictorySummary.scss
+++ b/src/components/pathToVictory/VictorySummary.scss
@@ -1,0 +1,107 @@
+.victory {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.victory__standing {
+  margin: 0;
+  color: var(--rak-text-tertiary);
+  font-size: 0.875rem;
+}
+
+.victory__section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.victory__section-title {
+  margin: 0;
+  color: var(--rak-text-tertiary);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.victory__picks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+// One pick reads as a chip of two halves: which game, then what to back in it.
+.victory__pick {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: var(--rak-radius-sm);
+  background-color: var(--rak-level1);
+  font-size: 0.875rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.victory__pick-label {
+  color: var(--rak-text-tertiary);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.victory__pick-team {
+  color: var(--rak-text);
+}
+
+.victory__routes {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.victory__route {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  // Drawn on the left alone, so a stack of routes reads as a list of alternatives
+  // rather than as a stack of boxes.
+  border-inline-start: var(--rak-border-width) solid var(--rak-gold-500);
+  background-color: var(--rak-level1);
+}
+
+.victory__help {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.victory__line {
+  margin: 0;
+  color: var(--rak-text-secondary);
+  font-size: 0.875rem;
+}
+
+.victory__message {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px 0;
+}
+
+.victory__heading {
+  margin: 0;
+  color: var(--rak-text);
+  font-size: 1rem;
+  font-weight: 600;
+}

--- a/src/components/pathToVictory/VictorySummary.scss
+++ b/src/components/pathToVictory/VictorySummary.scss
@@ -29,7 +29,9 @@
 // every route. Each list is the same width, so each divides the same way.
 .victory__picks {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  // The floor is what the longest pick a sheet can hold measures, so a column
+  // never has to cut one short or wrap it.
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
   gap: 6px;
   margin: 0;
   padding: 0;
@@ -40,8 +42,8 @@
 .victory__pick {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 4px 10px;
+  gap: 6px;
+  padding: 4px 8px;
   border-radius: var(--rak-radius-sm);
   background-color: var(--rak-level1);
   font-size: 0.875rem;

--- a/src/components/pathToVictory/VictorySummary.scss
+++ b/src/components/pathToVictory/VictorySummary.scss
@@ -126,16 +126,16 @@
   font-size: 0.875rem;
 }
 
+// No padding of its own, so it starts where a summary of routes would.
 .victory__message {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 16px 0;
 }
 
 .victory__heading {
   margin: 0;
   color: var(--rak-text);
-  font-size: 1rem;
+  font-size: 0.9375rem;
   font-weight: 600;
 }

--- a/src/components/pathToVictory/VictorySummary.scss
+++ b/src/components/pathToVictory/VictorySummary.scss
@@ -77,6 +77,10 @@
   background-color: var(--rak-level1);
 }
 
+.victory__more {
+  align-self: flex-start;
+}
+
 .victory__help {
   display: flex;
   flex-direction: column;

--- a/src/components/pathToVictory/VictorySummary.scss
+++ b/src/components/pathToVictory/VictorySummary.scss
@@ -25,10 +25,12 @@
   text-transform: uppercase;
 }
 
+// Columns rather than a wrapping row, so the same game sits at the same x down
+// every route. Each list is the same width, so each divides the same way.
 .victory__picks {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 6px;
   margin: 0;
   padding: 0;
   list-style: none;

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -279,7 +279,7 @@ describe("VictorySummary", () => {
       "P1KC -3",
       "P2BUF -1P3SF -6MNF points ≤ 32 to beat Rak.",
     ]);
-    const note = screen.getByText("2 other routes worked out but not shown.");
+    const note = screen.getByText("2 other routes found but not shown.");
     expect(note).toBe(document.querySelector(".victory")?.lastElementChild);
   });
 

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -124,7 +124,7 @@ describe("VictorySummary", () => {
 
     expect(
       screen.getByText(
-        "Needs a Monday night total between 38 and 44 to beat Rak and Bill.",
+        "Monday night total between 38 and 44 to beat Rak and Bill.",
       ),
     ).toBeInTheDocument();
   });
@@ -138,7 +138,7 @@ describe("VictorySummary", () => {
     render(<VictorySummary result={result} />);
 
     expect(
-      screen.getByText("Needs a Monday night total of 45 or less to beat Rak."),
+      screen.getByText("Monday night total of 45 or less to beat Rak."),
     ).toBeInTheDocument();
   });
 
@@ -207,7 +207,7 @@ describe("VictorySummary", () => {
     const routes = [...document.querySelectorAll(".victory__route")];
     expect(routes.map((route) => route.textContent)).toEqual([
       "P1KC -3",
-      "P2BUF -1P3SF -6Needs a Monday night total of 32 or less to beat Rak.",
+      "P2BUF -1P3SF -6Monday night total of 32 or less to beat Rak.",
     ]);
     expect(screen.getByText("2 other routes not shown.")).toBeInTheDocument();
   });

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PathsToVictory, VictoryRoute } from "../../types/PathsToVictory";
-import VictorySummary from "./VictorySummary";
+import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
+import VictorySummary, { Standing } from "./VictorySummary";
 
 /** Routes of one game each, all different, so only their number matters. */
 function routesOf(count: number): Array<VictoryRoute> {
@@ -29,6 +30,47 @@ const base = {
   hiddenRouteCount: 0,
   needsHelp: [],
 };
+
+describe("Standing", () => {
+  function player(name: string, total: number, pick: string): PlayerScore {
+    return {
+      name,
+      score: { total, college: 0, pro: total, proAgainstTheSpread: 0 },
+      tiebreaker: {},
+      college: [],
+      pro: [
+        {
+          pick,
+          status: "incomplete",
+          explanation: { header: "", message: "" },
+        },
+      ],
+      status: { hasNoPicks: false, isKnockedOut: false },
+    };
+  }
+
+  const scores: RakMadnessScores = {
+    scores: [player("Rak", 3, "KC -3"), player("Alice", 1, "DEN +3")],
+  };
+
+  it("names the leader before anyone is picked", () => {
+    render(<Standing scores={scores} />);
+
+    expect(screen.getByText("Rak leads · 1 game still to play"));
+  });
+
+  it("counts the player picked back to the leader", () => {
+    render(<Standing scores={scores} player="Alice" />);
+
+    expect(screen.getByText("2 points behind Rak · 1 game still to play"));
+  });
+
+  it("has nothing to say before a week is scored", () => {
+    const { container } = render(<Standing />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
 
 describe("VictorySummary", () => {
   it("says nothing until a player is picked", () => {
@@ -74,15 +116,6 @@ describe("VictorySummary", () => {
       screen.getByText("Alice needs at least 6 of their 13 remaining picks."),
     ).toBeInTheDocument();
     expect(screen.getByText(/MNF points tiebreaker/)).toBeInTheDocument();
-    expect(screen.getByText("14 games still to play")).toBeInTheDocument();
-  });
-
-  it("shows how far back the player is and what is left to play", () => {
-    render(<VictorySummary result={{ ...base, mustWin: [] }} />);
-
-    expect(
-      screen.getByText("2 points behind Rak · 4 games still to play"),
-    ).toBeInTheDocument();
   });
 
   it("lists the must-win games and the pool behind them", () => {
@@ -150,7 +183,7 @@ describe("VictorySummary", () => {
     render(<VictorySummary result={result} />);
 
     expect(
-      screen.getByText("Winning 3 games takes it outright."),
+      screen.getByText("Winning 3 games takes it outright. Otherwise:"),
     ).toBeInTheDocument();
   });
 
@@ -162,9 +195,7 @@ describe("VictorySummary", () => {
     };
     render(<VictorySummary result={result} />);
 
-    const outright = screen.getByText(
-      "Takes the week outright, whatever the MNF points come to.",
-    );
+    const outright = screen.getByText(/Takes the week outright/);
     const mustWin = screen.getByRole("heading", { name: "Must win" });
     expect(
       outright.compareDocumentPosition(mustWin) &

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -73,7 +73,7 @@ describe("VictorySummary", () => {
     expect(
       screen.getByText("Alice needs at least 6 of their 13 remaining picks."),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Monday night tiebreaker/)).toBeInTheDocument();
+    expect(screen.getByText(/MNF points tiebreaker/)).toBeInTheDocument();
     expect(screen.getByText("14 games still to play")).toBeInTheDocument();
   });
 
@@ -123,9 +123,7 @@ describe("VictorySummary", () => {
     render(<VictorySummary result={result} />);
 
     expect(
-      screen.getByText(
-        "Monday night total between 38 and 44 to beat Rak and Bill.",
-      ),
+      screen.getByText("38 ≤ MNF points ≤ 44 to beat Rak and Bill."),
     ).toBeInTheDocument();
   });
 
@@ -138,7 +136,7 @@ describe("VictorySummary", () => {
     render(<VictorySummary result={result} />);
 
     expect(
-      screen.getByText("Monday night total of 45 or less to beat Rak."),
+      screen.getByText("MNF points ≤ 45 to beat Rak."),
     ).toBeInTheDocument();
   });
 
@@ -207,7 +205,7 @@ describe("VictorySummary", () => {
     const routes = [...document.querySelectorAll(".victory__route")];
     expect(routes.map((route) => route.textContent)).toEqual([
       "P1KC -3",
-      "P2BUF -1P3SF -6Monday night total of 32 or less to beat Rak.",
+      "P2BUF -1P3SF -6MNF points ≤ 32 to beat Rak.",
     ]);
     expect(screen.getByText("2 other routes not shown.")).toBeInTheDocument();
   });

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -283,6 +283,28 @@ describe("VictorySummary", () => {
     expect(note).toBe(document.querySelector(".victory")?.lastElementChild);
   });
 
+  it("states a total every route shares once, not on each of them", () => {
+    const shared = { kind: "range" as const, max: 32, contenders: ["Rak"] };
+    const result: PathsToVictory = {
+      ...base,
+      routes: [
+        { games: [{ label: "P1", pick: "KC -3" }], mondayNight: shared },
+        { games: [{ label: "P2", pick: "BUF -1" }], mondayNight: shared },
+      ],
+      mondayNight: shared,
+    };
+    render(<VictorySummary result={result} />);
+
+    const routes = [...document.querySelectorAll(".victory__route")];
+    expect(routes.map((route) => route.textContent)).toEqual([
+      "P1KC -3",
+      "P2BUF -1",
+    ]);
+    expect(
+      screen.getByText("MNF points ≤ 32 to beat Rak."),
+    ).toBeInTheDocument();
+  });
+
   it("holds four routes open and folds the rest behind a button", () => {
     const result: PathsToVictory = { ...base, routes: routesOf(8) };
     render(<VictorySummary result={result} />);

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -53,16 +53,31 @@ describe("Standing", () => {
     scores: [player("Rak", 3, "KC -3"), player("Alice", 1, "DEN +3")],
   };
 
-  it("names the leader before anyone is picked", () => {
+  it("names the leader and their score before anyone is picked", () => {
     render(<Standing scores={scores} />);
 
-    expect(screen.getByText("Rak leads · 1 game still to play"));
+    expect(
+      screen.getByText("Rak leads with 3 points · 1 game still to play"),
+    ).toBeInTheDocument();
+  });
+
+  it("counts the leaders where the top is shared", () => {
+    const tied: RakMadnessScores = {
+      scores: [...scores.scores, player("Bill", 3, "KC -3")],
+    };
+    render(<Standing scores={tied} />);
+
+    expect(
+      screen.getByText("2 players lead with 3 points · 1 game still to play"),
+    ).toBeInTheDocument();
   });
 
   it("counts the player picked back to the leader", () => {
     render(<Standing scores={scores} player="Alice" />);
 
-    expect(screen.getByText("2 points behind Rak · 1 game still to play"));
+    expect(
+      screen.getByText("2 points behind Rak · 1 game still to play"),
+    ).toBeInTheDocument();
   });
 
   it("has nothing to say before a week is scored", () => {

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -23,28 +23,25 @@ function under(title: string): Array<string> {
 const base = {
   kind: "paths" as const,
   player: "Alice",
-  remainingGameCount: 4,
-  pointsBehind: 2,
-  leader: "Rak",
   mustWin: [],
   hiddenRouteCount: 0,
   needsHelp: [],
 };
 
 describe("Standing", () => {
+  /** One game already settled and one still open, which is a week under way. */
   function player(name: string, total: number, pick: string): PlayerScore {
+    const result = (status: PlayerScore["pro"][number]["status"]) => ({
+      pick,
+      status,
+      explanation: { header: "", message: "" },
+    });
     return {
       name,
       score: { total, college: 0, pro: total, proAgainstTheSpread: 0 },
       tiebreaker: {},
       college: [],
-      pro: [
-        {
-          pick,
-          status: "incomplete",
-          explanation: { header: "", message: "" },
-        },
-      ],
+      pro: [result("yes"), result("incomplete")],
       status: { hasNoPicks: false, isKnockedOut: false },
     };
   }
@@ -88,6 +85,21 @@ describe("Standing", () => {
     ).toBeInTheDocument();
   });
 
+  it("names no leader before a game has been played", () => {
+    const fresh: RakMadnessScores = {
+      scores: scores.scores.map((it) => ({
+        ...it,
+        score: { total: 0, college: 0, pro: 0, proAgainstTheSpread: 0 },
+        pro: it.pro.map((pick) => ({ ...pick, status: "incomplete" as const })),
+      })),
+    };
+    render(<Standing scores={fresh} />);
+
+    expect(
+      screen.getByText("No finished games · 2 games still to play"),
+    ).toBeInTheDocument();
+  });
+
   it("has nothing to say before a week is scored", () => {
     const { container } = render(<Standing />);
 
@@ -128,7 +140,6 @@ describe("VictorySummary", () => {
     const result: PathsToVictory = {
       kind: "headline",
       player: "Alice",
-      remainingGameCount: 14,
       remainingPickCount: 13,
       minimumWins: 6,
       needsMondayNight: true,
@@ -167,6 +178,20 @@ describe("VictorySummary", () => {
       "P9BUF +1",
       "P11SF -6",
     ]);
+  });
+
+  it("says something for a player the games can no longer separate", () => {
+    const result: PathsToVictory = {
+      ...base,
+      mondayNight: { kind: "range", max: 45, contenders: ["Rak"] },
+    };
+    render(<VictorySummary result={result} />);
+
+    expect(
+      screen.getByText(
+        "No clean path to victory. The MNF points tiebreaker decides it.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("writes a bounded Monday night range as a sentence", () => {

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -80,6 +80,14 @@ describe("Standing", () => {
     ).toBeInTheDocument();
   });
 
+  it("ties the player picked to the lead where they hold it", () => {
+    render(<Standing scores={scores} player="Rak" />);
+
+    expect(
+      screen.getByText("Tied for the lead · 1 game still to play"),
+    ).toBeInTheDocument();
+  });
+
   it("has nothing to say before a week is scored", () => {
     const { container } = render(<Standing />);
 

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -124,7 +124,7 @@ describe("VictorySummary", () => {
     ).toBeInTheDocument();
   });
 
-  it("gives a floor rather than routes on a week too big to search", () => {
+  it("gives a floor rather than paths on a week too big to search", () => {
     const result: PathsToVictory = {
       kind: "headline",
       player: "Alice",
@@ -139,6 +139,10 @@ describe("VictorySummary", () => {
       screen.getByText("Alice needs at least 6 of their 13 remaining picks."),
     ).toBeInTheDocument();
     expect(screen.getByText(/MNF points tiebreaker/)).toBeInTheDocument();
+    const why = screen.getByText(
+      "Detailed paths are worked out once ten games are left.",
+    );
+    expect(why).toBe(document.querySelector(".victory")?.lastElementChild);
   });
 
   it("lists the must-win games and the pool behind them", () => {

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -279,7 +279,7 @@ describe("VictorySummary", () => {
       "P1KC -3",
       "P2BUF -1P3SF -6MNF points ≤ 32 to beat Rak.",
     ]);
-    const note = screen.getByText("2 other routes found but not shown.");
+    const note = screen.getByText("2 other paths found but not shown.");
     expect(note).toBe(document.querySelector(".victory")?.lastElementChild);
   });
 
@@ -311,7 +311,7 @@ describe("VictorySummary", () => {
 
     expect(document.querySelectorAll(".victory__route")).toHaveLength(4);
     expect(
-      screen.getByRole("button", { name: "Show 4 more routes" }),
+      screen.getByRole("button", { name: "Show 4 more paths" }),
     ).toBeInTheDocument();
   });
 

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -1,0 +1,205 @@
+import { render, screen, within } from "@testing-library/react";
+import { PathsToVictory } from "../../types/PathsToVictory";
+import VictorySummary from "./VictorySummary";
+
+/** The picks under a heading, as the chips read on screen. */
+function under(title: string): Array<string> {
+  const heading = screen.getByRole("heading", { name: title });
+  return within(heading.parentElement as HTMLElement)
+    .getAllByRole("listitem")
+    .map((item) => item.textContent ?? "");
+}
+
+const base = {
+  kind: "paths" as const,
+  player: "Alice",
+  remainingGameCount: 4,
+  pointsBehind: 2,
+  leader: "Rak",
+  mustWin: [],
+  hiddenRouteCount: 0,
+  needsHelp: [],
+};
+
+describe("VictorySummary", () => {
+  it("asks for a player when it has no result yet", () => {
+    render(<VictorySummary />);
+
+    expect(screen.getByText("Pick a player")).toBeInTheDocument();
+  });
+
+  it("gives an eliminated player the reason they carry", () => {
+    const result: PathsToVictory = {
+      kind: "eliminated",
+      player: "Bob",
+      explanation: "Knocked out on Total Score by Alice.",
+    };
+    render(<VictorySummary result={result} />);
+
+    expect(screen.getByText("Bob cannot win this week.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Knocked out on Total Score by Alice."),
+    ).toBeInTheDocument();
+  });
+
+  it("says a clinched week is already won", () => {
+    render(<VictorySummary result={{ kind: "clinched", player: "Alice" }} />);
+
+    expect(
+      screen.getByText("Alice has already won the week."),
+    ).toBeInTheDocument();
+  });
+
+  it("gives a floor rather than routes on a week too big to search", () => {
+    const result: PathsToVictory = {
+      kind: "headline",
+      player: "Alice",
+      remainingGameCount: 14,
+      remainingPickCount: 13,
+      minimumWins: 6,
+      needsMondayNight: true,
+    };
+    render(<VictorySummary result={result} />);
+
+    expect(
+      screen.getByText("Alice needs at least 6 of their 13 remaining picks."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Monday night tiebreaker/)).toBeInTheDocument();
+    expect(screen.getByText("14 games still to play")).toBeInTheDocument();
+  });
+
+  it("shows how far back the player is and what is left to play", () => {
+    render(<VictorySummary result={{ ...base, mustWin: [] }} />);
+
+    expect(
+      screen.getByText("2 points behind Rak · 4 games still to play"),
+    ).toBeInTheDocument();
+  });
+
+  it("lists the must-win games and the pool behind them", () => {
+    const result: PathsToVictory = {
+      ...base,
+      mustWin: [{ label: "C4", pick: "UGA -7" }],
+      pool: {
+        choose: 2,
+        games: [
+          { label: "P2", pick: "KC -3" },
+          { label: "P9", pick: "BUF +1" },
+          { label: "P11", pick: "SF -6" },
+        ],
+      },
+      mondayNight: { kind: "notNeeded" },
+    };
+    render(<VictorySummary result={result} />);
+
+    expect(under("Must win")).toEqual(["C4UGA -7"]);
+    expect(under("Then any 2 of these")).toEqual([
+      "P2KC -3",
+      "P9BUF +1",
+      "P11SF -6",
+    ]);
+  });
+
+  it("writes a bounded Monday night range as a sentence", () => {
+    const result: PathsToVictory = {
+      ...base,
+      mustWin: [{ label: "P1", pick: "KC -3" }],
+      mondayNight: {
+        kind: "range",
+        min: 38,
+        max: 44,
+        contenders: ["Rak", "Bill"],
+      },
+    };
+    render(<VictorySummary result={result} />);
+
+    expect(
+      screen.getByText(
+        "Needs a Monday night total between 38 and 44 to beat Rak and Bill.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("writes an open-ended range from the end it is bounded on", () => {
+    const result: PathsToVictory = {
+      ...base,
+      mustWin: [{ label: "P1", pick: "KC -3" }],
+      mondayNight: { kind: "range", max: 45, contenders: ["Rak"] },
+    };
+    render(<VictorySummary result={result} />);
+
+    expect(
+      screen.getByText("Needs a Monday night total of 45 or less to beat Rak."),
+    ).toBeInTheDocument();
+  });
+
+  it("says what it takes to win without the tiebreaker at all", () => {
+    const result: PathsToVictory = {
+      ...base,
+      pool: { choose: 2, games: [{ label: "P1", pick: "KC -3" }] },
+      outrightAt: 3,
+      mondayNight: { kind: "range", max: 45, contenders: ["Rak"] },
+    };
+    render(<VictorySummary result={result} />);
+
+    expect(
+      screen.getByText("Winning 3 games instead takes it outright."),
+    ).toBeInTheDocument();
+  });
+
+  it("leaves the outright line off where it asks no more than the routes do", () => {
+    const result: PathsToVictory = {
+      ...base,
+      mustWin: [{ label: "P1", pick: "KC -3" }],
+      outrightAt: 1,
+      mondayNight: { kind: "notNeeded" },
+    };
+    render(<VictorySummary result={result} />);
+
+    expect(screen.queryByText(/takes it outright/)).not.toBeInTheDocument();
+  });
+
+  it("names the team that has to miss in a game the player left blank", () => {
+    const result: PathsToVictory = {
+      ...base,
+      mustWin: [{ label: "P1", pick: "KC -3" }],
+      needsHelp: [{ label: "P7", needsToMiss: ["DEN"] }],
+      mondayNight: { kind: "notNeeded" },
+    };
+    render(<VictorySummary result={result} />);
+
+    expect(
+      screen.getByText(/is blank on your sheet, so DEN has to miss/),
+    ).toBeInTheDocument();
+  });
+
+  it("lists routes of different shapes with the ones that need a total marked", () => {
+    const result: PathsToVictory = {
+      ...base,
+      routes: [
+        {
+          games: [{ label: "P1", pick: "KC -3" }],
+          mondayNight: { kind: "notNeeded" },
+        },
+        {
+          games: [
+            { label: "P2", pick: "BUF -1" },
+            { label: "P3", pick: "SF -6" },
+          ],
+          mondayNight: { kind: "range", max: 32, contenders: ["Rak"] },
+        },
+      ],
+      hiddenRouteCount: 2,
+    };
+    render(<VictorySummary result={result} />);
+
+    // Read off the routes themselves, since each one holds a list of picks of
+    // its own and reading every list item at once would flatten the two apart.
+    const routes = [...document.querySelectorAll(".victory__route")];
+    expect(routes.map((route) => route.textContent)).toEqual([
+      "P1KC -3",
+      "P2BUF -1P3SF -6Needs a Monday night total of 32 or less to beat Rak.",
+    ]);
+    expect(screen.getByText("2 other routes not shown.")).toBeInTheDocument();
+  });
+});

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -31,10 +31,10 @@ const base = {
 };
 
 describe("VictorySummary", () => {
-  it("asks for a player when it has no result yet", () => {
-    render(<VictorySummary />);
+  it("says nothing until a player is picked", () => {
+    const { container } = render(<VictorySummary />);
 
-    expect(screen.getByText("Pick a player")).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it("gives an eliminated player the reason they carry", () => {
@@ -154,6 +154,24 @@ describe("VictorySummary", () => {
     ).toBeInTheDocument();
   });
 
+  it("leads with taking the week outright, ahead of the games", () => {
+    const result: PathsToVictory = {
+      ...base,
+      mustWin: [{ label: "P1", pick: "KC -3" }],
+      mondayNight: { kind: "notNeeded" },
+    };
+    render(<VictorySummary result={result} />);
+
+    const outright = screen.getByText(
+      "Takes the week outright, whatever the MNF points come to.",
+    );
+    const mustWin = screen.getByRole("heading", { name: "Must win" });
+    expect(
+      outright.compareDocumentPosition(mustWin) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("leaves the outright line off where it asks no more than the routes do", () => {
     const result: PathsToVictory = {
       ...base,
@@ -210,13 +228,13 @@ describe("VictorySummary", () => {
     expect(screen.getByText("2 other routes not shown.")).toBeInTheDocument();
   });
 
-  it("holds five routes open and folds the rest behind a button", () => {
+  it("holds four routes open and folds the rest behind a button", () => {
     const result: PathsToVictory = { ...base, routes: routesOf(8) };
     render(<VictorySummary result={result} />);
 
-    expect(document.querySelectorAll(".victory__route")).toHaveLength(5);
+    expect(document.querySelectorAll(".victory__route")).toHaveLength(4);
     expect(
-      screen.getByRole("button", { name: "Show 3 more routes" }),
+      screen.getByRole("button", { name: "Show 4 more routes" }),
     ).toBeInTheDocument();
   });
 
@@ -232,7 +250,7 @@ describe("VictorySummary", () => {
   });
 
   it("leaves the button off where every route is already open", () => {
-    const result: PathsToVictory = { ...base, routes: routesOf(5) };
+    const result: PathsToVictory = { ...base, routes: routesOf(4) };
     render(<VictorySummary result={result} />);
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument();

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -279,7 +279,8 @@ describe("VictorySummary", () => {
       "P1KC -3",
       "P2BUF -1P3SF -6MNF points ≤ 32 to beat Rak.",
     ]);
-    expect(screen.getByText("2 other routes not shown.")).toBeInTheDocument();
+    const note = screen.getByText("2 other routes worked out but not shown.");
+    expect(note).toBe(document.querySelector(".victory")?.lastElementChild);
   });
 
   it("holds four routes open and folds the rest behind a button", () => {

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -150,7 +150,7 @@ describe("VictorySummary", () => {
     render(<VictorySummary result={result} />);
 
     expect(
-      screen.getByText("Winning 3 games instead takes it outright."),
+      screen.getByText("Winning 3 games takes it outright."),
     ).toBeInTheDocument();
   });
 

--- a/src/components/pathToVictory/VictorySummary.test.tsx
+++ b/src/components/pathToVictory/VictorySummary.test.tsx
@@ -1,6 +1,15 @@
 import { render, screen, within } from "@testing-library/react";
-import { PathsToVictory } from "../../types/PathsToVictory";
+import userEvent from "@testing-library/user-event";
+import { PathsToVictory, VictoryRoute } from "../../types/PathsToVictory";
 import VictorySummary from "./VictorySummary";
+
+/** Routes of one game each, all different, so only their number matters. */
+function routesOf(count: number): Array<VictoryRoute> {
+  return Array.from({ length: count }, (_, index) => ({
+    games: [{ label: `P${index + 1}`, pick: `T${index + 1} -3` }],
+    mondayNight: { kind: "notNeeded" as const },
+  }));
+}
 
 /** The picks under a heading, as the chips read on screen. */
 function under(title: string): Array<string> {
@@ -201,5 +210,33 @@ describe("VictorySummary", () => {
       "P2BUF -1P3SF -6Needs a Monday night total of 32 or less to beat Rak.",
     ]);
     expect(screen.getByText("2 other routes not shown.")).toBeInTheDocument();
+  });
+
+  it("holds five routes open and folds the rest behind a button", () => {
+    const result: PathsToVictory = { ...base, routes: routesOf(8) };
+    render(<VictorySummary result={result} />);
+
+    expect(document.querySelectorAll(".victory__route")).toHaveLength(5);
+    expect(
+      screen.getByRole("button", { name: "Show 3 more routes" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the rest once the button is clicked", async () => {
+    const result: PathsToVictory = { ...base, routes: routesOf(8) };
+    render(<VictorySummary result={result} />);
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(document.querySelectorAll(".victory__route")).toHaveLength(8);
+    expect(
+      screen.getByRole("button", { name: "Show fewer" }),
+    ).toBeInTheDocument();
+  });
+
+  it("leaves the button off where every route is already open", () => {
+    const result: PathsToVictory = { ...base, routes: routesOf(5) };
+    render(<VictorySummary result={result} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 });

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -10,7 +10,7 @@ import Button from "../button/Button";
 import "./VictorySummary.scss";
 
 /** How many routes stand open, the rest being a click away. */
-const ROUTES_SHOWN_AT_FIRST = 5;
+const ROUTES_SHOWN_AT_FIRST = 4;
 
 const NAMES = new Intl.ListFormat("en-US");
 
@@ -60,7 +60,11 @@ function mondayNightSentence(outlook: MondayNightOutlook): string | null {
   return `${points} to beat ${NAMES.format(outlook.contenders)}.`;
 }
 
-function MondayNight({
+/**
+ * Winning the week on points alone leads, since it settles the tiebreaker before
+ * the reader has to think about it.
+ */
+function Outright({
   outlook,
   outrightAt,
   minimumWins,
@@ -69,17 +73,32 @@ function MondayNight({
   outrightAt?: number;
   minimumWins: number;
 }) {
-  const sentence = outlook != null ? mondayNightSentence(outlook) : null;
-  // Only worth saying where it asks for more than the routes above already do.
-  const outright =
+  const lines = [
+    outlook?.kind === "notNeeded"
+      ? "Takes the week outright, whatever the MNF points come to."
+      : null,
+    // Only worth saying where it asks for more than the routes below already do.
     outrightAt != null && outrightAt > minimumWins
       ? `Winning ${plural(outrightAt, "game")} instead takes it outright.`
+      : null,
+  ].filter((line) => line != null);
+  if (lines.length === 0) return null;
+  return lines.map((line) => (
+    <p key={line} className="victory__line">
+      {line}
+    </p>
+  ));
+}
+
+function MondayNight({ outlook }: { outlook?: MondayNightOutlook }) {
+  const sentence =
+    outlook != null && outlook.kind !== "notNeeded"
+      ? mondayNightSentence(outlook)
       : null;
-  if (sentence == null && outright == null) return null;
+  if (sentence == null) return null;
   return (
     <Section title="MNF points">
-      {sentence && <p className="victory__line">{sentence}</p>}
-      {outright && <p className="victory__line">{outright}</p>}
+      <p className="victory__line">{sentence}</p>
     </Section>
   );
 }
@@ -165,14 +184,9 @@ export default function VictorySummary({
 }: {
   result?: PathsToVictory;
 }) {
-  if (result == null) {
-    return (
-      <Message
-        heading="Pick a player"
-        body="Search above for anyone who made picks this week."
-      />
-    );
-  }
+  // Nothing under the search until a name is picked, which the placeholder in it
+  // already asks for.
+  if (result == null) return null;
 
   if (result.kind === "eliminated") {
     return (
@@ -218,9 +232,17 @@ export default function VictorySummary({
 
   return (
     <div className="victory">
+      <Outright
+        outlook={result.mondayNight}
+        outrightAt={result.outrightAt}
+        minimumWins={minimumWins}
+      />
+
       {result.mustWin.length > 0 && (
         <Section title="Must win">
-          <Picks games={result.mustWin} />
+          <div className="victory__must-win">
+            <Picks games={result.mustWin} />
+          </div>
         </Section>
       )}
 
@@ -248,11 +270,7 @@ export default function VictorySummary({
       )}
 
       <NeedsHelp games={result.needsHelp} />
-      <MondayNight
-        outlook={result.mondayNight}
-        outrightAt={result.outrightAt}
-        minimumWins={minimumWins}
-      />
+      <MondayNight outlook={result.mondayNight} />
 
       <p className="victory__standing">
         {result.pointsBehind > 0

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -1,0 +1,228 @@
+import { ReactNode } from "react";
+import {
+  MondayNightOutlook,
+  PathsToVictory,
+  RemainingPick,
+  UncontrolledGame,
+} from "../../types/PathsToVictory";
+import "./VictorySummary.scss";
+
+function list(names: Array<string>): string {
+  if (names.length < 3) return names.join(" and ");
+  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="victory__section">
+      <h3 className="victory__section-title">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function Picks({ games }: { games: Array<RemainingPick> }) {
+  return (
+    <ul className="victory__picks">
+      {games.map((game) => (
+        <li key={game.label} className="victory__pick">
+          <span className="victory__pick-label">{game.label}</span>
+          <span className="victory__pick-team">{game.pick}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** The totals that win, written the way someone would say them. */
+function mondayNightSentence(outlook: MondayNightOutlook): string | null {
+  if (outlook.kind === "settled") {
+    return "Monday night is already final, so the games above settle it.";
+  }
+  if (outlook.kind === "notNeeded") {
+    return "Takes the week outright, whatever Monday night comes to.";
+  }
+  const { min, max } = outlook;
+  const total =
+    min != null && max != null
+      ? `between ${min} and ${max}`
+      : min != null
+        ? `of ${min} or more`
+        : `of ${max} or less`;
+  return `Needs a Monday night total ${total} to beat ${list(outlook.contenders)}.`;
+}
+
+function MondayNight({
+  outlook,
+  outrightAt,
+  minimumWins,
+}: {
+  outlook?: MondayNightOutlook;
+  outrightAt?: number;
+  minimumWins: number;
+}) {
+  const sentence = outlook != null ? mondayNightSentence(outlook) : null;
+  // Only worth saying where it asks for more than the routes above already do.
+  const outright =
+    outrightAt != null && outrightAt > minimumWins
+      ? `Winning ${plural(outrightAt, "game")} instead takes it outright.`
+      : null;
+  if (sentence == null && outright == null) return null;
+  return (
+    <Section title="Monday night">
+      {sentence && <p className="victory__line">{sentence}</p>}
+      {outright && <p className="victory__line">{outright}</p>}
+    </Section>
+  );
+}
+
+function NeedsHelp({ games }: { games: Array<UncontrolledGame> }) {
+  if (games.length === 0) return null;
+  return (
+    <Section title="Out of your hands">
+      <ul className="victory__help">
+        {games.map((game) => (
+          <li key={game.label} className="victory__line">
+            <span className="victory__pick-label">{game.label}</span> is blank
+            on your sheet, so {list(game.needsToMiss)} has to miss.
+          </li>
+        ))}
+      </ul>
+    </Section>
+  );
+}
+
+function Message({ heading, body }: { heading: string; body?: string }) {
+  return (
+    <div className="victory__message">
+      <p className="victory__heading">{heading}</p>
+      {body && <p className="victory__line">{body}</p>}
+    </div>
+  );
+}
+
+/** What the player has to do, or why there is nothing left to do about it. */
+export default function VictorySummary({
+  result,
+}: {
+  result?: PathsToVictory;
+}) {
+  if (result == null) {
+    return (
+      <Message
+        heading="Pick a player"
+        body="Search above for anyone who made picks this week."
+      />
+    );
+  }
+
+  if (result.kind === "eliminated") {
+    return (
+      <Message
+        heading={`${result.player} cannot win this week.`}
+        body={result.explanation}
+      />
+    );
+  }
+
+  if (result.kind === "clinched") {
+    return (
+      <Message
+        heading={`${result.player} has already won the week.`}
+        body="Nothing still to be played can take it away."
+      />
+    );
+  }
+
+  if (result.kind === "headline") {
+    return (
+      <div className="victory">
+        <p className="victory__standing">
+          {plural(result.remainingGameCount, "game")} still to play
+        </p>
+        <Message
+          heading={`${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`}
+          body={
+            result.needsMondayNight
+              ? "That is only enough to draw level, so the Monday night tiebreaker would still decide it. The routes are worked out once twelve games are left."
+              : "The routes are worked out once twelve games are left."
+          }
+        />
+      </div>
+    );
+  }
+
+  const fromPool = result.pool?.choose ?? 0;
+  const fromRoutes = result.routes?.length
+    ? Math.min(...result.routes.map((route) => route.games.length))
+    : 0;
+  const minimumWins = result.mustWin.length + Math.max(fromPool, fromRoutes);
+
+  return (
+    <div className="victory">
+      <p className="victory__standing">
+        {result.pointsBehind > 0
+          ? `${plural(result.pointsBehind, "point")} behind ${result.leader}`
+          : "Level at the top"}
+        {" · "}
+        {plural(result.remainingGameCount, "game")} still to play
+      </p>
+
+      {result.mustWin.length > 0 && (
+        <Section title="Must win">
+          <Picks games={result.mustWin} />
+        </Section>
+      )}
+
+      {result.pool && (
+        <Section
+          title={`${result.mustWin.length > 0 ? "Then any" : "Any"} ${result.pool.choose} of these`}
+        >
+          <Picks games={result.pool.games} />
+        </Section>
+      )}
+
+      {result.routes && (
+        <Section title={result.mustWin.length > 0 ? "Then one of" : "One of"}>
+          <ol className="victory__routes">
+            {result.routes.map((route) => (
+              <li
+                key={route.games.map((game) => game.label).join()}
+                className="victory__route"
+              >
+                <Picks games={route.games} />
+                {route.mondayNight.kind === "range" && (
+                  <p className="victory__line">
+                    {mondayNightSentence(route.mondayNight)}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ol>
+          {result.hiddenRouteCount > 0 && (
+            <p className="victory__line">
+              {plural(result.hiddenRouteCount, "other route")} not shown.
+            </p>
+          )}
+        </Section>
+      )}
+
+      {result.mustWin.length === 0 && !result.pool && !result.routes && (
+        <p className="victory__line">
+          Nothing left to win. The tiebreaker below decides it.
+        </p>
+      )}
+
+      <NeedsHelp games={result.needsHelp} />
+      <MondayNight
+        outlook={result.mondayNight}
+        outrightAt={result.outrightAt}
+        minimumWins={minimumWins}
+      />
+    </div>
+  );
+}

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -40,22 +40,24 @@ function Picks({ games }: { games: Array<RemainingPick> }) {
   );
 }
 
-/** The totals that win, written the way someone would say them. */
+/** The MNF points that win, named the way the scoreboard column is. */
 function mondayNightSentence(outlook: MondayNightOutlook): string | null {
   if (outlook.kind === "settled") {
-    return "Monday night is already final, so the games above settle it.";
+    return "MNF points are already final, so the games above settle it.";
   }
   if (outlook.kind === "notNeeded") {
-    return "Takes the week outright, whatever Monday night comes to.";
+    return "Takes the week outright, whatever the MNF points come to.";
   }
   const { min, max } = outlook;
-  const total =
+  const points =
     min != null && max != null
-      ? `between ${min} and ${max}`
+      ? min === max
+        ? `MNF points = ${min}`
+        : `${min} ≤ MNF points ≤ ${max}`
       : min != null
-        ? `of ${min} or more`
-        : `of ${max} or less`;
-  return `Monday night total ${total} to beat ${NAMES.format(outlook.contenders)}.`;
+        ? `MNF points ≥ ${min}`
+        : `MNF points ≤ ${max}`;
+  return `${points} to beat ${NAMES.format(outlook.contenders)}.`;
 }
 
 function MondayNight({
@@ -75,7 +77,7 @@ function MondayNight({
       : null;
   if (sentence == null && outright == null) return null;
   return (
-    <Section title="Monday night">
+    <Section title="MNF points">
       {sentence && <p className="victory__line">{sentence}</p>}
       {outright && <p className="victory__line">{outright}</p>}
     </Section>
@@ -197,7 +199,7 @@ export default function VictorySummary({
           heading={`${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`}
           body={
             result.needsMondayNight
-              ? "That is only enough to draw level, so the Monday night tiebreaker would still decide it. The routes are worked out once ten games are left."
+              ? "That is only enough to draw level, so the MNF points tiebreaker would still decide it. The routes are worked out once ten games are left."
               : "The routes are worked out once ten games are left."
           }
         />

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -6,7 +6,7 @@ import {
   UncontrolledGame,
   VictoryRoute,
 } from "../../types/PathsToVictory";
-import { RakMadnessScores } from "../../types/RakMadnessScores";
+import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
 import remainingGames from "../../utils/scoring/remainingGames";
 import Button from "../button/Button";
 import "./VictorySummary.scss";
@@ -14,10 +14,24 @@ import "./VictorySummary.scss";
 /** How many routes stand open, the rest being a click away. */
 const ROUTES_SHOWN_AT_FIRST = 4;
 
+type PathsResult = Extract<PathsToVictory, { kind: "paths" }>;
+
+/** The outlooks worth a sentence: a week won outright says so on its own line. */
+type DecidingOutlook = Exclude<MondayNightOutlook, { kind: "notNeeded" }>;
+
 const NAMES = new Intl.ListFormat("en-US");
 
 function plural(count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/** Whether any pick has been settled, which is when a standing means anything. */
+function hasKickedOff(players: Array<PlayerScore>): boolean {
+  return players.some((player) =>
+    [...player.college, ...player.pro].some(
+      (pick) => pick.status === "yes" || pick.status === "no",
+    ),
+  );
 }
 
 /**
@@ -44,11 +58,13 @@ export function Standing({
   const behind = chosen != null ? top - chosen.score.total : null;
   return (
     <p className="victory__standing">
-      {behind == null
-        ? lead
-        : behind > 0
-          ? `${plural(behind, "point")} behind ${leader.name}`
-          : "Tied for the lead"}
+      {!hasKickedOff(players)
+        ? "No finished games"
+        : behind == null
+          ? lead
+          : behind > 0
+            ? `${plural(behind, "point")} behind ${leader.name}`
+            : "Tied for the lead"}
       {" · "}
       {plural(remainingGames(players).length, "game")} still to play
     </p>
@@ -64,9 +80,17 @@ function Section({ title, children }: { title: string; children: ReactNode }) {
   );
 }
 
-function Picks({ games }: { games: Array<RemainingPick> }) {
+function Picks({
+  games,
+  className,
+}: {
+  games: Array<RemainingPick>;
+  className?: string;
+}) {
   return (
-    <ul className="victory__picks">
+    <ul
+      className={className ? `victory__picks ${className}` : "victory__picks"}
+    >
       {games.map((game) => (
         <li key={game.label} className="victory__pick">
           <span className="victory__pick-label">{game.label}</span>
@@ -78,12 +102,9 @@ function Picks({ games }: { games: Array<RemainingPick> }) {
 }
 
 /** The MNF points that win, named the way the scoreboard column is. */
-function mondayNightSentence(outlook: MondayNightOutlook): string | null {
+function mondayNightSentence(outlook: DecidingOutlook): string {
   if (outlook.kind === "settled") {
     return "MNF points are already final, so the games above settle it.";
-  }
-  if (outlook.kind === "notNeeded") {
-    return "Takes the week outright, whatever the MNF points come to.";
   }
   const { min, max } = outlook;
   const points =
@@ -97,33 +118,41 @@ function mondayNightSentence(outlook: MondayNightOutlook): string | null {
   return `${points} to beat ${NAMES.format(outlook.contenders)}.`;
 }
 
+/** Whether anything below the outright line asks the player for a game. */
+function hasGames(result: PathsResult): boolean {
+  return (
+    result.mustWin.length > 0 ||
+    result.pool != null ||
+    (result.routes?.length ?? 0) > 0
+  );
+}
+
+/** The fewest games any route asks for, which the outright line is measured on. */
+function fewestWins(result: PathsResult): number {
+  const fromPool = result.pool?.choose ?? 0;
+  const fromRoutes = result.routes?.length
+    ? Math.min(...result.routes.map((route) => route.games.length))
+    : 0;
+  return result.mustWin.length + Math.max(fromPool, fromRoutes);
+}
+
 /**
  * Winning the week on points alone leads, since it settles the tiebreaker before
  * the reader has to think about it.
  */
-function Outright({
-  outlook,
-  outrightAt,
-  minimumWins,
-  hasGames,
-}: {
-  outlook?: MondayNightOutlook;
-  outrightAt?: number;
-  minimumWins: number;
-  hasGames: boolean;
-}) {
+function Outright({ result }: { result: PathsResult }) {
   const lines = [
-    outlook?.kind === "notNeeded"
+    result.mondayNight?.kind === "notNeeded"
       ? "Takes the week outright, whatever the MNF points come to."
       : null,
     // Only worth saying where it asks for more than the routes below already do.
-    outrightAt != null && outrightAt > minimumWins
-      ? `Winning ${plural(outrightAt, "game")} takes it outright.`
+    result.outrightAt != null && result.outrightAt > fewestWins(result)
+      ? `Winning ${plural(result.outrightAt, "game")} takes it outright.`
       : null,
   ].filter((line) => line != null);
   if (lines.length === 0) return null;
   // The last of them hands over to the sections under it, which ask for less.
-  const last = hasGames ? " Otherwise:" : "";
+  const last = hasGames(result) ? " Otherwise:" : "";
   return lines.map((line, index) => (
     <p key={line} className="victory__line">
       {line}
@@ -133,14 +162,10 @@ function Outright({
 }
 
 function MondayNight({ outlook }: { outlook?: MondayNightOutlook }) {
-  const sentence =
-    outlook != null && outlook.kind !== "notNeeded"
-      ? mondayNightSentence(outlook)
-      : null;
-  if (sentence == null) return null;
+  if (outlook == null || outlook.kind === "notNeeded") return null;
   return (
     <Section title="MNF points">
-      <p className="victory__line">{sentence}</p>
+      <p className="victory__line">{mondayNightSentence(outlook)}</p>
     </Section>
   );
 }
@@ -208,11 +233,14 @@ function Routes({
   );
 }
 
-function Message({ heading, body }: { heading: string; body?: string }) {
+function Message({ lines }: { lines: Array<string> }) {
   return (
     <div className="victory__message">
-      <p className="victory__heading">{heading}</p>
-      {body && <p className="victory__line">{body}</p>}
+      {lines.map((line) => (
+        <p key={line} className="victory__line">
+          {line}
+        </p>
+      ))}
     </div>
   );
 }
@@ -229,19 +257,27 @@ export default function VictorySummary({
 
   if (result.kind === "eliminated") {
     return (
-      <Message
-        heading={`${result.player} cannot win this week.`}
-        body={result.explanation}
-      />
+      <div className="victory">
+        <Message
+          lines={[
+            `${result.player} cannot win this week.`,
+            ...(result.explanation ? [result.explanation] : []),
+          ]}
+        />
+      </div>
     );
   }
 
   if (result.kind === "clinched") {
     return (
-      <Message
-        heading={`${result.player} has already won the week.`}
-        body="Nothing still to be played can take it away."
-      />
+      <div className="victory">
+        <Message
+          lines={[
+            `${result.player} has already won the week.`,
+            "Nothing still to be played can take it away.",
+          ]}
+        />
+      </div>
     );
   }
 
@@ -249,44 +285,30 @@ export default function VictorySummary({
     return (
       <div className="victory">
         <Message
-          heading={`${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`}
-          body={
-            result.needsMondayNight
-              ? "That is only enough to draw level, so the MNF points tiebreaker would still decide it."
-              : undefined
-          }
+          lines={[
+            `${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`,
+            ...(result.needsMondayNight
+              ? [
+                  "That is only enough to draw level, so the MNF points tiebreaker would still decide it.",
+                ]
+              : []),
+          ]}
         />
         {/* Why there is nothing below it, in the place the paths count theirs. */}
-        <p className="victory__standing">
+        <p className="victory__note">
           Detailed paths are worked out once ten games are left.
         </p>
       </div>
     );
   }
 
-  const fromPool = result.pool?.choose ?? 0;
-  const fromRoutes = result.routes?.length
-    ? Math.min(...result.routes.map((route) => route.games.length))
-    : 0;
-  const minimumWins = result.mustWin.length + Math.max(fromPool, fromRoutes);
-
-  const hasGames =
-    result.mustWin.length > 0 || result.pool != null || result.routes != null;
-
   return (
     <div className="victory">
-      <Outright
-        outlook={result.mondayNight}
-        outrightAt={result.outrightAt}
-        minimumWins={minimumWins}
-        hasGames={hasGames}
-      />
+      <Outright result={result} />
 
       {result.mustWin.length > 0 && (
         <Section title="Must win">
-          <div className="victory__must-win">
-            <Picks games={result.mustWin} />
-          </div>
+          <Picks className="victory__must-win" games={result.mustWin} />
         </Section>
       )}
 
@@ -298,18 +320,18 @@ export default function VictorySummary({
         </Section>
       )}
 
-      {result.routes && (
+      {result.routes != null && result.routes.length > 0 && (
         <Routes
-          key={result.player}
           title={result.mustWin.length > 0 ? "Then one of" : "One of"}
           routes={result.routes}
           showMondayNight={result.mondayNight == null}
         />
       )}
 
-      {result.mustWin.length === 0 && !result.pool && !result.routes && (
+      {/* A picked player always reads a sentence, whatever the search turned up. */}
+      {!hasGames(result) && (
         <p className="victory__line">
-          Nothing left to win. The tiebreaker below decides it.
+          No clean path to victory. The MNF points tiebreaker decides it.
         </p>
       )}
 
@@ -318,7 +340,7 @@ export default function VictorySummary({
 
       {/* Worked out, then left off, so the count is what the reader is missing. */}
       {result.hiddenRouteCount > 0 && (
-        <p className="victory__standing">
+        <p className="victory__note">
           {plural(result.hiddenRouteCount, "other path")} found but not shown.
         </p>
       )}

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -165,9 +165,13 @@ function NeedsHelp({ games }: { games: Array<UncontrolledGame> }) {
 function Routes({
   title,
   routes,
+  // Off where every route asks the same of the tiebreaker, which the section
+  // below then states once rather than on each of them.
+  showMondayNight,
 }: {
   title: string;
   routes: Array<VictoryRoute>;
+  showMondayNight: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const folded = routes.length - ROUTES_SHOWN_AT_FIRST;
@@ -181,7 +185,7 @@ function Routes({
             className="victory__route"
           >
             <Picks games={route.games} />
-            {route.mondayNight.kind === "range" && (
+            {showMondayNight && route.mondayNight.kind === "range" && (
               <p className="victory__line">
                 {mondayNightSentence(route.mondayNight)}
               </p>
@@ -293,6 +297,7 @@ export default function VictorySummary({
           key={result.player}
           title={result.mustWin.length > 0 ? "Then one of" : "One of"}
           routes={result.routes}
+          showMondayNight={result.mondayNight == null}
         />
       )}
 

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -48,7 +48,7 @@ export function Standing({
         ? lead
         : behind > 0
           ? `${plural(behind, "point")} behind ${leader.name}`
-          : "Level at the top"}
+          : "Tied for the lead"}
       {" · "}
       {plural(remainingGames(players).length, "game")} still to play
     </p>

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -6,6 +6,8 @@ import {
   UncontrolledGame,
   VictoryRoute,
 } from "../../types/PathsToVictory";
+import { RakMadnessScores } from "../../types/RakMadnessScores";
+import remainingGames from "../../utils/scoring/remainingGames";
 import Button from "../button/Button";
 import "./VictorySummary.scss";
 
@@ -16,6 +18,40 @@ const NAMES = new Intl.ListFormat("en-US");
 
 function plural(count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * Where the week stands, which the scores already say. Read straight off them so
+ * it is on screen before anyone is picked, and while their routes are worked out.
+ */
+export function Standing({
+  scores,
+  player,
+}: {
+  scores?: RakMadnessScores;
+  player?: string;
+}) {
+  const [leader, runnerUp] = scores?.scores ?? [];
+  if (leader == null) return null;
+  const chosen = scores?.scores.find((it) => it.name === player);
+  const behind =
+    chosen != null ? leader.score.total - chosen.score.total : undefined;
+  const isLevel =
+    behind != null
+      ? behind === 0
+      : runnerUp?.score.total === leader.score.total;
+  return (
+    <p className="victory__standing">
+      {isLevel
+        ? "Level at the top"
+        : behind != null
+          ? `${plural(behind, "point")} behind ${leader.name}`
+          : `${leader.name} leads`}
+      {" · "}
+      {plural(remainingGames(scores?.scores ?? []).length, "game")} still to
+      play
+    </p>
+  );
 }
 
 function Section({ title, children }: { title: string; children: ReactNode }) {
@@ -68,10 +104,12 @@ function Outright({
   outlook,
   outrightAt,
   minimumWins,
+  hasGames,
 }: {
   outlook?: MondayNightOutlook;
   outrightAt?: number;
   minimumWins: number;
+  hasGames: boolean;
 }) {
   const lines = [
     outlook?.kind === "notNeeded"
@@ -83,9 +121,12 @@ function Outright({
       : null,
   ].filter((line) => line != null);
   if (lines.length === 0) return null;
-  return lines.map((line) => (
+  // The last of them hands over to the sections under it, which ask for less.
+  const last = hasGames ? " Otherwise:" : "";
+  return lines.map((line, index) => (
     <p key={line} className="victory__line">
       {line}
+      {index === lines.length - 1 && last}
     </p>
   ));
 }
@@ -208,19 +249,14 @@ export default function VictorySummary({
 
   if (result.kind === "headline") {
     return (
-      <div className="victory">
-        <Message
-          heading={`${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`}
-          body={
-            result.needsMondayNight
-              ? "That is only enough to draw level, so the MNF points tiebreaker would still decide it. The routes are worked out once ten games are left."
-              : "The routes are worked out once ten games are left."
-          }
-        />
-        <p className="victory__standing">
-          {plural(result.remainingGameCount, "game")} still to play
-        </p>
-      </div>
+      <Message
+        heading={`${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`}
+        body={
+          result.needsMondayNight
+            ? "That is only enough to draw level, so the MNF points tiebreaker would still decide it. The routes are worked out once ten games are left."
+            : "The routes are worked out once ten games are left."
+        }
+      />
     );
   }
 
@@ -230,20 +266,16 @@ export default function VictorySummary({
     : 0;
   const minimumWins = result.mustWin.length + Math.max(fromPool, fromRoutes);
 
+  const hasGames =
+    result.mustWin.length > 0 || result.pool != null || result.routes != null;
+
   return (
     <div className="victory">
-      <p className="victory__standing">
-        {result.pointsBehind > 0
-          ? `${plural(result.pointsBehind, "point")} behind ${result.leader}`
-          : "Level at the top"}
-        {" · "}
-        {plural(result.remainingGameCount, "game")} still to play
-      </p>
-
       <Outright
         outlook={result.mondayNight}
         outrightAt={result.outrightAt}
         minimumWins={minimumWins}
+        hasGames={hasGames}
       />
 
       {result.mustWin.length > 0 && (

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -247,14 +247,20 @@ export default function VictorySummary({
 
   if (result.kind === "headline") {
     return (
-      <Message
-        heading={`${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`}
-        body={
-          result.needsMondayNight
-            ? "That is only enough to draw level, so the MNF points tiebreaker would still decide it. Detailed paths are worked out once ten games are left."
-            : "Detailed paths are worked out once ten games are left."
-        }
-      />
+      <div className="victory">
+        <Message
+          heading={`${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`}
+          body={
+            result.needsMondayNight
+              ? "That is only enough to draw level, so the MNF points tiebreaker would still decide it."
+              : undefined
+          }
+        />
+        {/* Why there is nothing below it, in the place the paths count theirs. */}
+        <p className="victory__standing">
+          Detailed paths are worked out once ten games are left.
+        </p>
+      </div>
     );
   }
 

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -71,6 +71,11 @@ export function Standing({
   );
 }
 
+/** Whatever the answer turns out to be, it plays in under the same wrapper. */
+function Answer({ children }: { children: ReactNode }) {
+  return <div className="victory">{children}</div>;
+}
+
 function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section className="victory__section">
@@ -127,13 +132,12 @@ function hasGames(result: PathsResult): boolean {
   );
 }
 
-/** The fewest games any route asks for, which the outright line is measured on. */
+/** The fewest games a way through asks for, which the outright line is measured on. */
 function fewestWins(result: PathsResult): number {
-  const fromPool = result.pool?.choose ?? 0;
-  const fromRoutes = result.routes?.length
-    ? Math.min(...result.routes.map((route) => route.games.length))
-    : 0;
-  return result.mustWin.length + Math.max(fromPool, fromRoutes);
+  // The routes are held fewest games first, so the shortest is the one on top.
+  const fromGames =
+    result.pool?.choose ?? result.routes?.[0]?.games.length ?? 0;
+  return result.mustWin.length + fromGames;
 }
 
 /**
@@ -141,24 +145,21 @@ function fewestWins(result: PathsResult): number {
  * the reader has to think about it.
  */
 function Outright({ result }: { result: PathsResult }) {
-  const lines = [
+  const line =
     result.mondayNight?.kind === "notNeeded"
       ? "Takes the week outright, whatever the MNF points come to."
-      : null,
-    // Only worth saying where it asks for more than the routes below already do.
-    result.outrightAt != null && result.outrightAt > fewestWins(result)
-      ? `Winning ${plural(result.outrightAt, "game")} takes it outright.`
-      : null,
-  ].filter((line) => line != null);
-  if (lines.length === 0) return null;
-  // The last of them hands over to the sections under it, which ask for less.
-  const last = hasGames(result) ? " Otherwise:" : "";
-  return lines.map((line, index) => (
-    <p key={line} className="victory__line">
+      : // Only worth saying where it asks more than the routes below already do.
+        result.outrightAt != null && result.outrightAt > fewestWins(result)
+        ? `Winning ${plural(result.outrightAt, "game")} takes it outright.`
+        : null;
+  if (line == null) return null;
+  return (
+    <p className="victory__line">
       {line}
-      {index === lines.length - 1 && last}
+      {/* Hands over to the sections under it, which ask for less. */}
+      {hasGames(result) && " Otherwise:"}
     </p>
-  ));
+  );
 }
 
 function MondayNight({ outlook }: { outlook?: MondayNightOutlook }) {
@@ -233,14 +234,17 @@ function Routes({
   );
 }
 
-function Message({ lines }: { lines: Array<string> }) {
+/** A line absent is one the answer did not call for, so the caller can pass it. */
+function Message({ lines }: { lines: Array<string | undefined> }) {
   return (
     <div className="victory__message">
-      {lines.map((line) => (
-        <p key={line} className="victory__line">
-          {line}
-        </p>
-      ))}
+      {lines
+        .filter((line) => line != null)
+        .map((line) => (
+          <p key={line} className="victory__line">
+            {line}
+          </p>
+        ))}
     </div>
   );
 }
@@ -257,53 +261,48 @@ export default function VictorySummary({
 
   if (result.kind === "eliminated") {
     return (
-      <div className="victory">
+      <Answer>
         <Message
-          lines={[
-            `${result.player} cannot win this week.`,
-            ...(result.explanation ? [result.explanation] : []),
-          ]}
+          lines={[`${result.player} cannot win this week.`, result.explanation]}
         />
-      </div>
+      </Answer>
     );
   }
 
   if (result.kind === "clinched") {
     return (
-      <div className="victory">
+      <Answer>
         <Message
           lines={[
             `${result.player} has already won the week.`,
             "Nothing still to be played can take it away.",
           ]}
         />
-      </div>
+      </Answer>
     );
   }
 
   if (result.kind === "headline") {
     return (
-      <div className="victory">
+      <Answer>
         <Message
           lines={[
             `${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`,
-            ...(result.needsMondayNight
-              ? [
-                  "That is only enough to draw level, so the MNF points tiebreaker would still decide it.",
-                ]
-              : []),
+            result.needsMondayNight
+              ? "That is only enough to draw level, so the MNF points tiebreaker would still decide it."
+              : undefined,
           ]}
         />
         {/* Why there is nothing below it, in the place the paths count theirs. */}
         <p className="victory__note">
           Detailed paths are worked out once ten games are left.
         </p>
-      </div>
+      </Answer>
     );
   }
 
   return (
-    <div className="victory">
+    <Answer>
       <Outright result={result} />
 
       {result.mustWin.length > 0 && (
@@ -328,8 +327,9 @@ export default function VictorySummary({
         />
       )}
 
-      {/* A picked player always reads a sentence, whatever the search turned up. */}
-      {!hasGames(result) && (
+      {/* A picked player always reads a sentence. This is the one left where the
+          games ask nothing and the line above said nothing either. */}
+      {!hasGames(result) && result.mondayNight?.kind !== "notNeeded" && (
         <p className="victory__line">
           No clean path to victory. The MNF points tiebreaker decides it.
         </p>
@@ -344,6 +344,6 @@ export default function VictorySummary({
           {plural(result.hiddenRouteCount, "other path")} found but not shown.
         </p>
       )}
-    </div>
+    </Answer>
   );
 }

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -12,10 +12,7 @@ import "./VictorySummary.scss";
 /** How many routes stand open, the rest being a click away. */
 const ROUTES_SHOWN_AT_FIRST = 5;
 
-function list(names: Array<string>): string {
-  if (names.length < 3) return names.join(" and ");
-  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
-}
+const NAMES = new Intl.ListFormat("en-US");
 
 function plural(count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
@@ -58,7 +55,7 @@ function mondayNightSentence(outlook: MondayNightOutlook): string | null {
       : min != null
         ? `of ${min} or more`
         : `of ${max} or less`;
-  return `Needs a Monday night total ${total} to beat ${list(outlook.contenders)}.`;
+  return `Monday night total ${total} to beat ${NAMES.format(outlook.contenders)}.`;
 }
 
 function MondayNight({
@@ -93,7 +90,7 @@ function NeedsHelp({ games }: { games: Array<UncontrolledGame> }) {
         {games.map((game) => (
           <li key={game.label} className="victory__line">
             <span className="victory__pick-label">{game.label}</span> is blank
-            on your sheet, so {list(game.needsToMiss)} has to miss.
+            on your sheet, so {NAMES.format(game.needsToMiss)} has to miss.
           </li>
         ))}
       </ul>
@@ -134,9 +131,9 @@ function Routes({
       {folded > 0 && (
         <Button
           className="victory__more"
-          color="gold"
           variant="soft"
           size="sm"
+          ariaExpanded={isExpanded}
           onClick={() => setIsExpanded(!isExpanded)}
         >
           {isExpanded ? "Show fewer" : `Show ${plural(folded, "more route")}`}

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -165,11 +165,9 @@ function NeedsHelp({ games }: { games: Array<UncontrolledGame> }) {
 function Routes({
   title,
   routes,
-  hiddenRouteCount,
 }: {
   title: string;
   routes: Array<VictoryRoute>;
-  hiddenRouteCount: number;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const folded = routes.length - ROUTES_SHOWN_AT_FIRST;
@@ -201,11 +199,6 @@ function Routes({
         >
           {isExpanded ? "Show fewer" : `Show ${plural(folded, "more route")}`}
         </Button>
-      )}
-      {hiddenRouteCount > 0 && (
-        <p className="victory__line">
-          {plural(hiddenRouteCount, "other route")} not shown.
-        </p>
       )}
     </Section>
   );
@@ -300,7 +293,6 @@ export default function VictorySummary({
           key={result.player}
           title={result.mustWin.length > 0 ? "Then one of" : "One of"}
           routes={result.routes}
-          hiddenRouteCount={result.hiddenRouteCount}
         />
       )}
 
@@ -312,6 +304,14 @@ export default function VictorySummary({
 
       <NeedsHelp games={result.needsHelp} />
       <MondayNight outlook={result.mondayNight} />
+
+      {/* Worked out, then left off, so the count is what the reader is missing. */}
+      {result.hiddenRouteCount > 0 && (
+        <p className="victory__standing">
+          {plural(result.hiddenRouteCount, "other route")} worked out but not
+          shown.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -201,7 +201,7 @@ function Routes({
           ariaExpanded={isExpanded}
           onClick={() => setIsExpanded(!isExpanded)}
         >
-          {isExpanded ? "Show fewer" : `Show ${plural(folded, "more route")}`}
+          {isExpanded ? "Show fewer" : `Show ${plural(folded, "more path")}`}
         </Button>
       )}
     </Section>
@@ -251,8 +251,8 @@ export default function VictorySummary({
         heading={`${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`}
         body={
           result.needsMondayNight
-            ? "That is only enough to draw level, so the MNF points tiebreaker would still decide it. The routes are worked out once ten games are left."
-            : "The routes are worked out once ten games are left."
+            ? "That is only enough to draw level, so the MNF points tiebreaker would still decide it. Detailed paths are worked out once ten games are left."
+            : "Detailed paths are worked out once ten games are left."
         }
       />
     );
@@ -313,7 +313,7 @@ export default function VictorySummary({
       {/* Worked out, then left off, so the count is what the reader is missing. */}
       {result.hiddenRouteCount > 0 && (
         <p className="victory__standing">
-          {plural(result.hiddenRouteCount, "other route")} found but not shown.
+          {plural(result.hiddenRouteCount, "other path")} found but not shown.
         </p>
       )}
     </div>

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -31,25 +31,26 @@ export function Standing({
   scores?: RakMadnessScores;
   player?: string;
 }) {
-  const [leader, runnerUp] = scores?.scores ?? [];
+  const players = scores?.scores ?? [];
+  const [leader] = players;
   if (leader == null) return null;
-  const chosen = scores?.scores.find((it) => it.name === player);
-  const behind =
-    chosen != null ? leader.score.total - chosen.score.total : undefined;
-  const isLevel =
-    behind != null
-      ? behind === 0
-      : runnerUp?.score.total === leader.score.total;
+  const top = leader.score.total;
+  const chosen = players.find((it) => it.name === player);
+  const leaders = players.filter((it) => it.score.total === top).length;
+  const lead =
+    leaders > 1
+      ? `${leaders} players lead with ${plural(top, "point")}`
+      : `${leader.name} leads with ${plural(top, "point")}`;
+  const behind = chosen != null ? top - chosen.score.total : null;
   return (
     <p className="victory__standing">
-      {isLevel
-        ? "Level at the top"
-        : behind != null
+      {behind == null
+        ? lead
+        : behind > 0
           ? `${plural(behind, "point")} behind ${leader.name}`
-          : `${leader.name} leads`}
+          : "Level at the top"}
       {" · "}
-      {plural(remainingGames(scores?.scores ?? []).length, "game")} still to
-      play
+      {plural(remainingGames(players).length, "game")} still to play
     </p>
   );
 }

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -308,8 +308,7 @@ export default function VictorySummary({
       {/* Worked out, then left off, so the count is what the reader is missing. */}
       {result.hiddenRouteCount > 0 && (
         <p className="victory__standing">
-          {plural(result.hiddenRouteCount, "other route")} worked out but not
-          shown.
+          {plural(result.hiddenRouteCount, "other route")} found but not shown.
         </p>
       )}
     </div>

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -1,11 +1,16 @@
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import {
   MondayNightOutlook,
   PathsToVictory,
   RemainingPick,
   UncontrolledGame,
+  VictoryRoute,
 } from "../../types/PathsToVictory";
+import Button from "../button/Button";
 import "./VictorySummary.scss";
+
+/** How many routes stand open, the rest being a click away. */
+const ROUTES_SHOWN_AT_FIRST = 5;
 
 function list(names: Array<string>): string {
   if (names.length < 3) return names.join(" and ");
@@ -96,6 +101,56 @@ function NeedsHelp({ games }: { games: Array<UncontrolledGame> }) {
   );
 }
 
+/** The alternatives, fewest games first, with the long tail folded away. */
+function Routes({
+  title,
+  routes,
+  hiddenRouteCount,
+}: {
+  title: string;
+  routes: Array<VictoryRoute>;
+  hiddenRouteCount: number;
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const folded = routes.length - ROUTES_SHOWN_AT_FIRST;
+  const shown = isExpanded ? routes : routes.slice(0, ROUTES_SHOWN_AT_FIRST);
+  return (
+    <Section title={title}>
+      <ol className="victory__routes">
+        {shown.map((route) => (
+          <li
+            key={route.games.map((game) => game.label).join()}
+            className="victory__route"
+          >
+            <Picks games={route.games} />
+            {route.mondayNight.kind === "range" && (
+              <p className="victory__line">
+                {mondayNightSentence(route.mondayNight)}
+              </p>
+            )}
+          </li>
+        ))}
+      </ol>
+      {folded > 0 && (
+        <Button
+          className="victory__more"
+          color="gold"
+          variant="soft"
+          size="sm"
+          onClick={() => setIsExpanded(!isExpanded)}
+        >
+          {isExpanded ? "Show fewer" : `Show ${plural(folded, "more route")}`}
+        </Button>
+      )}
+      {hiddenRouteCount > 0 && (
+        <p className="victory__line">
+          {plural(hiddenRouteCount, "other route")} not shown.
+        </p>
+      )}
+    </Section>
+  );
+}
+
 function Message({ heading, body }: { heading: string; body?: string }) {
   return (
     <div className="victory__message">
@@ -141,17 +196,17 @@ export default function VictorySummary({
   if (result.kind === "headline") {
     return (
       <div className="victory">
-        <p className="victory__standing">
-          {plural(result.remainingGameCount, "game")} still to play
-        </p>
         <Message
           heading={`${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`}
           body={
             result.needsMondayNight
-              ? "That is only enough to draw level, so the Monday night tiebreaker would still decide it. The routes are worked out once twelve games are left."
-              : "The routes are worked out once twelve games are left."
+              ? "That is only enough to draw level, so the Monday night tiebreaker would still decide it. The routes are worked out once ten games are left."
+              : "The routes are worked out once ten games are left."
           }
         />
+        <p className="victory__standing">
+          {plural(result.remainingGameCount, "game")} still to play
+        </p>
       </div>
     );
   }
@@ -164,14 +219,6 @@ export default function VictorySummary({
 
   return (
     <div className="victory">
-      <p className="victory__standing">
-        {result.pointsBehind > 0
-          ? `${plural(result.pointsBehind, "point")} behind ${result.leader}`
-          : "Level at the top"}
-        {" · "}
-        {plural(result.remainingGameCount, "game")} still to play
-      </p>
-
       {result.mustWin.length > 0 && (
         <Section title="Must win">
           <Picks games={result.mustWin} />
@@ -187,28 +234,12 @@ export default function VictorySummary({
       )}
 
       {result.routes && (
-        <Section title={result.mustWin.length > 0 ? "Then one of" : "One of"}>
-          <ol className="victory__routes">
-            {result.routes.map((route) => (
-              <li
-                key={route.games.map((game) => game.label).join()}
-                className="victory__route"
-              >
-                <Picks games={route.games} />
-                {route.mondayNight.kind === "range" && (
-                  <p className="victory__line">
-                    {mondayNightSentence(route.mondayNight)}
-                  </p>
-                )}
-              </li>
-            ))}
-          </ol>
-          {result.hiddenRouteCount > 0 && (
-            <p className="victory__line">
-              {plural(result.hiddenRouteCount, "other route")} not shown.
-            </p>
-          )}
-        </Section>
+        <Routes
+          key={result.player}
+          title={result.mustWin.length > 0 ? "Then one of" : "One of"}
+          routes={result.routes}
+          hiddenRouteCount={result.hiddenRouteCount}
+        />
       )}
 
       {result.mustWin.length === 0 && !result.pool && !result.routes && (
@@ -223,6 +254,14 @@ export default function VictorySummary({
         outrightAt={result.outrightAt}
         minimumWins={minimumWins}
       />
+
+      <p className="victory__standing">
+        {result.pointsBehind > 0
+          ? `${plural(result.pointsBehind, "point")} behind ${result.leader}`
+          : "Level at the top"}
+        {" · "}
+        {plural(result.remainingGameCount, "game")} still to play
+      </p>
     </div>
   );
 }

--- a/src/components/pathToVictory/VictorySummary.tsx
+++ b/src/components/pathToVictory/VictorySummary.tsx
@@ -79,7 +79,7 @@ function Outright({
       : null,
     // Only worth saying where it asks for more than the routes below already do.
     outrightAt != null && outrightAt > minimumWins
-      ? `Winning ${plural(outrightAt, "game")} instead takes it outright.`
+      ? `Winning ${plural(outrightAt, "game")} takes it outright.`
       : null,
   ].filter((line) => line != null);
   if (lines.length === 0) return null;
@@ -232,6 +232,14 @@ export default function VictorySummary({
 
   return (
     <div className="victory">
+      <p className="victory__standing">
+        {result.pointsBehind > 0
+          ? `${plural(result.pointsBehind, "point")} behind ${result.leader}`
+          : "Level at the top"}
+        {" · "}
+        {plural(result.remainingGameCount, "game")} still to play
+      </p>
+
       <Outright
         outlook={result.mondayNight}
         outrightAt={result.outrightAt}
@@ -271,14 +279,6 @@ export default function VictorySummary({
 
       <NeedsHelp games={result.needsHelp} />
       <MondayNight outlook={result.mondayNight} />
-
-      <p className="victory__standing">
-        {result.pointsBehind > 0
-          ? `${plural(result.pointsBehind, "point")} behind ${result.leader}`
-          : "Level at the top"}
-        {" · "}
-        {plural(result.remainingGameCount, "game")} still to play
-      </p>
     </div>
   );
 }

--- a/src/components/results/CLAUDE.md
+++ b/src/components/results/CLAUDE.md
@@ -8,4 +8,7 @@ throttle. `ScoreboardRoute` and `PicksRoute` each render one table from context.
 `ResultsFrame` is the page and wireframe both `ResultsLayout` and
 `CurrentWeekRedirect` render into, and `ResultsFrame.scss` colors the scores area
 so the gap below it reads as part of the table. It reads `useIsWeekDecided` to
-pass `ScoresNavbar` its `canRefresh` prop.
+pass `ScoresNavbar` its `isWeekLive` prop, and holds the one `PathToVictoryDialog`
+the app has, opened from that navbar and fed the `scores` `ResultsLayout` passes
+down. One dialog toggled rather than one mounted per opening, because Base UI ties
+its scroll lock and focus guards to a dialog being open.

--- a/src/components/results/ResultsFrame.tsx
+++ b/src/components/results/ResultsFrame.tsx
@@ -1,10 +1,12 @@
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useState } from "react";
 import { useNavigate } from "react-router";
 import { useIsWeekDecided } from "../../context/AppDataContext";
+import { RakMadnessScores } from "../../types/RakMadnessScores";
 import getClasses from "../../utils/getClasses";
 import LogoButton from "../navbar/LogoButton/LogoButton";
 import ScoresNavbar, { ScoresView } from "../navbar/ScoresNavbar";
 import PageLayout from "../PageLayout";
+import PathToVictoryDialog from "../pathToVictory/PathToVictoryDialog";
 import SkeletonTable from "../table/SkeletonTable";
 import "./ResultsFrame.scss";
 
@@ -24,6 +26,7 @@ export default function ResultsFrame({
   onViewChange = doNothing,
   onRefresh = doNothing,
   isRefreshing = false,
+  scores,
   children,
 }: PropsWithChildren<{
   view: ScoresView;
@@ -32,11 +35,15 @@ export default function ResultsFrame({
   onViewChange?: (view: ScoresView) => void;
   onRefresh?: () => void;
   isRefreshing?: boolean;
+  /** What the path to victory is worked out from. Absent while a week loads. */
+  scores?: RakMadnessScores;
 }>) {
   const navigate = useNavigate();
-  // Once every game is final there is nothing left to fetch, so the refresh
-  // button and the divider beside it go rather than sit there doing nothing.
+  // Once every game is final there is nothing left to fetch and nobody has a path
+  // to victory left, so the refresh and path buttons and the divider beside them
+  // go rather than sit there doing nothing.
   const isWeekDecided = useIsWeekDecided();
+  const [isPathsOpen, setPathsOpen] = useState(false);
 
   return (
     <PageLayout
@@ -52,9 +59,10 @@ export default function ResultsFrame({
         <ScoresNavbar
           view={view}
           disabled={!isReady}
-          canRefresh={!isWeekDecided}
+          isWeekLive={!isWeekDecided}
           onViewChange={onViewChange}
           onRefresh={onRefresh}
+          onShowPaths={() => setPathsOpen(true)}
           isRefreshing={isRefreshing}
         />
       }
@@ -62,6 +70,11 @@ export default function ResultsFrame({
       <div className={`home__scores ${getClasses({ "--loading": !isReady })}`}>
         {isReady ? children : <SkeletonTable view={view} />}
       </div>
+      <PathToVictoryDialog
+        open={isPathsOpen}
+        onOpenChange={setPathsOpen}
+        scores={scores}
+      />
     </PageLayout>
   );
 }

--- a/src/components/results/ResultsLayout.tsx
+++ b/src/components/results/ResultsLayout.tsx
@@ -14,7 +14,7 @@ import ResultsFrame from "./ResultsFrame";
 export default function ResultsLayout() {
   const { season: rawSeason, week: rawWeek } = useParams();
   const navigate = useNavigate();
-  const { refresh, isRefreshing } = useAppData();
+  const { refresh, isRefreshing, scores } = useAppData();
   const guard = useWeekRouteGuard(rawSeason, rawWeek);
 
   // The route decides which view is showing, not component state.
@@ -33,6 +33,7 @@ export default function ResultsLayout() {
       }
       onRefresh={refresh}
       isRefreshing={isRefreshing}
+      scores={scores}
     >
       <Outlet />
     </ResultsFrame>

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -105,7 +105,7 @@
       border-left: var(--rak-table-border);
 
       &.--knocked-out {
-        background-color: #fac99e;
+        background-color: var(--rak-knocked-out);
       }
 
       &:not(.--knocked-out) {
@@ -115,7 +115,7 @@
 
     tr:nth-child(even) .table__player-col {
       &.--knocked-out {
-        background-color: #deaa7c;
+        background-color: var(--rak-knocked-out-dark);
       }
 
       &:not(.--knocked-out) {

--- a/src/context/AppDataContext.tsx
+++ b/src/context/AppDataContext.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 import { useLocation } from "react-router";
+import useCurrentSeason from "../hooks/useCurrentSeason";
 import useLeagueWeeks from "../hooks/useLeagueWeeks";
 import usePicksSeasons from "../hooks/usePicksSeasons";
 import usePlayerScores from "../hooks/usePlayerScores";
@@ -15,7 +16,8 @@ import isWeekDecided from "../utils/scoring/isWeekDecided";
 
 type AppData = ReturnType<typeof useLeagueWeeks> &
   ReturnType<typeof usePlayerScores> &
-  ReturnType<typeof usePicksSeasons> & {
+  ReturnType<typeof usePicksSeasons> &
+  ReturnType<typeof useCurrentSeason> & {
     /**
      * The `WeekInfo` for a week number, or undefined if the season has no such
      * week. Always the calendar's own object: the week picker compares options by
@@ -32,7 +34,7 @@ type AppData = ReturnType<typeof useLeagueWeeks> &
     requestedSeason?: number;
     /**
      * The seasons that can be chosen, newest first. The ones with picks in the
-     * database, or the season running now when that list cannot be had.
+     * database, plus the season running now whether or not it has any.
      */
     selectableSeasons: Array<number>;
   };
@@ -89,9 +91,10 @@ export function AppDataContextProvider({
   }
 
   const picksSeasons = usePicksSeasons();
+  const currentSeason = useCurrentSeason();
   // The newest season with picks, unless the URL or the picker named one. ESPN
   // moves on to the season about to start as soon as the last one ends, and that
-  // season has nothing to show.
+  // season has nothing to show, so it is offered below rather than opened on.
   const requestedSeason = selectedSeason ?? picksSeasons.seasons?.[0];
   const leagueWeeks = useLeagueWeeks(
     route.week,
@@ -115,21 +118,29 @@ export function AppDataContextProvider({
     [scores],
   );
 
-  // A season with no picks cannot be scored, so it is not offered. Falling back
-  // to the season running now keeps the picker usable where the list could not be
-  // fetched, which is every `make run`.
+  // The seasons with picks, plus the one running now whether or not it has any.
+  // That season's weeks are scored from a spreadsheet the user uploads until its
+  // picks reach the database, and leaving it out puts the week they are holding
+  // out of reach. Falling back to the season the week list describes keeps the
+  // picker usable where neither could be fetched, which is every `make run`.
   const { seasonYear } = leagueWeeks;
   const selectableSeasons = useMemo(() => {
-    const listed = picksSeasons.seasons ?? [];
-    if (listed.length > 0) return listed;
-    return seasonYear != null ? [seasonYear] : [];
-  }, [picksSeasons.seasons, seasonYear]);
+    const offered = new Set(picksSeasons.seasons ?? []);
+    if (currentSeason.currentSeason != null) {
+      offered.add(currentSeason.currentSeason);
+    }
+    if (offered.size === 0 && seasonYear != null) {
+      offered.add(seasonYear);
+    }
+    return [...offered].sort((a, b) => b - a);
+  }, [picksSeasons.seasons, currentSeason.currentSeason, seasonYear]);
 
   const value = useMemo(
     () => ({
       ...leagueWeeks,
       ...playerScores,
       ...picksSeasons,
+      ...currentSeason,
       findWeek,
       setSelectedSeason,
       requestedSeason,
@@ -139,6 +150,7 @@ export function AppDataContextProvider({
       leagueWeeks,
       playerScores,
       picksSeasons,
+      currentSeason,
       findWeek,
       requestedSeason,
       selectableSeasons,

--- a/src/context/AppDataContext.tsx
+++ b/src/context/AppDataContext.tsx
@@ -16,8 +16,7 @@ import isWeekDecided from "../utils/scoring/isWeekDecided";
 
 type AppData = ReturnType<typeof useLeagueWeeks> &
   ReturnType<typeof usePlayerScores> &
-  ReturnType<typeof usePicksSeasons> &
-  ReturnType<typeof useCurrentSeason> & {
+  ReturnType<typeof usePicksSeasons> & {
     /**
      * The `WeekInfo` for a week number, or undefined if the season has no such
      * week. Always the calendar's own object: the week picker compares options by
@@ -126,21 +125,20 @@ export function AppDataContextProvider({
   const { seasonYear } = leagueWeeks;
   const selectableSeasons = useMemo(() => {
     const offered = new Set(picksSeasons.seasons ?? []);
-    if (currentSeason.currentSeason != null) {
-      offered.add(currentSeason.currentSeason);
+    if (currentSeason != null) {
+      offered.add(currentSeason);
     }
     if (offered.size === 0 && seasonYear != null) {
       offered.add(seasonYear);
     }
     return [...offered].sort((a, b) => b - a);
-  }, [picksSeasons.seasons, currentSeason.currentSeason, seasonYear]);
+  }, [picksSeasons.seasons, currentSeason, seasonYear]);
 
   const value = useMemo(
     () => ({
       ...leagueWeeks,
       ...playerScores,
       ...picksSeasons,
-      ...currentSeason,
       findWeek,
       setSelectedSeason,
       requestedSeason,
@@ -150,7 +148,6 @@ export function AppDataContextProvider({
       leagueWeeks,
       playerScores,
       picksSeasons,
-      currentSeason,
       findWeek,
       requestedSeason,
       selectableSeasons,

--- a/src/context/CLAUDE.md
+++ b/src/context/CLAUDE.md
@@ -1,7 +1,11 @@
 # context
 
 `AppDataContext`: the season list, week list, picks, and scores, held above the
-routes. Derives the season and week from the pathname on every render. Publishes
+routes. Derives the season and week from the pathname on every render.
+`selectableSeasons` is the seasons with picks plus the one running now, which is
+offered whether or not it has any: its weeks are scored from a spreadsheet the user
+uploads until its picks reach the database. It still opens on the newest season with
+picks, since ESPN calls a season current as soon as the last one ends. Publishes
 `WeekDecidedContext` separately, so a table cell reading it does not re-render on
 every loading flag.
 

--- a/src/hooks/CLAUDE.md
+++ b/src/hooks/CLAUDE.md
@@ -1,7 +1,7 @@
 # hooks
 
 The app's data layer. Everything that talks to ESPN, the picks API, or the scoring
-pipeline lives here, so components only render. The first three are mounted once, in
+pipeline lives here, so components only render. The first four are mounted once, in
 `AppDataContext`, above the routes.
 
 - `usePicksSeasons`: the seasons that have picks, from `/api/picks`, newest first.

--- a/src/hooks/CLAUDE.md
+++ b/src/hooks/CLAUDE.md
@@ -5,6 +5,9 @@ pipeline lives here, so components only render. The first three are mounted once
 `AppDataContext`, above the routes.
 
 - `usePicksSeasons`: the seasons that have picks, from `/api/picks`, newest first.
+- `useCurrentSeason`: the season running now, asked of ESPN with no season named.
+  Its own lookup, because the picker has to offer that season whether or not it has
+  picks yet, and the list above holds only the ones that do.
 - `useLeagueWeeks`: the season's weeks from ESPN, and which one is selected. Takes
   the week the URL names and the season to fetch, so a results URL is not preceded
   by scoring the wrong week, and stays disabled until the season is known. The

--- a/src/hooks/useCurrentSeason.ts
+++ b/src/hooks/useCurrentSeason.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { League } from "../types/League";
 import getLeagueInfo from "../utils/getLeagueInfo";
 
@@ -36,5 +36,5 @@ export default function useCurrentSeason() {
     };
   }, []);
 
-  return useMemo(() => ({ currentSeason }), [currentSeason]);
+  return currentSeason;
 }

--- a/src/hooks/useCurrentSeason.ts
+++ b/src/hooks/useCurrentSeason.ts
@@ -1,0 +1,40 @@
+import { useEffect, useMemo, useState } from "react";
+import { League } from "../types/League";
+import getLeagueInfo from "../utils/getLeagueInfo";
+
+/**
+ * The season running now, by the year it started in.
+ *
+ * Asked for on its own, because the season list holds only the seasons with picks
+ * in the database, and the picker has to offer this one whether or not it has any.
+ * A week of it with no picks behind it is scored from a spreadsheet the user
+ * uploads, which is what that path is for.
+ *
+ * Left undefined where ESPN cannot be reached. The picker then falls back to the
+ * seasons it does know about, so a failure here costs the current season its place
+ * in the list and nothing else.
+ */
+export default function useCurrentSeason() {
+  const [currentSeason, setCurrentSeason] = useState<number>();
+
+  useEffect(() => {
+    let isCurrent = true;
+    const loadCurrentSeason = async () => {
+      try {
+        // No season named, so ESPN answers with the one running now.
+        const proLeagueInfo = await getLeagueInfo(League.PRO);
+        if (isCurrent) {
+          setCurrentSeason(proLeagueInfo?.season);
+        }
+      } catch (error) {
+        console.warn("Could not work out the season running now", error);
+      }
+    };
+    loadCurrentSeason();
+    return () => {
+      isCurrent = false;
+    };
+  }, []);
+
+  return useMemo(() => ({ currentSeason }), [currentSeason]);
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -37,6 +37,13 @@
   --rak-danger-600: #a51818;
   --rak-danger-700: #7d1212;
   --rak-warning-500: #9a5b13;
+  // The trophy button's accent. Its own hue rather than a step on any scale above,
+  // so the one affordance that is neither a view switch nor a result reads as
+  // neither. Light enough that text on it is `--rak-primary-800`, not
+  // `--rak-on-solid`.
+  --rak-gold-500: #d9a02b;
+  --rak-gold-600: #bd8a20;
+  --rak-gold-700: #9a7018;
 
   // Soft fills, used by the toasts.
   --rak-soft-primary-bg: #acc2d2;

--- a/src/index.scss
+++ b/src/index.scss
@@ -75,6 +75,12 @@
   --rak-pick-no-dark: #de7c7c;
   --rak-pick-error: #edfaa0;
   --rak-pick-error-dark: #cfde7c;
+  // A player who can no longer win, wherever they are named. The -dark value
+  // stripes the even rows of the tables. The -text value is the same hue taken
+  // far enough down to read on white, which the fill itself cannot.
+  --rak-knocked-out: #fac99e;
+  --rak-knocked-out-dark: #deaa7c;
+  --rak-knocked-out-text: #8a4a12;
 
   --rak-disabled-bg: #f0f4f8;
   --rak-disabled-text: #9fa6ad;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -7,6 +7,15 @@ import { vi } from "vitest";
 // per call site, because any of them can be the one that runs slowly.
 configure({ asyncUtilTimeout: 5000 });
 
+// jsdom lays nothing out, so it ships no ResizeObserver. The dialog that grows to
+// its content asks for one, and a stub that never reports leaves it at the height
+// the stylesheet gives it.
+globalThis.ResizeObserver = class {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+};
+
 // @testing-library/dom decides whether fake timers are installed by looking for
 // a `jest` global, then advances the clock through it. Without this shim its
 // waiting helpers schedule work on the faked clock and never resolve, so every

--- a/src/styles/CLAUDE.md
+++ b/src/styles/CLAUDE.md
@@ -4,5 +4,7 @@ Sass partials, no CSS of their own. `_breakpoints.scss` holds three mixins,
 `narrow-screen` (phone-width tables and navbar), `crowded-navbar` (too little
 room for the navbar to label its buttons), and `compact-screen` (too little room to
 center a dialog, so it rises from the bottom edge as a sheet), which have to be Sass
-because custom properties do not work inside a media query. Design tokens live in
+because custom properties do not work inside a media query. `_listbox.scss` holds
+`listbox-popup` and `listbox-item`, the shape the home page selects and the path to
+victory combobox both give a Base UI popup list. Design tokens live in
 `src/index.scss` instead.

--- a/src/styles/CLAUDE.md
+++ b/src/styles/CLAUDE.md
@@ -1,7 +1,8 @@
 # styles
 
-Sass partials, no CSS of their own. `_breakpoints.scss` holds two mixins,
-`narrow-screen` (phone-width tables and navbar) and `crowded-navbar` (too little
-room for the navbar to label its buttons), which have to be Sass because custom
-properties do not work inside a media query. Design tokens live in
+Sass partials, no CSS of their own. `_breakpoints.scss` holds three mixins,
+`narrow-screen` (phone-width tables and navbar), `crowded-navbar` (too little
+room for the navbar to label its buttons), and `compact-screen` (too little room to
+center a dialog, so it rises from the bottom edge as a sheet), which have to be Sass
+because custom properties do not work inside a media query. Design tokens live in
 `src/index.scss` instead.

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -11,6 +11,14 @@ $breakpoint-narrow: 400px;
  */
 $breakpoint-crowded-navbar: 560px;
 
+/**
+ * Below this a dialog centered in the viewport leaves too little either side of it
+ * to read as a window, and belongs on the bottom edge as a sheet instead. Wider
+ * than the navbar breakpoints, because this is about the width of a paragraph
+ * rather than about what fits in one bar.
+ */
+$breakpoint-compact: 600px;
+
 /** Phone-width screens, where the tables and navbar tighten up. */
 @mixin narrow-screen {
   @media (max-width: $breakpoint-narrow) {
@@ -21,6 +29,13 @@ $breakpoint-crowded-navbar: 560px;
 /** Too little room for the navbar to label its buttons. */
 @mixin crowded-navbar {
   @media (max-width: $breakpoint-crowded-navbar) {
+    @content;
+  }
+}
+
+/** Too little room to center a dialog, so it rises from the bottom edge. */
+@mixin compact-screen {
+  @media (max-width: $breakpoint-compact) {
     @content;
   }
 }

--- a/src/styles/_listbox.scss
+++ b/src/styles/_listbox.scss
@@ -1,0 +1,35 @@
+// The shape every Base UI popup list in the app shares: the season and week
+// selects on the home page, and the player combobox in the path to victory
+// dialog. Mixins only, so this emits no CSS of its own however many files pull it
+// in. Each caller adds what makes its own list different.
+
+@mixin listbox-popup {
+  box-sizing: border-box;
+  min-width: var(--anchor-width);
+  overflow-y: auto;
+  padding: 6px 0;
+  background-color: var(--rak-on-solid);
+  box-shadow: var(--rak-shadow-md);
+}
+
+@mixin listbox-item {
+  display: flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 4px 12px;
+  cursor: pointer;
+
+  &[data-highlighted] {
+    background-color: var(--rak-level1);
+  }
+
+  &[data-selected] {
+    background-color: var(--rak-neutral-200);
+  }
+
+  // A rule between rows rather than around them, so a long list reads down
+  // without a line closing the popup off from its own edge.
+  & + & {
+    border-top: 1px solid var(--rak-neutral-200);
+  }
+}

--- a/src/styles/_listbox.scss
+++ b/src/styles/_listbox.scss
@@ -8,6 +8,8 @@
   min-width: var(--anchor-width);
   overflow-y: auto;
   padding: 6px 0;
+  border: 1px solid var(--rak-border);
+  border-radius: var(--rak-radius-sm);
   background-color: var(--rak-on-solid);
   box-shadow: var(--rak-shadow-md);
 }

--- a/src/types/CLAUDE.md
+++ b/src/types/CLAUDE.md
@@ -1,3 +1,3 @@
 # src/types
 
-ESPN scoreboard shapes (EspnEvent, EspnCompetitor, GameStatus); League/SeasonType/WeekInfo/LeagueInfo; LeagueResult/Possession; GameScore pick-scoring result; RakMadnessScores/PlayerScore/PickResult/Status.
+ESPN scoreboard shapes (EspnEvent, EspnCompetitor, GameStatus); League/SeasonType/WeekInfo/LeagueInfo; LeagueResult/Possession; GameScore pick-scoring result; RakMadnessScores/PlayerScore/PickResult/Status; PathsToVictory, a union over eliminated, clinched, headline, and paths, so a summary cannot render a field that was never worked out.

--- a/src/types/PathsToVictory.ts
+++ b/src/types/PathsToVictory.ts
@@ -1,0 +1,90 @@
+/** A game still to be played, named the way the picks table names its columns. */
+export type RemainingPick = {
+  /** `C4`, `P11`: the position in the league's picks, which is the column label. */
+  label: string;
+  /** The cell as written, so the team and the spread read as they do in the table. */
+  pick: string;
+};
+
+/**
+ * A game still to be played that the player left blank. Nothing they do decides it,
+ * so a route through it needs the teams below to fall the right way.
+ */
+export type UncontrolledGame = {
+  label: string;
+  /** The teams a player still standing picked there, which all have to miss. */
+  needsToMiss: Array<string>;
+};
+
+/**
+ * How the week is settled once a route's games land.
+ *
+ * `settled` means the Monday night game is already final, so the standings carry its
+ * result and nothing here is open. `range` carries the totals that win, with an end
+ * absent where that side is unbounded.
+ */
+export type MondayNightOutlook =
+  | { kind: "notNeeded" }
+  | { kind: "settled" }
+  | {
+      kind: "range";
+      min?: number;
+      max?: number;
+      /** Who the player is level with on points, and so measured against. */
+      contenders: Array<string>;
+    };
+
+/** One way past the must-win games, and how it ends. */
+export type VictoryRoute = {
+  games: Array<RemainingPick>;
+  mondayNight: MondayNightOutlook;
+};
+
+/**
+ * What a player has to do to win a week that is still being played.
+ *
+ * Winning means finishing level with everyone or better, not finishing alone.
+ * `applyKnockouts` leaves a genuine tie standing and calls both players the winner,
+ * and this follows it.
+ */
+export type PathsToVictory =
+  /** `explanation` is the reason `applyKnockouts` already wrote. */
+  | { kind: "eliminated"; player: string; explanation?: string }
+  /** No result left can take the week off them. */
+  | { kind: "clinched"; player: string }
+  /**
+   * Too many games left to work out the routes, so this is a floor rather than a
+   * route: the fewest picks that could still be enough against the hardest rival.
+   */
+  | {
+      kind: "headline";
+      player: string;
+      remainingGameCount: number;
+      /** How many of those games the player has a pick in. */
+      remainingPickCount: number;
+      minimumWins: number;
+      /** Whether the player only draws level at that count, leaving Monday night to decide. */
+      needsMondayNight: boolean;
+    }
+  | {
+      kind: "paths";
+      player: string;
+      remainingGameCount: number;
+      /** How many points behind `leader` the player is now, zero when they lead. */
+      pointsBehind: number;
+      leader: string;
+      /** Games every route needs. */
+      mustWin: Array<RemainingPick>;
+      /** Set when the routes past `mustWin` are exactly "any `choose` of these". */
+      pool?: { choose: number; games: Array<RemainingPick> };
+      /** Set instead of `pool`, when the routes are not one pool of one size. */
+      routes?: Array<VictoryRoute>;
+      /** Routes past the ones `routes` lists. */
+      hiddenRouteCount: number;
+      /** Set when every route ends the same way, which is when `routes` is absent. */
+      mondayNight?: MondayNightOutlook;
+      /** The fewest wins that take the week whatever Monday night's total is. */
+      outrightAt?: number;
+      /** Empty unless no route wins regardless of the games the player left blank. */
+      needsHelp: Array<UncontrolledGame>;
+    };

--- a/src/types/PathsToVictory.ts
+++ b/src/types/PathsToVictory.ts
@@ -59,8 +59,7 @@ export type PathsToVictory =
   | {
       kind: "headline";
       player: string;
-      remainingGameCount: number;
-      /** How many of those games the player has a pick in. */
+      /** How many of the games still to be played the player has a pick in. */
       remainingPickCount: number;
       minimumWins: number;
       /** Whether the player only draws level at that count, leaving Monday night to decide. */
@@ -69,10 +68,6 @@ export type PathsToVictory =
   | {
       kind: "paths";
       player: string;
-      remainingGameCount: number;
-      /** How many points behind `leader` the player is now, zero when they lead. */
-      pointsBehind: number;
-      leader: string;
       /** Games every route needs. */
       mustWin: Array<RemainingPick>;
       /** Set when the routes past `mustWin` are exactly "any `choose` of these". */
@@ -81,7 +76,7 @@ export type PathsToVictory =
       routes?: Array<VictoryRoute>;
       /** Routes past the ones `routes` lists. */
       hiddenRouteCount: number;
-      /** Set when every route ends the same way, which is when `routes` is absent. */
+      /** Set when every route ends the same way, whether or not `routes` lists them. */
       mondayNight?: MondayNightOutlook;
       /** The fewest wins that take the week whatever Monday night's total is. */
       outrightAt?: number;

--- a/src/utils/getLeagueInfo.ts
+++ b/src/utils/getLeagueInfo.ts
@@ -72,7 +72,28 @@ const regularSeasonWeekCounts = new Map<string, number>();
  * 2026, not the 2026 games of the season after. Left out, ESPN answers with
  * whichever season is running now.
  */
-export default async function getLeagueInfo(
+export default function getLeagueInfo(
+  league: League,
+  season?: number,
+): Promise<LeagueInfo | null> {
+  // Two hooks can want the same calendar on the same render, and the season
+  // running now is the one they both ask for by name. One request answers both,
+  // and is dropped as it settles so the next ask is a fresh one.
+  const key = `${league}:${season ?? "current"}`;
+  const inFlight = requests.get(key);
+  if (inFlight != null) {
+    return inFlight;
+  }
+  const request = fetchLeagueInfo(league, season).finally(() =>
+    requests.delete(key),
+  );
+  requests.set(key, request);
+  return request;
+}
+
+const requests = new Map<string, Promise<LeagueInfo | null>>();
+
+async function fetchLeagueInfo(
   league: League,
   season?: number,
 ): Promise<LeagueInfo | null> {

--- a/src/utils/getLeagueInfo.ts
+++ b/src/utils/getLeagueInfo.ts
@@ -76,9 +76,8 @@ export default function getLeagueInfo(
   league: League,
   season?: number,
 ): Promise<LeagueInfo | null> {
-  // Two hooks can want the same calendar on the same render, and the season
-  // running now is the one they both ask for by name. One request answers both,
-  // and is dropped as it settles so the next ask is a fresh one.
+  // `useLeagueWeeks` and `getRegularSeasonWeekCount` ask for one season's calendar
+  // together. One request answers both, and is dropped as it settles.
   const key = `${league}:${season ?? "current"}`;
   const inFlight = requests.get(key);
   if (inFlight != null) {

--- a/src/utils/getLeagueInfo.ts
+++ b/src/utils/getLeagueInfo.ts
@@ -76,8 +76,8 @@ export default function getLeagueInfo(
   league: League,
   season?: number,
 ): Promise<LeagueInfo | null> {
-  // `useLeagueWeeks` and `getRegularSeasonWeekCount` ask for one season's calendar
-  // together. One request answers both, and is dropped as it settles.
+  // `useCurrentSeason` asks for whichever season is running, `useLeagueWeeks` and
+  // `getRegularSeasonWeekCount` for a named one. One request answers each, then drops.
   const key = `${league}:${season ?? "current"}`;
   const inFlight = requests.get(key);
   if (inFlight != null) {

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -19,14 +19,15 @@ sequences. `getPathsToVictory` is a second entry point, reading those results ba
   tiers leave tied have both won the week
 - `isWeekDecided`: whether every game and the tiebreaker are settled, which is when
   whoever the knockouts left standing has won
-- `applyKnockouts`: who can still win, and why not. Exports `remainingGameIndices`,
-  which reads the open games a column at a time, because a blank cell scores
-  "error" rather than "incomplete" and one row alone would drop a game that row's
-  player skipped
+- `remainingGames`: the open games a column at a time, each row's cell parsed. Read
+  a column at a time because a blank cell scores "error" rather than "incomplete",
+  so one row alone would drop a game that row's player skipped. Both halves of the
+  question below read it
+- `applyKnockouts`: who can still win, and why not
 - `getPathsToVictory`: the other half of `applyKnockouts`, for a player still
-  standing. Walks every way the open games can fall, up to ten of them, and
+  standing. Walks every way the contested games can fall, up to ten of them, and
   reduces the winning ones to the games that must go right, the pool the rest come
   from, and the Monday night totals that settle a dead heat on points. Where they
   do not reduce to a pool it lists the ten routes asking least of the player and
-  counts the rest. Above ten open games it gives a floor from a closed form
-  instead, since the search doubles per game
+  counts the rest. Past ten it gives a floor from a closed form instead, since the
+  search doubles per game

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -24,7 +24,9 @@ sequences. `getPathsToVictory` is a second entry point, reading those results ba
   "error" rather than "incomplete" and one row alone would drop a game that row's
   player skipped
 - `getPathsToVictory`: the other half of `applyKnockouts`, for a player still
-  standing. Walks every way the open games can fall, up to twelve of them, and
+  standing. Walks every way the open games can fall, up to ten of them, and
   reduces the winning ones to the games that must go right, the pool the rest come
-  from, and the Monday night totals that settle a dead heat on points. Above twelve
-  it gives a floor from a closed form instead, since the search doubles per game
+  from, and the Monday night totals that settle a dead heat on points. Where they
+  do not reduce to a pool it lists the ten routes asking least of the player and
+  counts the rest. Above ten open games it gives a floor from a closed form
+  instead, since the search doubles per game

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -1,7 +1,8 @@
 # scoring
 
 The picks-to-scoreboard pipeline, one concern per file. `getPlayerScores` is the only
-entry point the app calls; everything else is a step it sequences.
+entry point the app calls for a week's results; everything else is a step it
+sequences. `getPathsToVictory` is a second entry point, reading those results back.
 
 - `parsePicksWorkbook`: xlsx buffer to rows, column keys, and per-game matchups.
   Async because it imports `xlsx-js-style` on demand, which is over half the bundle.
@@ -13,7 +14,17 @@ entry point the app calls; everything else is a step it sequences.
 - `getPickResults`: scores picks against game results, plus `getStatus`
 - `getTiebreakerScore`: the Monday night game's real total, once it is final
 - `scorePlayers`: per-player totals, sorted
-- `comparePlayerScores`: the rank order and every tiebreaker tier
+- `comparePlayerScores`: the rank order. `comparePlayerScoresOnMerit` is every
+  tiebreaker tier without the name that settles a dead heat, since two players the
+  tiers leave tied have both won the week
 - `isWeekDecided`: whether every game and the tiebreaker are settled, which is when
   whoever the knockouts left standing has won
-- `applyKnockouts`: who can still win, and why not
+- `applyKnockouts`: who can still win, and why not. Exports `remainingGameIndices`,
+  which reads the open games a column at a time, because a blank cell scores
+  "error" rather than "incomplete" and one row alone would drop a game that row's
+  player skipped
+- `getPathsToVictory`: the other half of `applyKnockouts`, for a player still
+  standing. Walks every way the open games can fall, up to twelve of them, and
+  reduces the winning ones to the games that must go right, the pool the rest come
+  from, and the Monday night totals that settle a dead heat on points. Above twelve
+  it gives a floor from a closed form instead, since the search doubles per game

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -25,9 +25,9 @@ sequences. `getPathsToVictory` is a second entry point, reading those results ba
   question below read it
 - `applyKnockouts`: who can still win, and why not
 - `getPathsToVictory`: the other half of `applyKnockouts`, for a player still
-  standing. Walks every way the contested games can fall, up to ten of them, and
-  reduces the winning ones to the games that must go right, the pool the rest come
-  from, and the Monday night totals that settle a dead heat on points. Where they
-  do not reduce to a pool it lists the ten routes asking least of the player and
-  counts the rest. Past ten it gives a floor from a closed form instead, since the
-  search doubles per game
+  standing, once ten or fewer games are left. Walks every way the contested ones
+  can fall, and reduces the winning ones to the games that must go right, the pool
+  the rest come from, and the Monday night totals that settle a dead heat on
+  points. Where they do not reduce to a pool it lists the ten routes asking least
+  of the player and counts the rest. Above ten games it gives a floor from a closed
+  form instead, since the search doubles per game

--- a/src/utils/scoring/applyKnockouts.ts
+++ b/src/utils/scoring/applyKnockouts.ts
@@ -1,5 +1,8 @@
 import { PlayerScore } from "../../types/RakMadnessScores";
-import remainingGames, { RemainingGame } from "./remainingGames";
+import remainingGames, {
+  pickDifference,
+  RemainingGame,
+} from "./remainingGames";
 
 function ifNotOne(num: number, otherwise: string): string {
   return num !== 1 ? otherwise : "";
@@ -20,11 +23,7 @@ type PairDifferences = {
 
 /**
  * How many of the games still to be played these two players have picked
- * differently, which is the most ground the active player can still make up.
- *
- * A game the opponent left blank counts, because the active player can win a point
- * there that the opponent cannot. Only the active player's own blank is skipped:
- * neither of them can score it.
+ * differently, split by the tiebreaker tier each one can move.
  */
 function countDifferences(
   games: Array<RemainingGame>,
@@ -37,8 +36,8 @@ function countDifferences(
     differentProPicksWithSpreads: 0,
   };
   games.forEach((game) => {
+    if (pickDifference(game, activeIndex, oppIndex) === "none") return;
     const mine = game.cells[activeIndex];
-    if (mine.team == null || mine.team === game.cells[oppIndex].team) return;
     if (game.league === "college") {
       differences.differentCollegePicks += 1;
       return;

--- a/src/utils/scoring/applyKnockouts.ts
+++ b/src/utils/scoring/applyKnockouts.ts
@@ -1,5 +1,5 @@
 import { PlayerScore } from "../../types/RakMadnessScores";
-import parsePick from "./parsePick";
+import remainingGames, { RemainingGame } from "./remainingGames";
 
 function ifNotOne(num: number, otherwise: string): string {
   return num !== 1 ? otherwise : "";
@@ -10,27 +10,6 @@ function knockedOut(score: PlayerScore, explanation: string): PlayerScore {
     ...score,
     status: { ...score.status, isKnockedOut: true, explanation },
   };
-}
-
-/**
- * The positions of the games still to be played, read across every row.
- *
- * A row that left a game blank scores it "error", not "incomplete", so reading one
- * row alone would drop a game the leader happened to skip and knock out everybody
- * who needed it.
- */
-export function remainingGameIndices(
-  scores: Array<PlayerScore>,
-  league: "college" | "pro",
-): Array<number> {
-  const [firstPlayer] = scores;
-  return firstPlayer[league]
-    .map((_, index) =>
-      scores.some((score) => score[league][index].status === "incomplete")
-        ? index
-        : null,
-    )
-    .filter((index) => index != null);
 }
 
 type PairDifferences = {
@@ -46,44 +25,30 @@ type PairDifferences = {
  * A game the opponent left blank counts, because the active player can win a point
  * there that the opponent cannot. Only the active player's own blank is skipped:
  * neither of them can score it.
- *
- * A spread describes the game, so either row answers whether one is on it.
- * `parsePicksWorkbook` refuses to score a game whose rows disagree, which is what
- * makes reading the active player's own pick equivalent to reading the opponent's.
  */
 function countDifferences(
-  activeScore: PlayerScore,
-  oppScore: PlayerScore,
-  remainingCollegeIndices: Array<number>,
-  remainingProIndices: Array<number>,
+  games: Array<RemainingGame>,
+  activeIndex: number,
+  oppIndex: number,
 ): PairDifferences {
-  const differentCollegePicks = remainingCollegeIndices.reduce(
-    (sum, gameIndex) => {
-      const oppPick = oppScore.college[gameIndex].pick;
-      const activePick = activeScore.college[gameIndex].pick;
-      return activePick != null && oppPick !== activePick ? sum + 1 : sum;
-    },
-    0,
-  );
-
-  let differentProPicks = 0;
-  let differentProPicksWithSpreads = 0;
-  remainingProIndices.forEach((gameIndex) => {
-    const oppPick = oppScore.pro[gameIndex].pick;
-    const activePick = activeScore.pro[gameIndex].pick;
-    if (activePick != null && oppPick !== activePick) {
-      differentProPicks += 1;
-      if (parsePick(activePick).spread !== 0) {
-        differentProPicksWithSpreads += 1;
-      }
+  const differences = {
+    differentCollegePicks: 0,
+    differentProPicks: 0,
+    differentProPicksWithSpreads: 0,
+  };
+  games.forEach((game) => {
+    const mine = game.cells[activeIndex];
+    if (mine.team == null || mine.team === game.cells[oppIndex].team) return;
+    if (game.league === "college") {
+      differences.differentCollegePicks += 1;
+      return;
+    }
+    differences.differentProPicks += 1;
+    if (mine.hasSpread) {
+      differences.differentProPicksWithSpreads += 1;
     }
   });
-
-  return {
-    differentCollegePicks,
-    differentProPicks,
-    differentProPicksWithSpreads,
-  };
+  return differences;
 }
 
 /**
@@ -96,8 +61,8 @@ export default function applyKnockouts(
   sortedScores: Array<PlayerScore>,
   tiebreakerScore?: number,
 ): Array<PlayerScore> {
-  const remainingCollegeIndices = remainingGameIndices(sortedScores, "college");
-  const remainingProIndices = remainingGameIndices(sortedScores, "pro");
+  const games = remainingGames(sortedScores);
+  const isCollegeDone = games.every((game) => game.league !== "college");
 
   return sortedScores.map((activeScore, activeIndex) => {
     // If a player has no picks, they're knocked out.
@@ -125,12 +90,7 @@ export default function applyKnockouts(
           differentCollegePicks,
           differentProPicks,
           differentProPicksWithSpreads,
-        } = countDifferences(
-          activeScore,
-          oppScore,
-          remainingCollegeIndices,
-          remainingProIndices,
-        );
+        } = countDifferences(games, activeIndex, oppIndex);
 
         const totalScoreDiff = oppScore.score.total - activeScore.score.total;
         const totalDifferentPicks = differentCollegePicks + differentProPicks;
@@ -166,10 +126,7 @@ export default function applyKnockouts(
               );
             }
             // If college games are done and players are tied, check pro against the spread tiebreaker.
-            if (
-              collegeScoreDiff === 0 &&
-              remainingCollegeIndices.length === 0
-            ) {
+            if (collegeScoreDiff === 0 && isCollegeDone) {
               const proAgainstTheSpreadScoreDiff =
                 oppScore.score.proAgainstTheSpread -
                 activeScore.score.proAgainstTheSpread;

--- a/src/utils/scoring/applyKnockouts.ts
+++ b/src/utils/scoring/applyKnockouts.ts
@@ -24,6 +24,9 @@ type PairDifferences = {
 /**
  * How many of the games still to be played these two players have picked
  * differently, split by the tiebreaker tier each one can move.
+ *
+ * A game the rival left blank counts, because the active player can take a point
+ * there that the rival cannot.
  */
 function countDifferences(
   games: Array<RemainingGame>,
@@ -37,13 +40,13 @@ function countDifferences(
   };
   games.forEach((game) => {
     if (pickDifference(game, activeIndex, oppIndex) === "none") return;
-    const mine = game.cells[activeIndex];
+    const activeCell = game.cells[activeIndex];
     if (game.league === "college") {
       differences.differentCollegePicks += 1;
       return;
     }
     differences.differentProPicks += 1;
-    if (mine.hasSpread) {
+    if (activeCell.hasSpread) {
       differences.differentProPicksWithSpreads += 1;
     }
   });

--- a/src/utils/scoring/applyKnockouts.ts
+++ b/src/utils/scoring/applyKnockouts.ts
@@ -19,7 +19,7 @@ function knockedOut(score: PlayerScore, explanation: string): PlayerScore {
  * row alone would drop a game the leader happened to skip and knock out everybody
  * who needed it.
  */
-function remainingGameIndices(
+export function remainingGameIndices(
   scores: Array<PlayerScore>,
   league: "college" | "pro",
 ): Array<number> {

--- a/src/utils/scoring/comparePlayerScores.ts
+++ b/src/utils/scoring/comparePlayerScores.ts
@@ -38,10 +38,10 @@ const TIERS: Array<Tier> = [
   (a, b) => highestFirst(a.score.college, b.score.college),
   (a, b) =>
     highestFirst(a.score.proAgainstTheSpread, b.score.proAgainstTheSpread),
-  (a, b) => firstAlphabetically(a.name.toUpperCase(), b.name.toUpperCase()),
 ];
 
-export default function comparePlayerScores(
+/** Which of two players the pool itself ranks higher, ties left tied. */
+export function comparePlayerScoresOnMerit(
   a: PlayerScore,
   b: PlayerScore,
 ): number {
@@ -52,4 +52,20 @@ export default function comparePlayerScores(
     }
   }
   return 0;
+}
+
+/**
+ * The row order, which needs every pair separated even where the rules do not
+ * separate them. Two players the tiers leave tied have both won the week, so the
+ * name is a row order and not a tiebreaker, which is why it lives here rather than
+ * in `TIERS`.
+ */
+export default function comparePlayerScores(
+  a: PlayerScore,
+  b: PlayerScore,
+): number {
+  const onMerit = comparePlayerScoresOnMerit(a, b);
+  return onMerit !== 0
+    ? onMerit
+    : firstAlphabetically(a.name.toUpperCase(), b.name.toUpperCase());
 }

--- a/src/utils/scoring/getPathsToVictory.test.ts
+++ b/src/utils/scoring/getPathsToVictory.test.ts
@@ -209,18 +209,6 @@ describe("getPathsToVictory, the routes", () => {
     ]);
     expect(result.hiddenRouteCount).toBe(0);
   });
-
-  it("counts how far behind the leader the player is", () => {
-    const scores = week([
-      player({ name: "Alice", total: 3, pro: [pick("KC -3")] }),
-      player({ name: "Bob", total: 2, pro: [pick("DEN +3")] }),
-    ]);
-
-    const result = paths(getPathsToVictory(scores, "Bob"));
-    expect(result.leader).toBe("Alice");
-    expect(result.pointsBehind).toBe(1);
-    expect(result.remainingGameCount).toBe(1);
-  });
 });
 
 describe("getPathsToVictory, the Monday night tiebreaker", () => {
@@ -413,6 +401,40 @@ describe("getPathsToVictory, games out of the player's hands", () => {
     expect(result.needsHelp).toEqual([{ label: "P1", needsToMiss: ["KC"] }]);
   });
 
+  it("counts the routes wanting those games to fall some other way", () => {
+    // Winning P1 is enough, and so is winning P3, but the two need P2 and P4 to
+    // fall different ways. Only the P1 route is spelled out, since `needsHelp` is
+    // written once for every route shown, so the other is counted instead.
+    const scores = week([
+      player({
+        name: "Alice",
+        total: 1,
+        pro: [pick("KC -3"), pick(""), pick("SEA +6"), pick("")],
+      }),
+      player({
+        name: "Bob",
+        total: 1,
+        pro: [pick("KC -3"), pick("BUF -1"), pick(""), pick("CHI -2")],
+      }),
+      player({
+        name: "Carl",
+        total: 1,
+        pro: [pick("DEN +3"), pick("NYJ +1"), pick(""), pick("")],
+      }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(result.mustWin).toEqual([{ label: "P1", pick: "KC -3" }]);
+    expect(result.routes).toEqual([
+      { games: [], mondayNight: { kind: "notNeeded" } },
+    ]);
+    expect(result.hiddenRouteCount).toBe(1);
+    expect(result.needsHelp).toEqual([
+      { label: "P2", needsToMiss: ["BUF"] },
+      { label: "P4", needsToMiss: ["CHI"] },
+    ]);
+  });
+
   it("leaves it empty where a route wins however that game falls", () => {
     const scores = week([
       player({ name: "Alice", total: 5, pro: [pick("")] }),
@@ -455,16 +477,35 @@ describe("getPathsToVictory, weeks too big to search", () => {
     expect(getPathsToVictory(scores, "Alice")).toEqual({
       kind: "headline",
       player: "Alice",
-      remainingGameCount: 11,
       remainingPickCount: 11,
       minimumWins: 8,
       needsMondayNight: true,
     });
   });
 
-  it("counts the games in dispute, not the games left", () => {
-    // Eleven games left, ten of them picked the same way by both, so only one
-    // can change the order and the routes are worth working out.
+  it("leaves Monday night out where winning enough clears every rival", () => {
+    // The same eleven games with Alice four points back. Eight of them put her on
+    // eight and Bob on seven, so the count that draws her level is the count that
+    // takes the week, and the guesses never come into it.
+    const count = 11;
+    const scores = week([
+      player({ name: "Alice", total: 0, pro: opposed(count, "A", "-3") }),
+      player({ name: "Bob", total: 4, pro: opposed(count, "B", "+3") }),
+    ]);
+
+    expect(getPathsToVictory(scores, "Alice")).toEqual({
+      kind: "headline",
+      player: "Alice",
+      remainingPickCount: 11,
+      minimumWins: 8,
+      needsMondayNight: false,
+    });
+  });
+
+  it("counts the games left, whether or not they are in dispute", () => {
+    // Eleven games left, ten of them picked the same way by both. Only one can
+    // change the order, and a week this far out still gives a floor rather than
+    // routes.
     const agreed = Array.from({ length: 10 }, (_, index) =>
       pick(`S${index} -3`),
     );
@@ -473,8 +514,7 @@ describe("getPathsToVictory, weeks too big to search", () => {
       player({ name: "Bob", total: 1, pro: [...agreed, pick("DEN +3")] }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
-    expect(labels(result.mustWin)).toEqual(["P11"]);
+    expect(getPathsToVictory(scores, "Alice")?.kind).toBe("headline");
   });
 
   it("works the routes out at ten", () => {

--- a/src/utils/scoring/getPathsToVictory.test.ts
+++ b/src/utils/scoring/getPathsToVictory.test.ts
@@ -462,6 +462,21 @@ describe("getPathsToVictory, weeks too big to search", () => {
     });
   });
 
+  it("counts the games in dispute, not the games left", () => {
+    // Eleven games left, ten of them picked the same way by both, so only one
+    // can change the order and the routes are worth working out.
+    const agreed = Array.from({ length: 10 }, (_, index) =>
+      pick(`S${index} -3`),
+    );
+    const scores = week([
+      player({ name: "Alice", total: 0, pro: [...agreed, pick("KC -3")] }),
+      player({ name: "Bob", total: 1, pro: [...agreed, pick("DEN +3")] }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(labels(result.mustWin)).toEqual(["P11"]);
+  });
+
   it("works the routes out at ten", () => {
     const count = 10;
     const scores = week([

--- a/src/utils/scoring/getPathsToVictory.test.ts
+++ b/src/utils/scoring/getPathsToVictory.test.ts
@@ -1,0 +1,476 @@
+import { PathsToVictory } from "../../types/PathsToVictory";
+import {
+  PickResult,
+  PlayerScore,
+  RakMadnessScores,
+  Status,
+} from "../../types/RakMadnessScores";
+import getPathsToVictory from "./getPathsToVictory";
+
+/** A game still to be played unless a status says otherwise. */
+function pick(text: string, status: Status = "incomplete"): PickResult {
+  return { pick: text, status, explanation: { header: "", message: "" } };
+}
+
+type PlayerOptions = {
+  name: string;
+  college?: Array<PickResult>;
+  pro?: Array<PickResult>;
+  total?: number;
+  collegeScore?: number;
+  proAgainstTheSpread?: number;
+  tiebreakerPick?: number;
+  distance?: number;
+  isKnockedOut?: boolean;
+};
+
+function player({
+  name,
+  college = [],
+  pro = [],
+  total = 0,
+  collegeScore = 0,
+  proAgainstTheSpread = 0,
+  tiebreakerPick,
+  distance,
+  isKnockedOut = false,
+}: PlayerOptions): PlayerScore {
+  return {
+    name,
+    score: {
+      total,
+      college: collegeScore,
+      pro: total - collegeScore,
+      proAgainstTheSpread,
+    },
+    tiebreaker: { pick: tiebreakerPick, distance },
+    college,
+    pro,
+    status: { hasNoPicks: false, isKnockedOut },
+  };
+}
+
+function week(
+  players: Array<PlayerScore>,
+  tiebreaker?: number,
+): RakMadnessScores {
+  return { tiebreaker, scores: players };
+}
+
+/** Narrows to the routes result, so a case can read the fields it is about. */
+function paths(result: PathsToVictory | undefined) {
+  expect(result?.kind).toBe("paths");
+  return result as Extract<PathsToVictory, { kind: "paths" }>;
+}
+
+function labels(games: Array<{ label: string }>): Array<string> {
+  return games.map((game) => game.label);
+}
+
+describe("getPathsToVictory, whether there is anything to work out", () => {
+  it("has no answer for a name the sheet does not hold", () => {
+    const scores = week([player({ name: "Alice" })]);
+
+    expect(getPathsToVictory(scores, "Nobody")).toBeUndefined();
+  });
+
+  it("gives a knocked out player the reason they already carry", () => {
+    const scores = week([
+      player({ name: "Alice", total: 5 }),
+      player({
+        name: "Bob",
+        total: 0,
+        isKnockedOut: true,
+      }),
+    ]);
+    scores.scores[1].status.explanation =
+      "Knocked out on Total Score by Alice.";
+
+    expect(getPathsToVictory(scores, "Bob")).toEqual({
+      kind: "eliminated",
+      player: "Bob",
+      explanation: "Knocked out on Total Score by Alice.",
+    });
+  });
+
+  it("clinches a week no remaining game can change", () => {
+    // Both picked the same team, so the game moves both scores together and
+    // cannot close the gap.
+    const scores = week([
+      player({ name: "Alice", total: 5, pro: [pick("KC -3")] }),
+      player({ name: "Bob", total: 3, pro: [pick("KC -3")] }),
+    ]);
+
+    expect(getPathsToVictory(scores, "Alice")).toEqual({
+      kind: "clinched",
+      player: "Alice",
+    });
+  });
+
+  it("clinches once every rival left is knocked out", () => {
+    const scores = week([
+      player({ name: "Alice", total: 5, pro: [pick("KC -3")] }),
+      player({
+        name: "Bob",
+        total: 0,
+        pro: [pick("DEN +3")],
+        isKnockedOut: true,
+      }),
+    ]);
+
+    expect(getPathsToVictory(scores, "Alice")).toEqual({
+      kind: "clinched",
+      player: "Alice",
+    });
+  });
+});
+
+describe("getPathsToVictory, the routes", () => {
+  it("names the one game a player has to win", () => {
+    const scores = week([
+      player({ name: "Alice", total: 3, pro: [pick("KC -3")] }),
+      player({ name: "Bob", total: 3, pro: [pick("DEN +3")] }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(result.mustWin).toEqual([{ label: "P1", pick: "KC -3" }]);
+    expect(result.pool).toBeUndefined();
+    expect(result.routes).toBeUndefined();
+    expect(result.mondayNight).toEqual({ kind: "notNeeded" });
+    expect(result.outrightAt).toBe(1);
+  });
+
+  it("reads a pool of interchangeable games as any two of them", () => {
+    // Level on points with four games left that the two picked differently.
+    // Each one Alice takes is one Bob does not, so two of any of them is enough.
+    const alice = ["KC -3", "BUF -1", "SF -6", "GB -2"];
+    const bob = ["DEN +3", "NYJ +1", "SEA +6", "CHI +2"];
+    const scores = week([
+      player({ name: "Alice", total: 2, pro: alice.map((it) => pick(it)) }),
+      player({ name: "Bob", total: 2, pro: bob.map((it) => pick(it)) }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(result.mustWin).toEqual([]);
+    expect(result.pool?.choose).toBe(2);
+    expect(labels(result.pool?.games ?? [])).toEqual(["P1", "P2", "P3", "P4"]);
+    expect(result.hiddenRouteCount).toBe(0);
+  });
+
+  it("separates a must-win game from the pool behind it", () => {
+    // Bob differs on P1 alone, Carl on P2 and P3 alone, so Alice needs P1 and
+    // then either of the other two.
+    const scores = week([
+      player({
+        name: "Alice",
+        total: 0,
+        pro: [pick("KC -3"), pick("BUF -1"), pick("SF -6")],
+      }),
+      player({
+        name: "Bob",
+        total: 1,
+        pro: [pick("DEN +3"), pick("BUF -1"), pick("SF -6")],
+      }),
+      player({
+        name: "Carl",
+        total: 0,
+        pro: [pick("KC -3"), pick("NYJ +1"), pick("SEA +6")],
+      }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(result.mustWin).toEqual([{ label: "P1", pick: "KC -3" }]);
+    expect(result.pool?.choose).toBe(1);
+    expect(labels(result.pool?.games ?? [])).toEqual(["P2", "P3"]);
+  });
+
+  it("lists the routes when they are not one pool of one size", () => {
+    // P1 is worth two points against Bob, since the point Alice takes is one he
+    // loses. P2 and P3 are worth one each, because Bob picked neither.
+    const scores = week([
+      player({
+        name: "Alice",
+        total: 0,
+        pro: [pick("KC -3"), pick("BUF -1"), pick("SF -6")],
+      }),
+      player({
+        name: "Bob",
+        total: 1,
+        pro: [pick("DEN +3"), pick(""), pick("")],
+      }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(result.mustWin).toEqual([]);
+    expect(result.pool).toBeUndefined();
+    expect(result.routes?.map((route) => labels(route.games))).toEqual([
+      ["P1"],
+      ["P2", "P3"],
+    ]);
+    expect(result.hiddenRouteCount).toBe(0);
+  });
+
+  it("counts how far behind the leader the player is", () => {
+    const scores = week([
+      player({ name: "Alice", total: 3, pro: [pick("KC -3")] }),
+      player({ name: "Bob", total: 2, pro: [pick("DEN +3")] }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Bob"));
+    expect(result.leader).toBe("Alice");
+    expect(result.pointsBehind).toBe(1);
+    expect(result.remainingGameCount).toBe(1);
+  });
+});
+
+describe("getPathsToVictory, the Monday night tiebreaker", () => {
+  it("bounds the totals that win from above when the player guessed lower", () => {
+    // Level on points with nothing left to separate them but the guess. Alice is
+    // closer than Bob on every total under the midpoint of 45.5.
+    const scores = week([
+      player({
+        name: "Alice",
+        total: 3,
+        pro: [pick("KC -3")],
+        tiebreakerPick: 40,
+      }),
+      player({
+        name: "Bob",
+        total: 3,
+        pro: [pick("KC -3")],
+        tiebreakerPick: 51,
+      }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(result.mustWin).toEqual([]);
+    expect(result.mondayNight).toEqual({
+      kind: "range",
+      min: undefined,
+      max: 45,
+      contenders: ["Bob"],
+    });
+    expect(result.outrightAt).toBeUndefined();
+  });
+
+  it("bounds them from below when the player guessed higher", () => {
+    const scores = week([
+      player({
+        name: "Alice",
+        total: 3,
+        pro: [pick("KC -3")],
+        tiebreakerPick: 51,
+      }),
+      player({
+        name: "Bob",
+        total: 3,
+        pro: [pick("KC -3")],
+        tiebreakerPick: 40,
+      }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(result.mondayNight).toEqual({
+      kind: "range",
+      min: 46,
+      max: undefined,
+      contenders: ["Bob"],
+    });
+  });
+
+  it("keeps an exact midpoint, where neither guess is closer and the tiers below decide", () => {
+    // 40 and 50 sit either side of 45, and a total of 45 leaves both five off.
+    // Alice's better college score takes it from there.
+    const scores = week([
+      player({
+        name: "Alice",
+        total: 3,
+        collegeScore: 2,
+        pro: [pick("KC -3")],
+        tiebreakerPick: 50,
+      }),
+      player({
+        name: "Bob",
+        total: 3,
+        collegeScore: 1,
+        pro: [pick("KC -3")],
+        tiebreakerPick: 40,
+      }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(result.mondayNight).toEqual({
+      kind: "range",
+      min: 45,
+      max: undefined,
+      contenders: ["Bob"],
+    });
+  });
+
+  it("says which win takes the week whatever the total is", () => {
+    // P1 is worth two points against Bob and P2 only one, because he left P2
+    // blank. So P1 alone pulls Alice clear, while P2 alone only draws her level
+    // and hands the week to the guesses, where she is the closer of the two on
+    // anything under the midpoint of 32.5.
+    const scores = week([
+      player({
+        name: "Alice",
+        total: 3,
+        pro: [pick("KC -3"), pick("BUF -1")],
+        tiebreakerPick: 20,
+      }),
+      player({
+        name: "Bob",
+        total: 3,
+        pro: [pick("DEN +3"), pick("")],
+        tiebreakerPick: 45,
+      }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(result.mustWin).toEqual([]);
+    expect(result.outrightAt).toBe(1);
+    expect(result.mondayNight).toBeUndefined();
+    expect(result.routes).toEqual([
+      {
+        games: [{ label: "P1", pick: "KC -3" }],
+        mondayNight: { kind: "notNeeded" },
+      },
+      {
+        games: [{ label: "P2", pick: "BUF -1" }],
+        mondayNight: {
+          kind: "range",
+          min: undefined,
+          max: 32,
+          contenders: ["Bob"],
+        },
+      },
+    ]);
+  });
+
+  it("falls to the college score where both guessed the same total", () => {
+    const scores = week([
+      player({
+        name: "Alice",
+        total: 3,
+        collegeScore: 2,
+        pro: [pick("KC -3")],
+        tiebreakerPick: 45,
+      }),
+      player({
+        name: "Bob",
+        total: 3,
+        collegeScore: 1,
+        pro: [pick("KC -3")],
+        tiebreakerPick: 45,
+      }),
+    ]);
+
+    expect(getPathsToVictory(scores, "Alice")).toEqual({
+      kind: "clinched",
+      player: "Alice",
+    });
+  });
+
+  it("reads the tiebreaker as settled once its game is final", () => {
+    // The Monday night total is in, so the distances decide and no range is left
+    // to work out. A college game is still open, which keeps the week going.
+    const scores = week(
+      [
+        player({
+          name: "Alice",
+          total: 3,
+          college: [pick("UGA -7")],
+          tiebreakerPick: 44,
+          distance: 3,
+        }),
+        player({
+          name: "Bob",
+          total: 3,
+          college: [pick("BAMA +7")],
+          tiebreakerPick: 40,
+          distance: 7,
+        }),
+      ],
+      47,
+    );
+
+    const result = paths(getPathsToVictory(scores, "Bob"));
+    expect(result.mustWin).toEqual([{ label: "C1", pick: "BAMA +7" }]);
+    expect(result.mondayNight).toEqual({ kind: "settled" });
+  });
+});
+
+describe("getPathsToVictory, games out of the player's hands", () => {
+  it("names the team that has to miss where the player left a game blank", () => {
+    const scores = week([
+      player({ name: "Alice", total: 3, pro: [pick("")] }),
+      player({ name: "Bob", total: 3, pro: [pick("KC -3")] }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(result.mustWin).toEqual([]);
+    expect(result.needsHelp).toEqual([{ label: "P1", needsToMiss: ["KC"] }]);
+  });
+
+  it("leaves it empty where a route wins however that game falls", () => {
+    const scores = week([
+      player({ name: "Alice", total: 5, pro: [pick("")] }),
+      player({ name: "Bob", total: 3, pro: [pick("KC -3")] }),
+    ]);
+
+    expect(getPathsToVictory(scores, "Alice")).toEqual({
+      kind: "clinched",
+      player: "Alice",
+    });
+  });
+});
+
+describe("getPathsToVictory, weeks too big to search", () => {
+  /** Two sides of one game, on the same spread, so no tiebreaker tier splits them. */
+  function opposed(count: number, prefix: string, spread: string) {
+    return Array.from({ length: count }, (_, index) =>
+      pick(`${prefix}${index} ${spread}`),
+    );
+  }
+
+  it("gives a floor rather than routes above twelve open games", () => {
+    // Thirteen games the two picked differently, Alice five points back. Each one
+    // she takes is one Bob does not, so nine of them draw her level and a tenth
+    // takes it outright.
+    const count = 13;
+    const scores = week([
+      player({
+        name: "Alice",
+        total: 0,
+        pro: opposed(count, "A", "-3"),
+      }),
+      player({
+        name: "Bob",
+        total: 5,
+        pro: opposed(count, "B", "+3"),
+      }),
+    ]);
+
+    expect(getPathsToVictory(scores, "Alice")).toEqual({
+      kind: "headline",
+      player: "Alice",
+      remainingGameCount: 13,
+      remainingPickCount: 13,
+      minimumWins: 9,
+      needsMondayNight: true,
+    });
+  });
+
+  it("works the routes out at twelve", () => {
+    const count = 12;
+    const scores = week([
+      player({ name: "Alice", total: 0, pro: opposed(count, "A", "-3") }),
+      player({ name: "Bob", total: 0, pro: opposed(count, "B", "+3") }),
+    ]);
+
+    const result = paths(getPathsToVictory(scores, "Alice"));
+    expect(result.pool?.choose).toBe(6);
+    expect(result.pool?.games).toHaveLength(12);
+  });
+});

--- a/src/utils/scoring/getPathsToVictory.test.ts
+++ b/src/utils/scoring/getPathsToVictory.test.ts
@@ -434,11 +434,11 @@ describe("getPathsToVictory, weeks too big to search", () => {
     );
   }
 
-  it("gives a floor rather than routes above twelve open games", () => {
-    // Thirteen games the two picked differently, Alice five points back. Each one
-    // she takes is one Bob does not, so nine of them draw her level and a tenth
+  it("gives a floor rather than routes above ten open games", () => {
+    // Eleven games the two picked differently, Alice five points back. Each one
+    // she takes is one Bob does not, so eight of them draw her level and a ninth
     // takes it outright.
-    const count = 13;
+    const count = 11;
     const scores = week([
       player({
         name: "Alice",
@@ -455,22 +455,22 @@ describe("getPathsToVictory, weeks too big to search", () => {
     expect(getPathsToVictory(scores, "Alice")).toEqual({
       kind: "headline",
       player: "Alice",
-      remainingGameCount: 13,
-      remainingPickCount: 13,
-      minimumWins: 9,
+      remainingGameCount: 11,
+      remainingPickCount: 11,
+      minimumWins: 8,
       needsMondayNight: true,
     });
   });
 
-  it("works the routes out at twelve", () => {
-    const count = 12;
+  it("works the routes out at ten", () => {
+    const count = 10;
     const scores = week([
       player({ name: "Alice", total: 0, pro: opposed(count, "A", "-3") }),
       player({ name: "Bob", total: 0, pro: opposed(count, "B", "+3") }),
     ]);
 
     const result = paths(getPathsToVictory(scores, "Alice"));
-    expect(result.pool?.choose).toBe(6);
-    expect(result.pool?.games).toHaveLength(12);
+    expect(result.pool?.choose).toBe(5);
+    expect(result.pool?.games).toHaveLength(10);
   });
 });

--- a/src/utils/scoring/getPathsToVictory.ts
+++ b/src/utils/scoring/getPathsToVictory.ts
@@ -7,11 +7,14 @@ import {
 } from "../../types/PathsToVictory";
 import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
 import { comparePlayerScoresOnMerit } from "./comparePlayerScores";
-import remainingGames, { RemainingGame } from "./remainingGames";
+import remainingGames, {
+  pickDifference,
+  RemainingGame,
+} from "./remainingGames";
 
 /**
- * The most contested games the routes are worked out for. The search doubles in
- * cost with each one, and a fuller slate is too long an answer to read anyway.
+ * The most games still to play the routes are worked out for. The search doubles
+ * in cost with each one, and a fuller slate is too long an answer to read anyway.
  */
 const MAX_SEARCHED_GAMES = 10;
 
@@ -183,12 +186,13 @@ function evaluate(
     : { kind: "onTotal", lo, hi, contenders: level };
 }
 
-/** Prefers a win, then the outcome that leaves the widest range of totals. */
-function betterOf(a: Verdict | undefined, b: Verdict): Verdict {
-  if (a == null || a.kind === "loss") return b;
-  if (b.kind === "loss" || a.kind === "win") return a;
-  if (b.kind === "win") return b;
-  return b.hi - b.lo > a.hi - a.lo ? b : a;
+/** Whether `a` takes the week on more totals than `b`: a win, or a wider range. */
+function isBetter(a: Verdict, b: Verdict): boolean {
+  if (a.kind === "loss") return false;
+  if (b.kind === "loss") return true;
+  if (a.kind === "win") return b.kind !== "win";
+  if (b.kind === "win") return false;
+  return a.hi - a.lo > b.hi - b.lo;
 }
 
 type RouteOutcome = {
@@ -198,35 +202,21 @@ type RouteOutcome = {
 };
 
 /**
- * What a set of the player's own picks landing is worth.
- *
- * `guaranteed` holds the games the player left blank against them, so a route that
- * survives it wins however those fall. Only when nothing survives that are they
- * allowed to fall the player's way, which is where `needsHelp` comes from.
+ * What a set of the player's own picks landing is worth however the games they left
+ * blank fall, which is a route that can be reported without conditions.
  */
-function verdictFor(
+function guaranteedVerdict(
   hits: number,
   luckOutcomes: Array<number>,
-  guaranteed: boolean,
   read: (outcome: number) => Verdict,
-): RouteOutcome {
+): Verdict {
   let lo = 0;
   let hi = Number.POSITIVE_INFINITY;
   const level = new Set<string>();
-  let best: Verdict | undefined;
-  let bestLuck = 0;
 
   for (const luck of luckOutcomes) {
     const verdict = read(hits | luck);
-    if (!guaranteed) {
-      const improved = betterOf(best, verdict);
-      if (improved !== best) {
-        best = improved;
-        bestLuck = luck;
-      }
-      continue;
-    }
-    if (verdict.kind === "loss") return { verdict: LOSS, luck: 0 };
+    if (verdict.kind === "loss") return LOSS;
     if (verdict.kind === "onTotal") {
       lo = Math.max(lo, verdict.lo);
       hi = Math.min(hi, verdict.hi);
@@ -234,17 +224,32 @@ function verdictFor(
     }
   }
 
-  if (!guaranteed) {
-    return { verdict: best ?? LOSS, luck: bestLuck };
+  if (lo > hi) return LOSS;
+  return level.size === 0
+    ? WIN
+    : { kind: "onTotal", lo, hi, contenders: [...level] };
+}
+
+/**
+ * The best those same picks can do once the games the player left blank are allowed
+ * to fall their way, and the way they have to fall, which is where `needsHelp` comes
+ * from.
+ */
+function bestVerdict(
+  hits: number,
+  luckOutcomes: Array<number>,
+  read: (outcome: number) => Verdict,
+): RouteOutcome {
+  let best: Verdict = LOSS;
+  let bestLuck = 0;
+  for (const luck of luckOutcomes) {
+    const verdict = read(hits | luck);
+    if (isBetter(verdict, best)) {
+      best = verdict;
+      bestLuck = luck;
+    }
   }
-  if (lo > hi) return { verdict: LOSS, luck: 0 };
-  return {
-    verdict:
-      level.size === 0
-        ? WIN
-        : { kind: "onTotal", lo, hi, contenders: [...level] },
-    luck: 0,
-  };
+  return { verdict: best, luck: bestLuck };
 }
 
 function outlookOf(verdict: Verdict, isSettled: boolean): MondayNightOutlook {
@@ -269,7 +274,6 @@ function sameOutlook(a: MondayNightOutlook, b: MondayNightOutlook): boolean {
   );
 }
 
-/** How many ways `size` of `count` games can be chosen. */
 function combinations(count: number, size: number): number {
   let total = 1;
   for (let step = 0; step < size; step++) {
@@ -321,11 +325,9 @@ function fewestWinsToCatch(
   let different = 0;
   let playerOnly = 0;
   games.forEach((game) => {
-    const mine = game.cells[playerIndex].team;
-    const theirs = game.cells[rivalIndex].team;
-    if (mine == null) return;
-    if (theirs == null) playerOnly += 1;
-    else if (theirs !== mine) different += 1;
+    const difference = pickDifference(game, playerIndex, rivalIndex);
+    if (difference === "opposed") different += 1;
+    else if (difference === "playerOnly") playerOnly += 1;
   });
 
   const target = gap + different + (clear ? 1 : 0);
@@ -347,15 +349,16 @@ function headline(
       fewestWinsToCatch(playerIndex, rival.index, games, gap, clear);
     return { toLevel: at(false), toClear: at(true) };
   });
-  if (counts.some((count) => count.toLevel == null)) {
-    return eliminated(player);
-  }
 
-  const minimumWins = Math.max(...counts.map((count) => count.toLevel ?? 0));
+  // `toLevel` is only absent where `applyKnockouts` has already knocked the player
+  // out on total score, which `getPathsToVictory` answers before reaching here.
+  const minimumWins = Math.max(
+    0,
+    ...counts.map((count) => count.toLevel).filter((count) => count != null),
+  );
   return {
     kind: "headline",
     player: player.name,
-    remainingGameCount: games.length,
     remainingPickCount: games.filter(
       (game) => game.cells[playerIndex].team != null,
     ).length,
@@ -365,6 +368,144 @@ function headline(
     needsMondayNight: counts.some(
       (count) => count.toClear == null || count.toClear > minimumWins,
     ),
+  };
+}
+
+type Route = { hits: number; outcome: RouteOutcome };
+
+type Search = { minimal: Array<Route>; outrightAt?: number };
+
+/**
+ * The sets of the player's own picks that take the week, each one minimal.
+ *
+ * `ordered` is read fewest games first, so a set holding a winner already found adds
+ * nothing. It is still read while `outrightAt` is open, since a bigger set can win
+ * outright where the one inside it only draws level.
+ */
+function search(
+  ordered: Array<number>,
+  luckOutcomes: Array<number>,
+  guaranteed: boolean,
+  read: (outcome: number) => Verdict,
+): Search {
+  const minimal: Array<Route> = [];
+  let outrightAt: number | undefined;
+  for (const hits of ordered) {
+    const isRedundant = minimal.some(
+      (found) => (found.hits & hits) === found.hits,
+    );
+    if (isRedundant && outrightAt != null) continue;
+    const outcome = guaranteed
+      ? { verdict: guaranteedVerdict(hits, luckOutcomes, read), luck: 0 }
+      : bestVerdict(hits, luckOutcomes, read);
+    if (outcome.verdict.kind === "loss") continue;
+    if (outcome.verdict.kind === "win" && outrightAt == null) {
+      outrightAt = bitCount(hits);
+    }
+    if (!isRedundant) minimal.push({ hits, outcome });
+  }
+  return { minimal, outrightAt };
+}
+
+/**
+ * The games the player left blank, and who has to miss in each for `luck` to land.
+ *
+ * A bit set in `luck` is the game's coverer covering, so every other team a player
+ * still standing picked there has to miss. A bit clear is the coverer missing.
+ */
+function uncontrolledGames(
+  contested: Array<RemainingGame>,
+  live: Array<number>,
+  coverers: Array<string>,
+  luckMask: number,
+  luck: number,
+): Array<UncontrolledGame> {
+  return contested
+    .map((game, bit): UncontrolledGame | null => {
+      const mask = 1 << bit;
+      if ((luckMask & mask) === 0) return null;
+      const covers = (luck & mask) !== 0;
+      const teams = live
+        .map((index) => game.cells[index].team)
+        .filter((team) => team != null);
+      return {
+        label: game.label,
+        needsToMiss: [
+          ...new Set(
+            covers
+              ? teams.filter((team) => team !== coverers[bit])
+              : [coverers[bit]],
+          ),
+        ],
+      };
+    })
+    .filter((game) => game != null);
+}
+
+type RouteShape = {
+  mustWin: Array<RemainingPick>;
+  pool?: { choose: number; games: Array<RemainingPick> };
+  routes?: Array<VictoryRoute>;
+  hiddenRouteCount: number;
+  mondayNight?: MondayNightOutlook;
+};
+
+/** The games every route needs, and the ways past them: one pool, or a list. */
+function reduceRoutes(
+  minimal: Array<Route>,
+  dropped: number,
+  contested: Array<RemainingGame>,
+  playerIndex: number,
+  isMondayNightSettled: boolean,
+): RouteShape {
+  const mustWinMask = minimal.reduce(
+    (shared, route) => shared & route.hits,
+    minimal[0].hits,
+  );
+  const mustWin = picksIn(mustWinMask, contested, playerIndex);
+  const rests = minimal.map((route) => ({
+    mask: route.hits & ~mustWinMask,
+    outlook: outlookOf(route.outcome.verdict, isMondayNightSettled),
+  }));
+  const isOneOutlook = rests.every((rest) =>
+    sameOutlook(rest.outlook, rests[0].outlook),
+  );
+  const sizes = new Set(rests.map((rest) => bitCount(rest.mask)));
+  const poolMask = rests.reduce((all, rest) => all | rest.mask, 0);
+  const choose = bitCount(rests[0].mask);
+  // Every way of choosing that many of the pool is a route only when there are as
+  // many routes as there are ways, since each route is a different one of them.
+  const isPool =
+    dropped === 0 &&
+    isOneOutlook &&
+    sizes.size === 1 &&
+    rests.length === combinations(bitCount(poolMask), choose);
+
+  if (isPool) {
+    return {
+      mustWin,
+      pool:
+        choose > 0
+          ? { choose, games: picksIn(poolMask, contested, playerIndex) }
+          : undefined,
+      hiddenRouteCount: 0,
+      mondayNight: rests[0].outlook,
+    };
+  }
+
+  // Fewest games first, so the routes asking least of the player are the ones kept
+  // and the ones shown before the rest are unfolded.
+  const routes: Array<VictoryRoute> = rests
+    .map((rest) => ({
+      games: picksIn(rest.mask, contested, playerIndex),
+      mondayNight: rest.outlook,
+    }))
+    .sort((a, b) => a.games.length - b.games.length);
+  return {
+    mustWin,
+    routes: routes.slice(0, MAX_LISTED_ROUTES),
+    hiddenRouteCount: Math.max(0, routes.length - MAX_LISTED_ROUTES) + dropped,
+    mondayNight: isOneOutlook ? rests[0].outlook : undefined,
   };
 }
 
@@ -399,13 +540,14 @@ export default function getPathsToVictory(
   // A game every live player picked the same way moves all their scores together,
   // in the total and in both tiebreaker tiers, so it cannot change the order.
   const games = remainingGames(players);
+  if (games.length > MAX_SEARCHED_GAMES) {
+    return headline(player, playerIndex, rivals, games);
+  }
+
   const live = [playerIndex, ...rivals.map((it) => it.index)];
   const contested = games.filter(
     (game) => new Set(live.map((index) => game.cells[index].team)).size > 1,
   );
-  if (contested.length > MAX_SEARCHED_GAMES) {
-    return headline(player, playerIndex, rivals, games);
-  }
 
   // The bit for a game reads as the player's own pick landing, or where they have
   // no pick, as a live rival's. A contested game always holds one of those.
@@ -435,64 +577,34 @@ export default function getPathsToVictory(
     (a, b) => bitCount(a) - bitCount(b) || a - b,
   );
   const luckOutcomes = subMasks(luckMask);
-  const search = (guaranteed: boolean) => {
-    const minimal: Array<{ hits: number; outcome: RouteOutcome }> = [];
-    let outrightAt: number | undefined;
-    for (const hits of ordered) {
-      const isRedundant = minimal.some(
-        (found) => (found.hits & hits) === found.hits,
-      );
-      if (isRedundant && outrightAt != null) continue;
-      const outcome = verdictFor(hits, luckOutcomes, guaranteed, read);
-      if (outcome.verdict.kind === "loss") continue;
-      if (outcome.verdict.kind === "win" && outrightAt == null) {
-        outrightAt = bitCount(hits);
-      }
-      if (!isRedundant) minimal.push({ hits, outcome });
-    }
-    return { minimal, outrightAt };
-  };
 
   // Held against the player first, so a route that survives every way the games
   // they left blank can fall is reported without conditions.
-  let found = search(true);
+  let { minimal, outrightAt } = search(ordered, luckOutcomes, true, read);
   let needsHelp: Array<UncontrolledGame> = [];
   let dropped = 0;
-  if (found.minimal.length === 0 && luckMask !== 0) {
-    found = search(false);
-    const [best] = found.minimal;
+  if (minimal.length === 0 && luckMask !== 0) {
+    const helped = search(ordered, luckOutcomes, false, read);
+    const [best] = helped.minimal;
     if (best != null) {
-      // The games below are written once for every route shown, so the routes
-      // wanting those to fall some other way are counted rather than listed.
-      const kept = found.minimal.filter(
+      // `needsHelp` is written once for every route shown, so the routes wanting
+      // those games to fall some other way are counted rather than listed.
+      const kept = helped.minimal.filter(
         (route) => route.outcome.luck === best.outcome.luck,
       );
-      dropped = found.minimal.length - kept.length;
-      found = { ...found, minimal: kept };
-      needsHelp = contested
-        .map((game, bit): UncontrolledGame | null => {
-          const mask = 1 << bit;
-          if ((luckMask & mask) === 0) return null;
-          const covers = (best.outcome.luck & mask) !== 0;
-          const teams = live
-            .map((index) => game.cells[index].team)
-            .filter((team) => team != null);
-          return {
-            label: game.label,
-            needsToMiss: [
-              ...new Set(
-                covers
-                  ? teams.filter((team) => team !== coverers[bit])
-                  : [coverers[bit]],
-              ),
-            ],
-          };
-        })
-        .filter((game) => game != null);
+      minimal = kept;
+      dropped = helped.minimal.length - kept.length;
+      outrightAt = helped.outrightAt;
+      needsHelp = uncontrolledGames(
+        contested,
+        live,
+        coverers,
+        luckMask,
+        best.outcome.luck,
+      );
     }
   }
 
-  const { minimal, outrightAt } = found;
   if (minimal.length === 0) {
     return eliminated(player);
   }
@@ -507,64 +619,17 @@ export default function getPathsToVictory(
     return { kind: "clinched", player: player.name };
   }
 
-  const mustWinMask = minimal.reduce(
-    (shared, route) => shared & route.hits,
-    minimal[0].hits,
-  );
-  const rests = minimal.map((route) => ({
-    mask: route.hits & ~mustWinMask,
-    outlook: outlookOf(route.outcome.verdict, isMondayNightSettled),
-  }));
-  const isOneOutlook = rests.every((rest) =>
-    sameOutlook(rest.outlook, rests[0].outlook),
-  );
-  const sizes = new Set(rests.map((rest) => bitCount(rest.mask)));
-  const poolMask = rests.reduce((all, rest) => all | rest.mask, 0);
-  const choose = bitCount(rests[0].mask);
-  // Every way of choosing that many of the pool is a route only when there are as
-  // many routes as there are ways, since each route is a different one of them.
-  const isPool =
-    dropped === 0 &&
-    isOneOutlook &&
-    sizes.size === 1 &&
-    rests.length === combinations(bitCount(poolMask), choose);
-
-  const leader = players[0];
-  const base = {
-    kind: "paths" as const,
+  return {
+    kind: "paths",
     player: player.name,
-    remainingGameCount: games.length,
-    pointsBehind: Math.max(0, leader.score.total - player.score.total),
-    leader: leader.name,
-    mustWin: picksIn(mustWinMask, contested, playerIndex),
+    ...reduceRoutes(
+      minimal,
+      dropped,
+      contested,
+      playerIndex,
+      isMondayNightSettled,
+    ),
     outrightAt,
     needsHelp,
-  };
-
-  if (isPool) {
-    return {
-      ...base,
-      pool:
-        choose > 0
-          ? { choose, games: picksIn(poolMask, contested, playerIndex) }
-          : undefined,
-      hiddenRouteCount: 0,
-      mondayNight: rests[0].outlook,
-    };
-  }
-
-  // Fewest games first, so the routes asking least of the player are the ones kept
-  // and the ones shown before the rest are unfolded.
-  const routes: Array<VictoryRoute> = rests
-    .map((rest) => ({
-      games: picksIn(rest.mask, contested, playerIndex),
-      mondayNight: rest.outlook,
-    }))
-    .sort((a, b) => a.games.length - b.games.length);
-  return {
-    ...base,
-    routes: routes.slice(0, MAX_LISTED_ROUTES),
-    hiddenRouteCount: Math.max(0, routes.length - MAX_LISTED_ROUTES) + dropped,
-    mondayNight: isOneOutlook ? rests[0].outlook : undefined,
   };
 }

--- a/src/utils/scoring/getPathsToVictory.ts
+++ b/src/utils/scoring/getPathsToVictory.ts
@@ -13,8 +13,8 @@ import remainingGames, {
 } from "./remainingGames";
 
 /**
- * The most games still to play the routes are worked out for. The search doubles
- * in cost with each one, and a fuller slate is too long an answer to read anyway.
+ * The most games still to play the routes are worked out for. Only the contested
+ * ones are searched, and the search doubles per one, so this is a loose ceiling.
  */
 const MAX_SEARCHED_GAMES = 10;
 
@@ -384,9 +384,7 @@ type Search = { minimal: Array<Route>; outrightAt?: number };
  */
 function search(
   ordered: Array<number>,
-  luckOutcomes: Array<number>,
-  guaranteed: boolean,
-  read: (outcome: number) => Verdict,
+  outcomeOf: (hits: number) => RouteOutcome,
 ): Search {
   const minimal: Array<Route> = [];
   let outrightAt: number | undefined;
@@ -395,9 +393,7 @@ function search(
       (found) => (found.hits & hits) === found.hits,
     );
     if (isRedundant && outrightAt != null) continue;
-    const outcome = guaranteed
-      ? { verdict: guaranteedVerdict(hits, luckOutcomes, read), luck: 0 }
-      : bestVerdict(hits, luckOutcomes, read);
+    const outcome = outcomeOf(hits);
     if (outcome.verdict.kind === "loss") continue;
     if (outcome.verdict.kind === "win" && outrightAt == null) {
       outrightAt = bitCount(hits);
@@ -417,13 +413,13 @@ function uncontrolledGames(
   contested: Array<RemainingGame>,
   live: Array<number>,
   coverers: Array<string>,
-  luckMask: number,
+  playerIndex: number,
   luck: number,
 ): Array<UncontrolledGame> {
   return contested
     .map((game, bit): UncontrolledGame | null => {
+      if (game.cells[playerIndex].team != null) return null;
       const mask = 1 << bit;
-      if ((luckMask & mask) === 0) return null;
       const covers = (luck & mask) !== 0;
       const teams = live
         .map((index) => game.cells[index].team)
@@ -442,13 +438,10 @@ function uncontrolledGames(
     .filter((game) => game != null);
 }
 
-type RouteShape = {
-  mustWin: Array<RemainingPick>;
-  pool?: { choose: number; games: Array<RemainingPick> };
-  routes?: Array<VictoryRoute>;
-  hiddenRouteCount: number;
-  mondayNight?: MondayNightOutlook;
-};
+type RouteShape = Pick<
+  Extract<PathsToVictory, { kind: "paths" }>,
+  "mustWin" | "pool" | "routes" | "hiddenRouteCount" | "mondayNight"
+>;
 
 /** The games every route needs, and the ways past them: one pool, or a list. */
 function reduceRoutes(
@@ -580,11 +573,16 @@ export default function getPathsToVictory(
 
   // Held against the player first, so a route that survives every way the games
   // they left blank can fall is reported without conditions.
-  let { minimal, outrightAt } = search(ordered, luckOutcomes, true, read);
+  let { minimal, outrightAt } = search(ordered, (hits) => ({
+    verdict: guaranteedVerdict(hits, luckOutcomes, read),
+    luck: 0,
+  }));
   let needsHelp: Array<UncontrolledGame> = [];
   let dropped = 0;
   if (minimal.length === 0 && luckMask !== 0) {
-    const helped = search(ordered, luckOutcomes, false, read);
+    const helped = search(ordered, (hits) =>
+      bestVerdict(hits, luckOutcomes, read),
+    );
     const [best] = helped.minimal;
     if (best != null) {
       // `needsHelp` is written once for every route shown, so the routes wanting
@@ -599,7 +597,7 @@ export default function getPathsToVictory(
         contested,
         live,
         coverers,
-        luckMask,
+        playerIndex,
         best.outcome.luck,
       );
     }

--- a/src/utils/scoring/getPathsToVictory.ts
+++ b/src/utils/scoring/getPathsToVictory.ts
@@ -18,10 +18,10 @@ import parsePick from "./parsePick";
  * one. A Thursday with a full slate left would run to millions of scenarios for an
  * answer too long to read anyway. Above this the caller gets a floor instead.
  */
-const MAX_SEARCHED_GAMES = 12;
+const MAX_SEARCHED_GAMES = 10;
 
-/** How many routes are listed before the rest are only counted. */
-const MAX_LISTED_ROUTES = 6;
+/** How many routes are carried before the rest are only counted. */
+const MAX_LISTED_ROUTES = 10;
 
 type LeagueKey = "college" | "pro";
 
@@ -611,6 +611,8 @@ export default function getPathsToVictory(
     };
   }
 
+  // Fewest games first, so the routes asking least of the player are the ones kept
+  // and the ones shown before the rest are unfolded.
   const routes: Array<VictoryRoute> = rests
     .map((rest) => ({
       games: picksIn(rest.mask, contested, playerIndex),

--- a/src/utils/scoring/getPathsToVictory.ts
+++ b/src/utils/scoring/getPathsToVictory.ts
@@ -6,42 +6,17 @@ import {
   VictoryRoute,
 } from "../../types/PathsToVictory";
 import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
-import rangeWithPrefix from "../rangeWithPrefix";
-import { remainingGameIndices } from "./applyKnockouts";
 import { comparePlayerScoresOnMerit } from "./comparePlayerScores";
-import parsePick from "./parsePick";
+import remainingGames, { RemainingGame } from "./remainingGames";
 
 /**
- * The most games still to be played that the routes are worked out for.
- *
- * The search walks every way the open games can fall, so its cost doubles with each
- * one. A Thursday with a full slate left would run to millions of scenarios for an
- * answer too long to read anyway. Above this the caller gets a floor instead.
+ * The most contested games the routes are worked out for. The search doubles in
+ * cost with each one, and a fuller slate is too long an answer to read anyway.
  */
 const MAX_SEARCHED_GAMES = 10;
 
 /** How many routes are carried before the rest are only counted. */
 const MAX_LISTED_ROUTES = 10;
-
-type LeagueKey = "college" | "pro";
-
-const LEAGUES: Array<LeagueKey> = ["college", "pro"];
-
-const LEAGUE_PREFIX: Record<LeagueKey, string> = { college: "C", pro: "P" };
-
-type Cell = {
-  /** Absent where the player left the game blank, which scores them nothing. */
-  team?: string;
-  hasSpread: boolean;
-  text: string;
-};
-
-type RemainingGame = {
-  label: string;
-  league: LeagueKey;
-  /** Every row's cell, in the order the scores hold their players. */
-  cells: Array<Cell>;
-};
 
 /**
  * Where a player takes a point, as one bit per open game.
@@ -93,29 +68,6 @@ function subMasks(mask: number): Array<number> {
     if (subset === 0) break;
   }
   return masks;
-}
-
-/**
- * The games still to be played, read a column at a time.
- *
- * `remainingGameIndices` is the same reading `applyKnockouts` does, and for the same
- * reason: a blank cell scores "error" rather than "incomplete", so one row alone
- * would drop a game that row's player happened to skip.
- */
-function remainingGames(players: Array<PlayerScore>): Array<RemainingGame> {
-  const [first] = players;
-  return LEAGUES.flatMap((league) => {
-    const labels = rangeWithPrefix(first[league].length, LEAGUE_PREFIX[league]);
-    return remainingGameIndices(players, league).map((index) => ({
-      label: labels[index],
-      league,
-      cells: players.map((player) => {
-        const text = player[league][index].pick ?? "";
-        const { teamAbbreviation, spread } = parsePick(text);
-        return { team: teamAbbreviation, hasSpread: spread !== 0, text };
-      }),
-    }));
-  });
 }
 
 function gainsFor(
@@ -254,7 +206,7 @@ type RouteOutcome = {
  */
 function verdictFor(
   hits: number,
-  luckMask: number,
+  luckOutcomes: Array<number>,
   guaranteed: boolean,
   read: (outcome: number) => Verdict,
 ): RouteOutcome {
@@ -264,7 +216,7 @@ function verdictFor(
   let best: Verdict | undefined;
   let bestLuck = 0;
 
-  for (const luck of subMasks(luckMask)) {
+  for (const luck of luckOutcomes) {
     const verdict = read(hits | luck);
     if (!guaranteed) {
       const improved = betterOf(best, verdict);
@@ -340,6 +292,15 @@ function picksIn(
     .filter((pick) => pick != null);
 }
 
+/** Carries the reason `applyKnockouts` already wrote, rather than writing another. */
+function eliminated(player: PlayerScore): PathsToVictory {
+  return {
+    kind: "eliminated",
+    player: player.name,
+    explanation: player.status.explanation,
+  };
+}
+
 /**
  * The fewest of their own remaining picks the player has to win to reach a rival.
  *
@@ -380,34 +341,17 @@ function headline(
   rivals: Array<{ player: PlayerScore; index: number }>,
   games: Array<RemainingGame>,
 ): PathsToVictory {
-  let minimumWins = 0;
-  let needsMondayNight = false;
-  for (const rival of rivals) {
+  const counts = rivals.map((rival) => {
     const gap = rival.player.score.total - player.score.total;
-    const toLevel = fewestWinsToCatch(
-      playerIndex,
-      rival.index,
-      games,
-      gap,
-      false,
-    );
-    if (toLevel == null) {
-      return {
-        kind: "eliminated",
-        player: player.name,
-        explanation: player.status.explanation,
-      };
-    }
-    minimumWins = Math.max(minimumWins, toLevel);
-    const toClear = fewestWinsToCatch(
-      playerIndex,
-      rival.index,
-      games,
-      gap,
-      true,
-    );
-    if (toClear == null || toClear > toLevel) needsMondayNight = true;
+    const at = (clear: boolean) =>
+      fewestWinsToCatch(playerIndex, rival.index, games, gap, clear);
+    return { toLevel: at(false), toClear: at(true) };
+  });
+  if (counts.some((count) => count.toLevel == null)) {
+    return eliminated(player);
   }
+
+  const minimumWins = Math.max(...counts.map((count) => count.toLevel ?? 0));
   return {
     kind: "headline",
     player: player.name,
@@ -416,7 +360,11 @@ function headline(
       (game) => game.cells[playerIndex].team != null,
     ).length,
     minimumWins,
-    needsMondayNight,
+    // Winning that many still only draws level with somebody, so the tiebreaker
+    // would decide it.
+    needsMondayNight: counts.some(
+      (count) => count.toClear == null || count.toClear > minimumWins,
+    ),
   };
 }
 
@@ -436,15 +384,11 @@ export default function getPathsToVictory(
 
   const player = players[playerIndex];
   if (player.status.isKnockedOut) {
-    return {
-      kind: "eliminated",
-      player: player.name,
-      explanation: player.status.explanation,
-    };
+    return eliminated(player);
   }
 
-  // A player already knocked out cannot take the week off anyone, so they are not
-  // measured against. That is what keeps the search small late in a week.
+  // A knocked out player cannot take the week off anyone, so they are not measured
+  // against. That is what keeps the search small late in a week.
   const rivals = players
     .map((it, index) => ({ player: it, index }))
     .filter((it) => it.index !== playerIndex && !it.player.status.isKnockedOut);
@@ -452,32 +396,24 @@ export default function getPathsToVictory(
     return { kind: "clinched", player: player.name };
   }
 
-  const games = remainingGames(players);
-  if (games.length > MAX_SEARCHED_GAMES) {
-    return headline(player, playerIndex, rivals, games);
-  }
-
   // A game every live player picked the same way moves all their scores together,
-  // in the total and in both tiebreaker tiers, so it cannot change the order and
-  // does not need searching.
+  // in the total and in both tiebreaker tiers, so it cannot change the order.
+  const games = remainingGames(players);
   const live = [playerIndex, ...rivals.map((it) => it.index)];
   const contested = games.filter(
     (game) => new Set(live.map((index) => game.cells[index].team)).size > 1,
   );
+  if (contested.length > MAX_SEARCHED_GAMES) {
+    return headline(player, playerIndex, rivals, games);
+  }
 
-  // The bit for a game reads as the player's own pick landing. Where they have no
-  // pick it reads as the first team a live rival took covering, which is a side to
-  // measure from and nothing more.
-  const coverers = contested.map((game) => {
-    const mine = game.cells[playerIndex].team;
-    if (mine != null) return mine;
-    // A contested game always holds one, since a column every live player left
-    // blank cannot differ between them.
-    const anyRival = live
-      .map((index) => game.cells[index].team)
-      .find((team) => team != null);
-    return anyRival ?? "";
-  });
+  // The bit for a game reads as the player's own pick landing, or where they have
+  // no pick, as a live rival's. A contested game always holds one of those.
+  const coverers = contested.map(
+    (game) =>
+      game.cells[playerIndex].team ??
+      live.map((index) => game.cells[index].team).find((team) => team != null)!,
+  );
 
   const gains = gainsFor(playerIndex, contested, coverers);
   const contenders: Array<Contender> = rivals.map((rival) => ({
@@ -498,6 +434,7 @@ export default function getPathsToVictory(
   const ordered = subMasks(mineMask).sort(
     (a, b) => bitCount(a) - bitCount(b) || a - b,
   );
+  const luckOutcomes = subMasks(luckMask);
   const search = (guaranteed: boolean) => {
     const minimal: Array<{ hits: number; outcome: RouteOutcome }> = [];
     let outrightAt: number | undefined;
@@ -506,7 +443,7 @@ export default function getPathsToVictory(
         (found) => (found.hits & hits) === found.hits,
       );
       if (isRedundant && outrightAt != null) continue;
-      const outcome = verdictFor(hits, luckMask, guaranteed, read);
+      const outcome = verdictFor(hits, luckOutcomes, guaranteed, read);
       if (outcome.verdict.kind === "loss") continue;
       if (outcome.verdict.kind === "win" && outrightAt == null) {
         outrightAt = bitCount(hits);
@@ -520,10 +457,18 @@ export default function getPathsToVictory(
   // they left blank can fall is reported without conditions.
   let found = search(true);
   let needsHelp: Array<UncontrolledGame> = [];
+  let dropped = 0;
   if (found.minimal.length === 0 && luckMask !== 0) {
     found = search(false);
     const [best] = found.minimal;
     if (best != null) {
+      // The games below are written once for every route shown, so the routes
+      // wanting those to fall some other way are counted rather than listed.
+      const kept = found.minimal.filter(
+        (route) => route.outcome.luck === best.outcome.luck,
+      );
+      dropped = found.minimal.length - kept.length;
+      found = { ...found, minimal: kept };
       needsHelp = contested
         .map((game, bit): UncontrolledGame | null => {
           const mask = 1 << bit;
@@ -549,11 +494,7 @@ export default function getPathsToVictory(
 
   const { minimal, outrightAt } = found;
   if (minimal.length === 0) {
-    return {
-      kind: "eliminated",
-      player: player.name,
-      explanation: player.status.explanation,
-    };
+    return eliminated(player);
   }
   // Nothing left to win, and nothing the games they left blank can do about it.
   // A route that only survives because those fell right is not a clinch.
@@ -583,6 +524,7 @@ export default function getPathsToVictory(
   // Every way of choosing that many of the pool is a route only when there are as
   // many routes as there are ways, since each route is a different one of them.
   const isPool =
+    dropped === 0 &&
     isOneOutlook &&
     sizes.size === 1 &&
     rests.length === combinations(bitCount(poolMask), choose);
@@ -622,7 +564,7 @@ export default function getPathsToVictory(
   return {
     ...base,
     routes: routes.slice(0, MAX_LISTED_ROUTES),
-    hiddenRouteCount: Math.max(0, routes.length - MAX_LISTED_ROUTES),
+    hiddenRouteCount: Math.max(0, routes.length - MAX_LISTED_ROUTES) + dropped,
     mondayNight: isOneOutlook ? rests[0].outlook : undefined,
   };
 }

--- a/src/utils/scoring/getPathsToVictory.ts
+++ b/src/utils/scoring/getPathsToVictory.ts
@@ -1,0 +1,626 @@
+import {
+  MondayNightOutlook,
+  PathsToVictory,
+  RemainingPick,
+  UncontrolledGame,
+  VictoryRoute,
+} from "../../types/PathsToVictory";
+import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
+import rangeWithPrefix from "../rangeWithPrefix";
+import { remainingGameIndices } from "./applyKnockouts";
+import { comparePlayerScoresOnMerit } from "./comparePlayerScores";
+import parsePick from "./parsePick";
+
+/**
+ * The most games still to be played that the routes are worked out for.
+ *
+ * The search walks every way the open games can fall, so its cost doubles with each
+ * one. A Thursday with a full slate left would run to millions of scenarios for an
+ * answer too long to read anyway. Above this the caller gets a floor instead.
+ */
+const MAX_SEARCHED_GAMES = 12;
+
+/** How many routes are listed before the rest are only counted. */
+const MAX_LISTED_ROUTES = 6;
+
+type LeagueKey = "college" | "pro";
+
+const LEAGUES: Array<LeagueKey> = ["college", "pro"];
+
+const LEAGUE_PREFIX: Record<LeagueKey, string> = { college: "C", pro: "P" };
+
+type Cell = {
+  /** Absent where the player left the game blank, which scores them nothing. */
+  team?: string;
+  hasSpread: boolean;
+  text: string;
+};
+
+type RemainingGame = {
+  label: string;
+  league: LeagueKey;
+  /** Every row's cell, in the order the scores hold their players. */
+  cells: Array<Cell>;
+};
+
+/**
+ * Where a player takes a point, as one bit per open game.
+ *
+ * A bit being set means the game's named team covered. Both directions are kept
+ * because the other side of a game is worth a point to whoever picked it, so a
+ * player's score has to be read off the outcome twice.
+ */
+type Gains = {
+  setTotal: number;
+  clearTotal: number;
+  setCollege: number;
+  clearCollege: number;
+  setSpread: number;
+  clearSpread: number;
+};
+
+const NO_GAINS: Gains = {
+  setTotal: 0,
+  clearTotal: 0,
+  setCollege: 0,
+  clearCollege: 0,
+  setSpread: 0,
+  clearSpread: 0,
+};
+
+type Verdict =
+  | { kind: "loss" }
+  | { kind: "win" }
+  /** Level on points, so the Monday night total between `lo` and `hi` decides it. */
+  | { kind: "onTotal"; lo: number; hi: number; contenders: Array<string> };
+
+const LOSS: Verdict = { kind: "loss" };
+const WIN: Verdict = { kind: "win" };
+
+function bitCount(value: number): number {
+  let count = 0;
+  for (let bits = value; bits !== 0; bits &= bits - 1) {
+    count += 1;
+  }
+  return count;
+}
+
+/** Every subset of `mask`, largest first, ending at zero. */
+function subMasks(mask: number): Array<number> {
+  const masks: Array<number> = [];
+  for (let subset = mask; ; subset = (subset - 1) & mask) {
+    masks.push(subset);
+    if (subset === 0) break;
+  }
+  return masks;
+}
+
+/**
+ * The games still to be played, read a column at a time.
+ *
+ * `remainingGameIndices` is the same reading `applyKnockouts` does, and for the same
+ * reason: a blank cell scores "error" rather than "incomplete", so one row alone
+ * would drop a game that row's player happened to skip.
+ */
+function remainingGames(players: Array<PlayerScore>): Array<RemainingGame> {
+  const [first] = players;
+  return LEAGUES.flatMap((league) => {
+    const labels = rangeWithPrefix(first[league].length, LEAGUE_PREFIX[league]);
+    return remainingGameIndices(players, league).map((index) => ({
+      label: labels[index],
+      league,
+      cells: players.map((player) => {
+        const text = player[league][index].pick ?? "";
+        const { teamAbbreviation, spread } = parsePick(text);
+        return { team: teamAbbreviation, hasSpread: spread !== 0, text };
+      }),
+    }));
+  });
+}
+
+function gainsFor(
+  playerIndex: number,
+  contested: Array<RemainingGame>,
+  coverers: Array<string>,
+): Gains {
+  const gains = { ...NO_GAINS };
+  contested.forEach((game, bit) => {
+    const cell = game.cells[playerIndex];
+    if (cell.team == null) return;
+    const mask = 1 << bit;
+    const scoresWhenSet = cell.team === coverers[bit];
+    if (game.league === "college") {
+      if (scoresWhenSet) gains.setCollege |= mask;
+      else gains.clearCollege |= mask;
+    } else if (cell.hasSpread) {
+      // Pro against the spread is a tiebreaker tier of its own, and counts only
+      // the pro games that carry a spread.
+      if (scoresWhenSet) gains.setSpread |= mask;
+      else gains.clearSpread |= mask;
+    }
+    if (scoresWhenSet) gains.setTotal |= mask;
+    else gains.clearTotal |= mask;
+  });
+  return gains;
+}
+
+/** The player's score as the outcome leaves it, every open game counted. */
+function projected(
+  player: PlayerScore,
+  gains: Gains,
+  outcome: number,
+): PlayerScore {
+  const missed = ~outcome;
+  const won = (set: number, clear: number) =>
+    bitCount(set & outcome) + bitCount(clear & missed);
+  const total = player.score.total + won(gains.setTotal, gains.clearTotal);
+  const college =
+    player.score.college + won(gains.setCollege, gains.clearCollege);
+  return {
+    ...player,
+    score: {
+      total,
+      college,
+      pro: total - college,
+      proAgainstTheSpread:
+        player.score.proAgainstTheSpread +
+        won(gains.setSpread, gains.clearSpread),
+    },
+  };
+}
+
+type Contender = { player: PlayerScore; gains: Gains };
+
+/**
+ * Whether one outcome takes the week, and on what.
+ *
+ * Winning means finishing level with everyone or better. `applyKnockouts` leaves a
+ * genuine tie standing and calls both players the winner, so this does too.
+ *
+ * Where the Monday night game is still to be played nobody has a distance yet, so a
+ * dead heat on points is answered as the totals that would win it. The player is
+ * closer than a rival on every total on their side of the midpoint between the two
+ * guesses. An exact midpoint is a dead heat on Monday night as well, and falls to
+ * the tiers below it, which is what `midpointWins` reads.
+ */
+function evaluate(
+  player: PlayerScore,
+  gains: Gains,
+  contenders: Array<Contender>,
+  outcome: number,
+  isMondayNightSettled: boolean,
+): Verdict {
+  const me = projected(player, gains, outcome);
+  let lo = 0;
+  let hi = Number.POSITIVE_INFINITY;
+  const level: Array<string> = [];
+
+  for (const contender of contenders) {
+    const them = projected(contender.player, contender.gains, outcome);
+    if (them.score.total > me.score.total) return LOSS;
+    if (them.score.total < me.score.total) continue;
+
+    const mine = me.tiebreaker.pick;
+    const theirs = them.tiebreaker.pick;
+    const behindOnLowerTiers = comparePlayerScoresOnMerit(me, them) > 0;
+    if (
+      isMondayNightSettled ||
+      mine == null ||
+      theirs == null ||
+      mine === theirs
+    ) {
+      // Monday night cannot separate them, or it already has, so the tiers
+      // `comparePlayerScoresOnMerit` runs decide it.
+      if (behindOnLowerTiers) return LOSS;
+      continue;
+    }
+
+    level.push(them.name);
+    const midpoint = (mine + theirs) / 2;
+    const midpointWins = Number.isInteger(midpoint) && !behindOnLowerTiers;
+    if (mine < theirs) {
+      hi = Math.min(hi, midpointWins ? midpoint : Math.ceil(midpoint) - 1);
+    } else {
+      lo = Math.max(lo, midpointWins ? midpoint : Math.floor(midpoint) + 1);
+    }
+  }
+
+  if (lo > hi) return LOSS;
+  return level.length === 0
+    ? WIN
+    : { kind: "onTotal", lo, hi, contenders: level };
+}
+
+/** Prefers a win, then the outcome that leaves the widest range of totals. */
+function betterOf(a: Verdict | undefined, b: Verdict): Verdict {
+  if (a == null || a.kind === "loss") return b;
+  if (b.kind === "loss" || a.kind === "win") return a;
+  if (b.kind === "win") return b;
+  return b.hi - b.lo > a.hi - a.lo ? b : a;
+}
+
+type RouteOutcome = {
+  verdict: Verdict;
+  /** The way the games out of the player's hands fall, for the best case only. */
+  luck: number;
+};
+
+/**
+ * What a set of the player's own picks landing is worth.
+ *
+ * `guaranteed` holds the games the player left blank against them, so a route that
+ * survives it wins however those fall. Only when nothing survives that are they
+ * allowed to fall the player's way, which is where `needsHelp` comes from.
+ */
+function verdictFor(
+  hits: number,
+  luckMask: number,
+  guaranteed: boolean,
+  read: (outcome: number) => Verdict,
+): RouteOutcome {
+  let lo = 0;
+  let hi = Number.POSITIVE_INFINITY;
+  const level = new Set<string>();
+  let best: Verdict | undefined;
+  let bestLuck = 0;
+
+  for (const luck of subMasks(luckMask)) {
+    const verdict = read(hits | luck);
+    if (!guaranteed) {
+      const improved = betterOf(best, verdict);
+      if (improved !== best) {
+        best = improved;
+        bestLuck = luck;
+      }
+      continue;
+    }
+    if (verdict.kind === "loss") return { verdict: LOSS, luck: 0 };
+    if (verdict.kind === "onTotal") {
+      lo = Math.max(lo, verdict.lo);
+      hi = Math.min(hi, verdict.hi);
+      verdict.contenders.forEach((name) => level.add(name));
+    }
+  }
+
+  if (!guaranteed) {
+    return { verdict: best ?? LOSS, luck: bestLuck };
+  }
+  if (lo > hi) return { verdict: LOSS, luck: 0 };
+  return {
+    verdict:
+      level.size === 0
+        ? WIN
+        : { kind: "onTotal", lo, hi, contenders: [...level] },
+    luck: 0,
+  };
+}
+
+function outlookOf(verdict: Verdict, isSettled: boolean): MondayNightOutlook {
+  if (verdict.kind !== "onTotal") {
+    return isSettled ? { kind: "settled" } : { kind: "notNeeded" };
+  }
+  return {
+    kind: "range",
+    min: verdict.lo > 0 ? verdict.lo : undefined,
+    max: Number.isFinite(verdict.hi) ? verdict.hi : undefined,
+    contenders: verdict.contenders,
+  };
+}
+
+function sameOutlook(a: MondayNightOutlook, b: MondayNightOutlook): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind !== "range" || b.kind !== "range") return true;
+  return (
+    a.min === b.min &&
+    a.max === b.max &&
+    a.contenders.join() === b.contenders.join()
+  );
+}
+
+/** How many ways `size` of `count` games can be chosen. */
+function combinations(count: number, size: number): number {
+  let total = 1;
+  for (let step = 0; step < size; step++) {
+    total = (total * (count - step)) / (step + 1);
+  }
+  return total;
+}
+
+function picksIn(
+  mask: number,
+  contested: Array<RemainingGame>,
+  playerIndex: number,
+): Array<RemainingPick> {
+  return contested
+    .map((game, bit) =>
+      (mask & (1 << bit)) === 0
+        ? null
+        : { label: game.label, pick: game.cells[playerIndex].text },
+    )
+    .filter((pick) => pick != null);
+}
+
+/**
+ * The fewest of their own remaining picks the player has to win to reach a rival.
+ *
+ * A game the two picked differently swings two points, since the point one takes is
+ * one the other does not, so those are spent first. A game only the player picked
+ * swings one. Undefined where nothing they do is enough, which is the same
+ * arithmetic `applyKnockouts` knocks a player out on total score with.
+ *
+ * A game only the rival picked is assumed to miss, which is what makes this a floor.
+ */
+function fewestWinsToCatch(
+  playerIndex: number,
+  rivalIndex: number,
+  games: Array<RemainingGame>,
+  gap: number,
+  clear: boolean,
+): number | undefined {
+  let different = 0;
+  let playerOnly = 0;
+  games.forEach((game) => {
+    const mine = game.cells[playerIndex].team;
+    const theirs = game.cells[rivalIndex].team;
+    if (mine == null) return;
+    if (theirs == null) playerOnly += 1;
+    else if (theirs !== mine) different += 1;
+  });
+
+  const target = gap + different + (clear ? 1 : 0);
+  if (target <= 0) return 0;
+  const onDifferent = Math.min(different, Math.ceil(target / 2));
+  const onOwn = Math.max(0, target - onDifferent * 2);
+  return onOwn > playerOnly ? undefined : onDifferent + onOwn;
+}
+
+function headline(
+  player: PlayerScore,
+  playerIndex: number,
+  rivals: Array<{ player: PlayerScore; index: number }>,
+  games: Array<RemainingGame>,
+): PathsToVictory {
+  let minimumWins = 0;
+  let needsMondayNight = false;
+  for (const rival of rivals) {
+    const gap = rival.player.score.total - player.score.total;
+    const toLevel = fewestWinsToCatch(
+      playerIndex,
+      rival.index,
+      games,
+      gap,
+      false,
+    );
+    if (toLevel == null) {
+      return {
+        kind: "eliminated",
+        player: player.name,
+        explanation: player.status.explanation,
+      };
+    }
+    minimumWins = Math.max(minimumWins, toLevel);
+    const toClear = fewestWinsToCatch(
+      playerIndex,
+      rival.index,
+      games,
+      gap,
+      true,
+    );
+    if (toClear == null || toClear > toLevel) needsMondayNight = true;
+  }
+  return {
+    kind: "headline",
+    player: player.name,
+    remainingGameCount: games.length,
+    remainingPickCount: games.filter(
+      (game) => game.cells[playerIndex].team != null,
+    ).length,
+    minimumWins,
+    needsMondayNight,
+  };
+}
+
+/**
+ * What a player still has to do to win a week that is being played.
+ *
+ * Undefined where the sheet holds nobody by that name, which is the only way the
+ * question has no answer at all.
+ */
+export default function getPathsToVictory(
+  scores: RakMadnessScores,
+  playerName: string,
+): PathsToVictory | undefined {
+  const players = scores.scores;
+  const playerIndex = players.findIndex((it) => it.name === playerName);
+  if (playerIndex < 0) return undefined;
+
+  const player = players[playerIndex];
+  if (player.status.isKnockedOut) {
+    return {
+      kind: "eliminated",
+      player: player.name,
+      explanation: player.status.explanation,
+    };
+  }
+
+  // A player already knocked out cannot take the week off anyone, so they are not
+  // measured against. That is what keeps the search small late in a week.
+  const rivals = players
+    .map((it, index) => ({ player: it, index }))
+    .filter((it) => it.index !== playerIndex && !it.player.status.isKnockedOut);
+  if (rivals.length === 0) {
+    return { kind: "clinched", player: player.name };
+  }
+
+  const games = remainingGames(players);
+  if (games.length > MAX_SEARCHED_GAMES) {
+    return headline(player, playerIndex, rivals, games);
+  }
+
+  // A game every live player picked the same way moves all their scores together,
+  // in the total and in both tiebreaker tiers, so it cannot change the order and
+  // does not need searching.
+  const live = [playerIndex, ...rivals.map((it) => it.index)];
+  const contested = games.filter(
+    (game) => new Set(live.map((index) => game.cells[index].team)).size > 1,
+  );
+
+  // The bit for a game reads as the player's own pick landing. Where they have no
+  // pick it reads as the first team a live rival took covering, which is a side to
+  // measure from and nothing more.
+  const coverers = contested.map((game) => {
+    const mine = game.cells[playerIndex].team;
+    if (mine != null) return mine;
+    // A contested game always holds one, since a column every live player left
+    // blank cannot differ between them.
+    const anyRival = live
+      .map((index) => game.cells[index].team)
+      .find((team) => team != null);
+    return anyRival ?? "";
+  });
+
+  const gains = gainsFor(playerIndex, contested, coverers);
+  const contenders: Array<Contender> = rivals.map((rival) => ({
+    player: rival.player,
+    gains: gainsFor(rival.index, contested, coverers),
+  }));
+  const isMondayNightSettled = scores.tiebreaker != null;
+  const read = (outcome: number) =>
+    evaluate(player, gains, contenders, outcome, isMondayNightSettled);
+
+  let mineMask = 0;
+  let luckMask = 0;
+  contested.forEach((game, bit) => {
+    if (game.cells[playerIndex].team != null) mineMask |= 1 << bit;
+    else luckMask |= 1 << bit;
+  });
+
+  const ordered = subMasks(mineMask).sort(
+    (a, b) => bitCount(a) - bitCount(b) || a - b,
+  );
+  const search = (guaranteed: boolean) => {
+    const minimal: Array<{ hits: number; outcome: RouteOutcome }> = [];
+    let outrightAt: number | undefined;
+    for (const hits of ordered) {
+      const isRedundant = minimal.some(
+        (found) => (found.hits & hits) === found.hits,
+      );
+      if (isRedundant && outrightAt != null) continue;
+      const outcome = verdictFor(hits, luckMask, guaranteed, read);
+      if (outcome.verdict.kind === "loss") continue;
+      if (outcome.verdict.kind === "win" && outrightAt == null) {
+        outrightAt = bitCount(hits);
+      }
+      if (!isRedundant) minimal.push({ hits, outcome });
+    }
+    return { minimal, outrightAt };
+  };
+
+  // Held against the player first, so a route that survives every way the games
+  // they left blank can fall is reported without conditions.
+  let found = search(true);
+  let needsHelp: Array<UncontrolledGame> = [];
+  if (found.minimal.length === 0 && luckMask !== 0) {
+    found = search(false);
+    const [best] = found.minimal;
+    if (best != null) {
+      needsHelp = contested
+        .map((game, bit): UncontrolledGame | null => {
+          const mask = 1 << bit;
+          if ((luckMask & mask) === 0) return null;
+          const covers = (best.outcome.luck & mask) !== 0;
+          const teams = live
+            .map((index) => game.cells[index].team)
+            .filter((team) => team != null);
+          return {
+            label: game.label,
+            needsToMiss: [
+              ...new Set(
+                covers
+                  ? teams.filter((team) => team !== coverers[bit])
+                  : [coverers[bit]],
+              ),
+            ],
+          };
+        })
+        .filter((game) => game != null);
+    }
+  }
+
+  const { minimal, outrightAt } = found;
+  if (minimal.length === 0) {
+    return {
+      kind: "eliminated",
+      player: player.name,
+      explanation: player.status.explanation,
+    };
+  }
+  // Nothing left to win, and nothing the games they left blank can do about it.
+  // A route that only survives because those fell right is not a clinch.
+  if (
+    needsHelp.length === 0 &&
+    minimal.length === 1 &&
+    minimal[0].hits === 0 &&
+    minimal[0].outcome.verdict.kind === "win"
+  ) {
+    return { kind: "clinched", player: player.name };
+  }
+
+  const mustWinMask = minimal.reduce(
+    (shared, route) => shared & route.hits,
+    minimal[0].hits,
+  );
+  const rests = minimal.map((route) => ({
+    mask: route.hits & ~mustWinMask,
+    outlook: outlookOf(route.outcome.verdict, isMondayNightSettled),
+  }));
+  const isOneOutlook = rests.every((rest) =>
+    sameOutlook(rest.outlook, rests[0].outlook),
+  );
+  const sizes = new Set(rests.map((rest) => bitCount(rest.mask)));
+  const poolMask = rests.reduce((all, rest) => all | rest.mask, 0);
+  const choose = bitCount(rests[0].mask);
+  // Every way of choosing that many of the pool is a route only when there are as
+  // many routes as there are ways, since each route is a different one of them.
+  const isPool =
+    isOneOutlook &&
+    sizes.size === 1 &&
+    rests.length === combinations(bitCount(poolMask), choose);
+
+  const leader = players[0];
+  const base = {
+    kind: "paths" as const,
+    player: player.name,
+    remainingGameCount: games.length,
+    pointsBehind: Math.max(0, leader.score.total - player.score.total),
+    leader: leader.name,
+    mustWin: picksIn(mustWinMask, contested, playerIndex),
+    outrightAt,
+    needsHelp,
+  };
+
+  if (isPool) {
+    return {
+      ...base,
+      pool:
+        choose > 0
+          ? { choose, games: picksIn(poolMask, contested, playerIndex) }
+          : undefined,
+      hiddenRouteCount: 0,
+      mondayNight: rests[0].outlook,
+    };
+  }
+
+  const routes: Array<VictoryRoute> = rests
+    .map((rest) => ({
+      games: picksIn(rest.mask, contested, playerIndex),
+      mondayNight: rest.outlook,
+    }))
+    .sort((a, b) => a.games.length - b.games.length);
+  return {
+    ...base,
+    routes: routes.slice(0, MAX_LISTED_ROUTES),
+    hiddenRouteCount: Math.max(0, routes.length - MAX_LISTED_ROUTES),
+    mondayNight: isOneOutlook ? rests[0].outlook : undefined,
+  };
+}

--- a/src/utils/scoring/remainingGames.ts
+++ b/src/utils/scoring/remainingGames.ts
@@ -45,11 +45,11 @@ function remainingGameIndices(
 }
 
 /**
- * What one game still to be played is worth to a player against a rival.
+ * How one game still to be played separates a player from a rival.
  *
- * `opposed` swings two points, since the point one takes is one the other does not.
- * `playerOnly` swings one, and covers a game the rival left blank as well as one
- * only the player picked. `none` is a game the player cannot score.
+ * `opposed` is a game the two picked different teams in. `playerOnly` is one the
+ * player picked and the rival left blank. `none` is one the player left blank, or
+ * one they both picked the same way.
  */
 export type PickDifference = "none" | "opposed" | "playerOnly";
 

--- a/src/utils/scoring/remainingGames.ts
+++ b/src/utils/scoring/remainingGames.ts
@@ -2,13 +2,13 @@ import { PlayerScore } from "../../types/RakMadnessScores";
 import rangeWithPrefix from "../rangeWithPrefix";
 import parsePick from "./parsePick";
 
-export type LeagueKey = "college" | "pro";
+type LeagueKey = "college" | "pro";
 
 const LEAGUES: Array<LeagueKey> = ["college", "pro"];
 
 const LEAGUE_PREFIX: Record<LeagueKey, string> = { college: "C", pro: "P" };
 
-export type Cell = {
+type Cell = {
   /** Absent where the player left the game blank, which scores them nothing. */
   team?: string;
   hasSpread: boolean;
@@ -30,7 +30,7 @@ export type RemainingGame = {
  * row alone would drop a game the leader happened to skip and knock out everybody
  * who needed it.
  */
-export function remainingGameIndices(
+function remainingGameIndices(
   scores: Array<PlayerScore>,
   league: LeagueKey,
 ): Array<number> {

--- a/src/utils/scoring/remainingGames.ts
+++ b/src/utils/scoring/remainingGames.ts
@@ -1,0 +1,70 @@
+import { PlayerScore } from "../../types/RakMadnessScores";
+import rangeWithPrefix from "../rangeWithPrefix";
+import parsePick from "./parsePick";
+
+export type LeagueKey = "college" | "pro";
+
+const LEAGUES: Array<LeagueKey> = ["college", "pro"];
+
+const LEAGUE_PREFIX: Record<LeagueKey, string> = { college: "C", pro: "P" };
+
+export type Cell = {
+  /** Absent where the player left the game blank, which scores them nothing. */
+  team?: string;
+  hasSpread: boolean;
+  text: string;
+};
+
+export type RemainingGame = {
+  /** `C4`, `P11`: the column label the picks table gives the same game. */
+  label: string;
+  league: LeagueKey;
+  /** Every row's cell, in the order the scores hold their players. */
+  cells: Array<Cell>;
+};
+
+/**
+ * The positions of the games still to be played, read across every row.
+ *
+ * A row that left a game blank scores it "error", not "incomplete", so reading one
+ * row alone would drop a game the leader happened to skip and knock out everybody
+ * who needed it.
+ */
+export function remainingGameIndices(
+  scores: Array<PlayerScore>,
+  league: LeagueKey,
+): Array<number> {
+  const [firstPlayer] = scores;
+  return firstPlayer[league]
+    .map((_, index) =>
+      scores.some((score) => score[league][index].status === "incomplete")
+        ? index
+        : null,
+    )
+    .filter((index) => index != null);
+}
+
+/**
+ * The games still to be played, read a column at a time.
+ *
+ * Both halves of the app that ask what is still open read them this way: the
+ * knockouts, to count what two players have picked differently, and the routes, to
+ * walk every way those games can fall.
+ */
+export default function remainingGames(
+  players: Array<PlayerScore>,
+): Array<RemainingGame> {
+  const [first] = players;
+  return LEAGUES.flatMap((league) => {
+    const labels = rangeWithPrefix(first[league].length, LEAGUE_PREFIX[league]);
+    return remainingGameIndices(players, league).map((index) => ({
+      label: labels[index],
+      league,
+      cells: players.map((player) => {
+        const text = player[league][index].pick ?? "";
+        const { teamAbbreviation, spread } = parsePick(text);
+        return { team: teamAbbreviation, hasSpread: spread !== 0, text };
+      }),
+    }));
+  });
+}

--- a/src/utils/scoring/remainingGames.ts
+++ b/src/utils/scoring/remainingGames.ts
@@ -45,6 +45,27 @@ function remainingGameIndices(
 }
 
 /**
+ * What one game still to be played is worth to a player against a rival.
+ *
+ * `opposed` swings two points, since the point one takes is one the other does not.
+ * `playerOnly` swings one, and covers a game the rival left blank as well as one
+ * only the player picked. `none` is a game the player cannot score.
+ */
+export type PickDifference = "none" | "opposed" | "playerOnly";
+
+export function pickDifference(
+  game: RemainingGame,
+  playerIndex: number,
+  rivalIndex: number,
+): PickDifference {
+  const mine = game.cells[playerIndex].team;
+  if (mine == null) return "none";
+  const theirs = game.cells[rivalIndex].team;
+  if (theirs == null) return "playerOnly";
+  return theirs === mine ? "none" : "opposed";
+}
+
+/**
  * The games still to be played, read a column at a time.
  *
  * Both halves of the app that ask what is still open read them this way: the


### PR DESCRIPTION
## What

A gold trophy button beside refresh on a live week. It opens a modal, a sheet
under 600px, showing what a player still has to do to win.

## Why

The scoreboard says who is ahead, never what is left to do about it.

## Changes

- At ten games or fewer left, the search walks every way the contested ones can
  fall. Two sides to a game means the player's own hits fix every rival's score.
- Paths reduce to must-win plus a pool only when they all end the same way.
- Winning is finishing level or better, following `applyKnockouts`.
- `remainingGames` reads the open games once, for knockouts and paths both.

## Screenshots

<img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-media/pr18v2/must-win.png" width="620">

*A game every path needs, in red, then the paths in gold.*

<img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-media/pr18v2/hidden-paths.png" width="620">

*Four paths open, closing with a count of what was left off.*

<img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-media/pr18v2/many-paths.png" width="620">

*Unfolded to the ten kept.*

<img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-media/pr18v2/too-many-games.png" width="620">

*Above ten games left, a floor instead of paths.*

<img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-media/pr18v2/loading.png" width="620">

*The search waits a frame so the spinner paints first.*

<img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-media/pr18v2/eliminated.png" width="620">

*Letters only a knocked out player answers, offered unselectable.*

<img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-media/pr18v2/mobile.png" width="260">

*The same dialog as a sheet on a phone.*

## Verification

`make check`, then 2026 week 1 at both sizes.
