### PR TITLE
chore(claude): nudge the CLAUDE.md tree at commit and push

### DIFF
--- a/.claude/hooks/claude_md_hook.py
+++ b/.claude/hooks/claude_md_hook.py
@@ -1,18 +1,26 @@
 #!/usr/bin/env python3
-"""PostToolUse hook: nudge Claude to keep the CLAUDE.md search tree current.
+"""PreToolUse hook: nudge Claude to bring the CLAUDE.md search tree current before it ships.
 
-Pairs with the agentify-docs skill. Fires after Edit/Write/MultiEdit. When an
-edit *structurally* changes a directory (a new file appears, i.e. something the
-directory's CLAUDE.md index or its parent's child links should reflect), it
-injects a short reminder naming the affected CLAUDE.md so Claude can update it.
+Pairs with the agentify-docs skill. Fires on `git commit` and on `git push`, and
+injects one reminder naming the CLAUDE.md files the new files affect.
 
-Deliberately does NOT nudge on in-place edits to existing files: rewriting a
-function body rarely changes a one-line directory summary. The hook only detects;
-Claude judges whether the summary actually needs to change and rewrites it.
+Commit time, not edit time: a directory summary is only wrong once the work is
+done, and one reminder per commit costs a fraction of one per edit. Push is the
+backstop for commits this hook never saw, made by hand or by a script.
 
-Self-gating: silent when the file is not in a git repo, when no ancestor
-directory has a CLAUDE.md (tree never built), or when the edit is a plain modify.
-Any unexpected error exits 0 silently so the hook never blocks a tool call.
+The two triggers read different sources. A commit is judged from the working tree
+(staged additions plus untracked files), a push from the files the branch adds
+over its upstream. Either way a directory is dropped once the same change touches
+the CLAUDE.md that covers it, so a documented addition never nags.
+
+Deliberately ignores in-place edits to existing files: rewriting a function body
+rarely changes a one-line directory summary. The hook only detects; Claude judges
+whether the summary actually needs to change and rewrites it.
+
+Self-gating: silent when the command is neither, when cwd is not a git repo, when
+nothing was added, or when no ancestor directory has a CLAUDE.md (tree never
+built). Never decides the permission, so the command always proceeds. Any
+unexpected error exits 0 silently so the hook never blocks a tool call.
 """
 
 import json
@@ -20,8 +28,13 @@ import os
 import subprocess
 import sys
 
-STRUCTURAL_TOOLS = {"Edit", "Write", "MultiEdit"}
 CLAUDE_MD = "CLAUDE.md"
+COMMIT_TRIGGER = "git commit"
+PUSH_TRIGGER = "git push"
+# Porcelain codes for a file that did not exist before: untracked, staged add.
+NEW_CODES = {"??", "A ", "AM"}
+# Enough dirs to act on, few enough to stay a nudge.
+MAX_DIRS = 10
 # Named once: every reminder is tagged by emit(), so a skill rename touches one line.
 SKILL_TAG = "(agentify-docs skill)"
 
@@ -34,14 +47,91 @@ def git(root, *args):
 
 
 def emit(context):
-    """Print PostToolUse additionalContext, skill-tagged, and exit."""
+    """Print PreToolUse additionalContext, skill-tagged, and exit.
+
+    No permissionDecision, so the normal permission flow runs and the command
+    is never blocked.
+    """
     print(json.dumps({
         "hookSpecificOutput": {
-            "hookEventName": "PostToolUse",
+            "hookEventName": "PreToolUse",
             "additionalContext": "%s %s" % (context, SKILL_TAG),
         }
     }))
     sys.exit(0)
+
+
+def working_tree_changes(root):
+    """(paths added, CLAUDE.md paths touched) in the working tree."""
+    # -z avoids porcelain's quoting of unusual paths; a rename or copy entry
+    # carries its source path as an extra NUL-separated field.
+    fields = git(root, "status", "--porcelain", "-z",
+                 "--untracked-files=all").split("\0")
+    added, touched_md = [], set()
+    i = 0
+    while i < len(fields):
+        entry = fields[i]
+        i += 1
+        if len(entry) < 4:
+            continue
+        code, path = entry[:2], entry[3:]
+        if code[0] in ("R", "C"):
+            i += 1
+        if os.path.basename(path) == CLAUDE_MD:
+            touched_md.add(path)
+            continue
+        # --untracked-files=all expands every untracked directory except one git
+        # will not descend into, i.e. a nested repo or linked worktree. Those
+        # arrive as a single trailing-slash entry and index nothing here.
+        if code in NEW_CODES and not path.endswith("/"):
+            added.append(path)
+    return added, touched_md
+
+
+def upstream_base(root):
+    """Ref the branch will be pushed onto, or None when there is nothing to compare."""
+    for args in (("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"),
+                 ("rev-parse", "--abbrev-ref", "origin/HEAD")):
+        try:
+            ref = git(root, *args).strip()
+        except subprocess.CalledProcessError:
+            continue
+        if ref:
+            return ref
+    return None
+
+
+def branch_changes(root):
+    """(paths added, CLAUDE.md paths touched) by the commits the push would send."""
+    base = upstream_base(root)
+    if base is None:
+        return [], set()
+    # Three-dot: only what this branch added since it forked, so a branch that
+    # trails its upstream does not answer for the other side's files.
+    def names(*extra):
+        out = git(root, "diff", "--name-only", "-z", *extra,
+                  "%s...HEAD" % base)
+        return [p for p in out.split("\0") if p]
+
+    added = [p for p in names("--diff-filter=A")
+             if os.path.basename(p) != CLAUDE_MD]
+    touched_md = {p for p in names() if os.path.basename(p) == CLAUDE_MD}
+    return added, touched_md
+
+
+def nearest_claude_md(file_dir, root):
+    """Closest CLAUDE.md at or above file_dir, stopping at the repo root."""
+    d = file_dir
+    while True:
+        candidate = os.path.join(d, CLAUDE_MD)
+        if os.path.isfile(candidate):
+            return candidate
+        if d == root:
+            return None
+        parent = os.path.dirname(d)
+        if parent == d:
+            return None
+        d = parent
 
 
 def main():
@@ -50,88 +140,77 @@ def main():
         return
     payload = json.loads(raw)
 
-    if payload.get("tool_name") not in STRUCTURAL_TOOLS:
-        return
-
-    tool_input = payload.get("tool_input") or {}
-    file_path = tool_input.get("file_path")
-    if not file_path:
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    # A commit inside a longer command line wins: the working tree sees
+    # everything the push would carry, and more.
+    if COMMIT_TRIGGER in command:
+        collect, occasion = working_tree_changes, "commit"
+    elif PUSH_TRIGGER in command:
+        collect, occasion = branch_changes, "push"
+    else:
         return
 
     cwd = payload.get("cwd") or os.getcwd()
-    if not os.path.isabs(file_path):
-        file_path = os.path.join(cwd, file_path)
-    # realpath so it shares a symlink-resolved prefix with git's toplevel
-    # (e.g. macOS /var -> /private/var), keeping relative paths clean.
-    file_path = os.path.realpath(file_path)
-
-    # Never nudge about edits to a CLAUDE.md itself (avoids feedback loops).
-    if os.path.basename(file_path) == CLAUDE_MD:
-        return
-
-    file_dir = os.path.dirname(file_path)
     try:
-        root = os.path.realpath(git(file_dir, "rev-parse", "--show-toplevel").strip())
+        # realpath so paths share a symlink-resolved prefix with git's toplevel
+        # (e.g. macOS /var -> /private/var), keeping relative paths clean.
+        root = os.path.realpath(git(cwd, "rev-parse", "--show-toplevel").strip())
     except (subprocess.CalledProcessError, FileNotFoundError):
         return  # not a git repo
 
-    # lint_claude_md.py never indexes a dot-directory, so nothing under one can need a
-    # CLAUDE.md. `.claude/skills/` in particular is written by the build, contrib,
-    # and boundaries phases, which would otherwise nudge on every run. Judged
-    # relative to the repo root, so a checkout that itself lives under a
-    # dot-directory (~/.local/src/repo) still gets nudges.
-    if any(part.startswith(".")
-           for part in os.path.relpath(file_dir, root).split(os.sep)):
-        return
+    added, touched_md = collect(root)
+    covered, uncovered = {}, {}
+    for rel_file in added:
+        rel_dir = os.path.dirname(rel_file)
+        # lint_claude_md.py never indexes a dot-directory, so nothing under one
+        # can need a CLAUDE.md. `.claude/skills/` in particular is written by the
+        # build, contrib, and boundaries phases. Judged relative to the repo
+        # root, so a checkout that itself lives under a dot-directory
+        # (~/.local/src/repo) still gets nudges.
+        if any(part.startswith(".") for part in rel_dir.split(os.sep) if part):
+            continue
+        if rel_dir in covered or rel_dir in uncovered:
+            continue
+        file_dir = os.path.join(root, rel_dir) if rel_dir else root
+        nearest = nearest_claude_md(file_dir, root)
+        if nearest is None:
+            continue  # no CLAUDE.md tree here; skill hasn't been run
+        rel_md = os.path.relpath(nearest, root)
+        if rel_md in touched_md:
+            continue  # already answered for, in this same change
+        # A hit in the file's own directory means that directory is indexed.
+        if os.path.dirname(nearest) == file_dir:
+            covered[rel_dir] = rel_md
+        else:
+            uncovered[rel_dir] = rel_md
 
-    # Structural check: only nudge when the file is newly added/untracked.
-    # Plain modifications (" M" / "M ") and staged edits ("MM") are skipped.
-    status = git(root, "status", "--porcelain", "--", file_path)
-    code = status[:2] if status else ""
-    is_new = code in ("??", "A ", "AM")
-    if not is_new:
-        return
-
-    # Walk up from the file's directory to the repo root for the nearest CLAUDE.md.
-    # file_dir and root are both absolute and symlink-resolved, so compare directly.
-    nearest = None
-    d = file_dir
-    while True:
-        candidate = os.path.join(d, CLAUDE_MD)
-        if os.path.isfile(candidate):
-            nearest = candidate
-            break
-        if d == root:
-            break
-        parent = os.path.dirname(d)
-        if parent == d:
-            break
-        d = parent
-
-    if nearest is None:
-        return  # no CLAUDE.md tree here; skill hasn't been run
-
-    # A hit on the first step up means the file's own directory is already indexed.
-    own_dir_covered = os.path.dirname(nearest) == file_dir
-
-    rel_file = os.path.relpath(file_path, root)
-    rel_md = os.path.relpath(nearest, root)
-
-    if own_dir_covered:
-        emit(
-            f"New file `{rel_file}` was added. Its directory has a CLAUDE.md "
-            f"(`{rel_md}`) that is part of the repo search tree. If this file "
-            f"changes what that directory contains, update the summary in "
-            f"`{rel_md}`. Only edit the index if the description is now "
-            f"inaccurate."
+    lines = []
+    for rel_dir, rel_md in sorted(covered.items()):
+        lines.append(
+            f"- `{rel_dir or '.'}/` gained files and is indexed by `{rel_md}`. "
+            f"Update that summary if it is now inaccurate."
         )
+    for rel_dir, rel_md in sorted(uncovered.items()):
+        lines.append(
+            f"- `{rel_dir}/` gained files and has no CLAUDE.md, but sits under "
+            f"the tree indexed by `{rel_md}`. If it is now a meaningful "
+            f"directory, add a CLAUDE.md there and link it from `{rel_md}`."
+        )
+    if not lines:
+        return
 
-    rel_dir = os.path.relpath(file_dir, root)
+    dropped = len(lines) - MAX_DIRS
+    lines = lines[:MAX_DIRS]
+    if dropped > 0:
+        lines.append(f"- ...and {dropped} more directories.")
+
+    tail = ("Bring those files current before committing."
+            if occasion == "commit" else
+            "Bring those files current and commit them before pushing.")
     emit(
-        f"New file `{rel_file}` was added in `{rel_dir}/`, which has no CLAUDE.md "
-        f"but sits under the search tree indexed by `{rel_md}`. If `{rel_dir}/` is "
-        f"now a meaningful directory, consider adding a CLAUDE.md there and linking "
-        f"it from `{rel_md}`."
+        f"About to {occasion}. New files landed in directories the CLAUDE.md "
+        "search tree covers:\n" + "\n".join(lines) +
+        f"\n{tail} Edit only what is now inaccurate."
     )
 
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,10 +52,7 @@
       "Bash(git *)",
       "Bash(gh *)"
     ],
-    "ask": [
-      "Bash(wrangler *)",
-      "Bash(npx wrangler *)"
-    ],
+    "ask": ["Bash(wrangler *)", "Bash(npx wrangler *)"],
     "deny": [
       "Read(**/.env)",
       "Read(**/.env.*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,16 +1,5 @@
 {
   "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/claude_md_hook.py"
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -33,6 +22,16 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check_conventions.py",
             "if": "Bash(gh pr edit *)"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/claude_md_hook.py",
+            "if": "Bash(git commit *)"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/claude_md_hook.py",
+            "if": "Bash(git push *)"
           }
         ]
       }
@@ -53,7 +52,10 @@
       "Bash(git *)",
       "Bash(gh *)"
     ],
-    "ask": ["Bash(wrangler *)", "Bash(npx wrangler *)"],
+    "ask": [
+      "Bash(wrangler *)",
+      "Bash(npx wrangler *)"
+    ],
     "deny": [
       "Read(**/.env)",
       "Read(**/.env.*)",


### PR DESCRIPTION
## What

Refresh the vendored agentify hook in `.claude/`. `claude_md_hook.py` now runs at `git commit` and `git push` instead of on every edit. No ticket.

## Why

Firing on every Edit and Write nudged while the work was still unfinished. A directory summary is only wrong once the change is done.

## Changes

- `settings.json`: the `PostToolUse` entry is gone, replaced by two `PreToolUse` Bash filters, `git commit *` and `git push *`.
- Commit reads the working tree, push reads what the branch adds over its upstream, so a push catches commits the hook never saw.
- A directory drops out of the reminder once the same change touches the CLAUDE.md covering it.
- Ten directories at most per reminder, then a count of the rest.
- The hook file is a verbatim copy from `claude-tools` `agentify-docs`. No local edits.

## Verification

Fed the hook a fake commit payload with an untracked file under `src/utils/`. It named `src/utils/CLAUDE.md`. A non-git command and a clean branch both stayed silent.
