### PR TITLE
feat(analysis): open the player analysis from a player's name

### DIFF
--- a/src/App.routes.test.tsx
+++ b/src/App.routes.test.tsx
@@ -41,8 +41,6 @@ describe("the app, week routes", () => {
     expect(await screen.findByText("MNF Points Pick")).toBeInTheDocument();
   });
 
-  // Read inside the table, because the navbar's player analysis button carries
-  // the same trophy while a week that is still being played collapses it away.
   const crown = () =>
     within(screen.getByRole("table")).queryByTestId("EmojiEventsIcon");
 
@@ -94,9 +92,9 @@ describe("the app, week routes", () => {
     fetchMock.mockResolvedValue(spreadsheetResponse());
     mountApp(`/${SEASON}/${CURRENT_WEEK}/scoreboard`);
 
-    // Scoreboard, picks, refresh, and player analysis.
+    // Scoreboard, picks, and refresh.
     const loading = scoresHeaderButtons();
-    expect(loading).toHaveLength(4);
+    expect(loading).toHaveLength(3);
     loading.forEach((button) => expect(button).toBeDisabled());
 
     await screen.findByText("MNF Points Pick");

--- a/src/App.routes.test.tsx
+++ b/src/App.routes.test.tsx
@@ -41,7 +41,7 @@ describe("the app, week routes", () => {
     expect(await screen.findByText("MNF Points Pick")).toBeInTheDocument();
   });
 
-  // Read inside the table, because the navbar's path to victory button carries
+  // Read inside the table, because the navbar's player analysis button carries
   // the same trophy while a week that is still being played collapses it away.
   const crown = () =>
     within(screen.getByRole("table")).queryByTestId("EmojiEventsIcon");
@@ -94,7 +94,7 @@ describe("the app, week routes", () => {
     fetchMock.mockResolvedValue(spreadsheetResponse());
     mountApp(`/${SEASON}/${CURRENT_WEEK}/scoreboard`);
 
-    // Scoreboard, picks, refresh, and path to victory.
+    // Scoreboard, picks, refresh, and player analysis.
     const loading = scoresHeaderButtons();
     expect(loading).toHaveLength(4);
     loading.forEach((button) => expect(button).toBeDisabled());

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -5,7 +5,7 @@
 ## Subdirectories
 
 - [`components/`](components/CLAUDE.md) — React UI, layout, routes
-- [`context/`](context/CLAUDE.md) — app data and toast providers
+- [`context/`](context/CLAUDE.md) — app data, toast, and analysis providers
 - [`hooks/`](hooks/CLAUDE.md) — picks, scoring, export, route guard
 - [`styles/`](styles/CLAUDE.md) — Sass mixins: breakpoints, listbox shape
 - [`types/`](types/CLAUDE.md) — ESPN, league, and scoring types

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -11,7 +11,7 @@ Route components live in `home/` and `results/`; the routes themselves are in
 - [`home/`](home/CLAUDE.md) — home route: pickers, upload, export
 - [`icon/`](icon/CLAUDE.md) — SVG icons inlined from Material Design
 - [`navbar/`](navbar/CLAUDE.md) — top nav bar and view switch
-- [`playerAnalysis/`](playerAnalysis/CLAUDE.md) — what a player still has to win
+- [`playerAnalysis/`](playerAnalysis/CLAUDE.md) — where a player stands, and why
 - [`results/`](results/CLAUDE.md) — results routes, layout, redirect
 - [`table/`](table/CLAUDE.md) — shared frame and the results tables
 - [`toaster/`](toaster/CLAUDE.md) — toast notification renderer

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -11,7 +11,7 @@ Route components live in `home/` and `results/`; the routes themselves are in
 - [`home/`](home/CLAUDE.md) — home route: pickers, upload, export
 - [`icon/`](icon/CLAUDE.md) — SVG icons inlined from Material Design
 - [`navbar/`](navbar/CLAUDE.md) — top nav bar and view switch
-- [`pathToVictory/`](pathToVictory/CLAUDE.md) — what a player still has to win
+- [`playerAnalysis/`](playerAnalysis/CLAUDE.md) — what a player still has to win
 - [`results/`](results/CLAUDE.md) — results routes, layout, redirect
 - [`table/`](table/CLAUDE.md) — shared frame and the results tables
 - [`toaster/`](toaster/CLAUDE.md) — toast notification renderer

--- a/src/components/button/Button.scss
+++ b/src/components/button/Button.scss
@@ -80,20 +80,6 @@
         background-color: var(--rak-danger-700);
       }
     }
-
-    // The only solid color light enough that white on it fails to read, so it
-    // overrides the fill and the text both.
-    &.--gold {
-      background-color: var(--rak-gold-500);
-      color: var(--rak-primary-800);
-
-      &:hover {
-        background-color: var(--rak-gold-600);
-      }
-      &:active {
-        background-color: var(--rak-gold-700);
-      }
-    }
   }
 
   // Soft buttons inherit the surrounding tint, which is how the toast close

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 import getClasses from "../../utils/getClasses";
 import "./Button.scss";
 
-export type ButtonColor = "primary" | "success" | "danger" | "gold";
+export type ButtonColor = "primary" | "success" | "danger";
 
 export default function Button({
   children,

--- a/src/components/button/CLAUDE.md
+++ b/src/components/button/CLAUDE.md
@@ -2,10 +2,7 @@
 
 `Button`: the app's only button, icon-only buttons included. Wraps Base UI's
 unstyled `Button` and adds the `--solid`/`--soft` variants,
-`--primary`/`--success`/`--danger`/`--gold` colors, `--sm`, and `--icon`.
-
-`--gold` is the only solid fill light enough that white on it fails to read, so it
-sets its own text color rather than taking the one `--solid` gives the rest.
+`--primary`/`--success`/`--danger` colors, `--sm`, and `--icon`.
 
 Every color rule is scoped to `:not(:disabled)`. The variant selectors are more
 specific than `&:disabled`, so without that scoping a disabled button keeps its

--- a/src/components/icon/CLAUDE.md
+++ b/src/components/icon/CLAUDE.md
@@ -3,7 +3,7 @@
 Every icon the app draws, as one `<svg>` each. Path data copied verbatim from
 `@mui/icons-material` (Material Design icons, Apache 2.0), inlined because those
 components drag `@mui/material` and emotion in behind them. `Icon.scss` holds the
-24px box, which `PlayerName.scss` overrides down to 16px.
+24px box, which `PlayerStatusIcon.scss` overrides down to 16px.
 
 Each icon carries the `data-testid` its MUI counterpart had, which is how the
 toaster suite finds them.

--- a/src/components/icon/Icon.scss
+++ b/src/components/icon/Icon.scss
@@ -1,7 +1,7 @@
 .icon {
   // 1em at 1.5rem is the 24px box the Material icons are drawn in, and is what
   // `SvgIcon` sized them at. Anything wanting another size overrides it, the way
-  // `PlayerName.scss` asks for 16px.
+  // `PlayerStatusIcon.scss` asks for 16px.
   width: 1em;
   height: 1em;
   font-size: 1.5rem;

--- a/src/components/navbar/CLAUDE.md
+++ b/src/components/navbar/CLAUDE.md
@@ -3,18 +3,15 @@
 `Navbar`: `<header>` with `left`/`right` `ReactNode` slots, solid primary fill.
 Owns the padding and the phone-sized touch target of every button it contains,
 trading its own padding for theirs on a narrow screen.
-`ScoresNavbar`: the scoreboard/picks switch plus the buttons a week still being
+`ScoresNavbar`: the scoreboard/picks switch plus the refresh a week still being
 played gets, for the results routes. Clearing `isWeekLive` collapses the refresh
-button, the gold player analysis button, and the divider before them, since
-rescoring cannot change a finished week and nobody has a route left to work out.
-A player's name still opens the analysis on a finished week, where it reads as the
-week's result. They share one collapsing wrapper, fade and narrow out over
+button and the divider before it, since rescoring cannot change a finished week.
+They share one collapsing wrapper, fade and narrow out over
 `COLLAPSE_DURATION_MS`, then unmount, and cancel `Navbar`'s `--navbar-gap` with a
 negative margin so no gap is left where they were.
 
-The analysis button carries `EmojiEventsIcon`, the same trophy `PlayerStatusIcon`
-crowns a winner with. They never share a screen except during that collapse, since
-one is for a week still being played and the other for a week that is over.
+Nothing here opens the player analysis. A player's name does, in either table, on
+a finished week as well as a live one.
 
 ## Subdirectories
 

--- a/src/components/navbar/CLAUDE.md
+++ b/src/components/navbar/CLAUDE.md
@@ -5,15 +5,16 @@ Owns the padding and the phone-sized touch target of every button it contains,
 trading its own padding for theirs on a narrow screen.
 `ScoresNavbar`: the scoreboard/picks switch plus the buttons a week still being
 played gets, for the results routes. Clearing `isWeekLive` collapses the refresh
-button, the gold path to victory button, and the divider before them, since
+button, the gold player analysis button, and the divider before them, since
 rescoring cannot change a finished week and nobody has a route left to work out.
-They share one collapsing wrapper, fade and narrow out over
+A player's name still opens the analysis on a finished week, where it reads as the
+week's result. They share one collapsing wrapper, fade and narrow out over
 `COLLAPSE_DURATION_MS`, then unmount, and cancel `Navbar`'s `--navbar-gap` with a
 negative margin so no gap is left where they were.
 
-The path button carries `EmojiEventsIcon`, the same trophy `PlayerName` crowns a
-winner with. They never share a screen except during that collapse, since one is
-for a week still being played and the other for a week that is over.
+The analysis button carries `EmojiEventsIcon`, the same trophy `PlayerStatusIcon`
+crowns a winner with. They never share a screen except during that collapse, since
+one is for a week still being played and the other for a week that is over.
 
 ## Subdirectories
 

--- a/src/components/navbar/ScoresNavbar.scss
+++ b/src/components/navbar/ScoresNavbar.scss
@@ -45,14 +45,14 @@
 
 // Same idea, its own rule because the one above would repaint it in the navbar's
 // own blue and lose the accent that tells it apart from the buttons beside it.
-.button.--solid.home__scores-header-paths:disabled {
+.button.--solid.home__scores-header-analysis:disabled {
   background-color: var(--rak-gold-500);
   color: var(--rak-primary-800);
 }
 
 // The divider carries the space on its own side, so this is the only gap left to
 // set between the two buttons past it.
-.home__scores-header-paths {
+.home__scores-header-analysis {
   margin-inline-start: 6px;
 }
 

--- a/src/components/navbar/ScoresNavbar.scss
+++ b/src/components/navbar/ScoresNavbar.scss
@@ -43,19 +43,6 @@
   }
 }
 
-// Same idea, its own rule because the one above would repaint it in the navbar's
-// own blue and lose the accent that tells it apart from the buttons beside it.
-.button.--solid.home__scores-header-analysis:disabled {
-  background-color: var(--rak-gold-500);
-  color: var(--rak-primary-800);
-}
-
-// The divider carries the space on its own side, so this is the only gap left to
-// set between the two buttons past it.
-.home__scores-header-analysis {
-  margin-inline-start: 6px;
-}
-
 .home__scores-header-divider {
   width: 2px;
   height: 1.5rem;
@@ -63,10 +50,10 @@
   background-color: var(--rak-on-solid);
 }
 
-// What a week still being played gets: the refresh and player analysis buttons,
-// and the divider before them, collapsed together once the week is decided. A grid
-// column from `1fr` to `0fr` narrows them, because they measure whatever their
-// padding and their icons come to, and `auto` cannot be interpolated.
+// What a week still being played gets: the refresh button and the divider before
+// it, collapsed together once the week is decided. A grid column from `1fr` to
+// `0fr` narrows them, because they measure whatever their padding and their icon
+// come to, and `auto` cannot be interpolated.
 // `--collapse-duration` comes from `ScoresNavbar`, which unmounts this after it.
 .home__scores-header-live {
   display: grid;
@@ -92,6 +79,6 @@
 .home__scores-header-live-content {
   display: flex;
   align-items: center;
-  // So the column can narrow past what the divider and buttons measure.
+  // So the column can narrow past what the divider and button measure.
   min-width: 0;
 }

--- a/src/components/navbar/ScoresNavbar.scss
+++ b/src/components/navbar/ScoresNavbar.scss
@@ -63,7 +63,7 @@
   background-color: var(--rak-on-solid);
 }
 
-// What a week still being played gets: the refresh and path to victory buttons,
+// What a week still being played gets: the refresh and player analysis buttons,
 // and the divider before them, collapsed together once the week is decided. A grid
 // column from `1fr` to `0fr` narrows them, because they measure whatever their
 // padding and their icons come to, and `auto` cannot be interpolated.

--- a/src/components/navbar/ScoresNavbar.test.tsx
+++ b/src/components/navbar/ScoresNavbar.test.tsx
@@ -23,7 +23,7 @@ describe("ScoresNavbar", () => {
     vi.useRealTimers();
   });
 
-  it("offers refresh and a path to victory for a week that is still open", () => {
+  it("offers refresh and the player analysis for a week that is still open", () => {
     render(<ScoresNavbar {...props} isWeekLive />);
 
     expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();

--- a/src/components/navbar/ScoresNavbar.test.tsx
+++ b/src/components/navbar/ScoresNavbar.test.tsx
@@ -6,7 +6,6 @@ const props = {
   view: "Scoreboard" as const,
   onViewChange: () => undefined,
   onRefresh: () => undefined,
-  onShowAnalysis: () => undefined,
   isRefreshing: false,
 };
 
@@ -23,13 +22,10 @@ describe("ScoresNavbar", () => {
     vi.useRealTimers();
   });
 
-  it("offers refresh and the player analysis for a week that is still open", () => {
+  it("offers refresh for a week that is still open", () => {
     render(<ScoresNavbar {...props} isWeekLive />);
 
     expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Player Analysis" }),
-    ).toBeInTheDocument();
     expect(liveWrapper()).not.toHaveClass("--collapsed");
   });
 
@@ -67,7 +63,7 @@ describe("ScoresNavbar", () => {
 
     expect(liveWrapper()).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Player Analysis" }),
+      screen.queryByRole("button", { name: "Refresh" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/navbar/ScoresNavbar.test.tsx
+++ b/src/components/navbar/ScoresNavbar.test.tsx
@@ -6,7 +6,7 @@ const props = {
   view: "Scoreboard" as const,
   onViewChange: () => undefined,
   onRefresh: () => undefined,
-  onShowPaths: () => undefined,
+  onShowAnalysis: () => undefined,
   isRefreshing: false,
 };
 
@@ -28,7 +28,7 @@ describe("ScoresNavbar", () => {
 
     expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Path to Victory" }),
+      screen.getByRole("button", { name: "Player Analysis" }),
     ).toBeInTheDocument();
     expect(liveWrapper()).not.toHaveClass("--collapsed");
   });
@@ -67,7 +67,7 @@ describe("ScoresNavbar", () => {
 
     expect(liveWrapper()).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Path to Victory" }),
+      screen.queryByRole("button", { name: "Player Analysis" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/navbar/ScoresNavbar.tsx
+++ b/src/components/navbar/ScoresNavbar.tsx
@@ -23,7 +23,7 @@ export default function ScoresNavbar({
   view,
   onViewChange,
   onRefresh,
-  onShowPaths,
+  onShowAnalysis,
   isRefreshing,
   disabled = false,
   isWeekLive,
@@ -31,7 +31,7 @@ export default function ScoresNavbar({
   view: ScoresView;
   onViewChange: (view: ScoresView) => void;
   onRefresh: () => void;
-  onShowPaths: () => void;
+  onShowAnalysis: () => void;
   isRefreshing: boolean;
   /** Set while a week is still loading, so the navbar keeps its shape. */
   disabled?: boolean;
@@ -103,11 +103,11 @@ export default function ScoresNavbar({
               <RefreshIcon />
             </Button>
             <Button
-              ariaLabel="Path to Victory"
+              ariaLabel="Player Analysis"
               color="gold"
               disabled={disabled}
-              onClick={onShowPaths}
-              className="home__scores-header-button home__scores-header-paths"
+              onClick={onShowAnalysis}
+              className="home__scores-header-button home__scores-header-analysis"
             >
               <EmojiEventsIcon />
             </Button>

--- a/src/components/navbar/ScoresNavbar.tsx
+++ b/src/components/navbar/ScoresNavbar.tsx
@@ -7,8 +7,8 @@ import "./ScoresNavbar.scss";
 export type ScoresView = "Scoreboard" | "Picks";
 
 /**
- * How long the live-week buttons take to fade and narrow away. Held here because
- * they have to stay mounted for exactly that long. The stylesheet reads it back as
+ * How long the refresh button takes to fade and narrow away. Held here because it
+ * has to stay mounted for exactly that long. The stylesheet reads it back as
  * `--collapse-duration`, so the two cannot drift apart.
  */
 export const COLLAPSE_DURATION_MS = 300;

--- a/src/components/navbar/ScoresNavbar.tsx
+++ b/src/components/navbar/ScoresNavbar.tsx
@@ -37,7 +37,7 @@ export default function ScoresNavbar({
   disabled?: boolean;
   /**
    * Cleared once the week is over, when rescoring cannot change anything and
-   * nobody has a path to victory left to work out.
+   * nobody has a route left to work out. A player's name still opens the analysis.
    */
   isWeekLive: boolean;
 }) {

--- a/src/components/navbar/ScoresNavbar.tsx
+++ b/src/components/navbar/ScoresNavbar.tsx
@@ -1,10 +1,5 @@
 import { CSSProperties, useEffect, useState } from "react";
-import {
-  EmojiEventsIcon,
-  FactCheckIcon,
-  LeaderboardIcon,
-  RefreshIcon,
-} from "../icon/Icon";
+import { FactCheckIcon, LeaderboardIcon, RefreshIcon } from "../icon/Icon";
 import getClasses from "../../utils/getClasses";
 import Button from "../button/Button";
 import "./ScoresNavbar.scss";
@@ -18,12 +13,11 @@ export type ScoresView = "Scoreboard" | "Picks";
  */
 export const COLLAPSE_DURATION_MS = 300;
 
-/** The scoreboard/picks switch, and the buttons a week still being played gets. */
+/** The scoreboard/picks switch, and the refresh a week still being played gets. */
 export default function ScoresNavbar({
   view,
   onViewChange,
   onRefresh,
-  onShowAnalysis,
   isRefreshing,
   disabled = false,
   isWeekLive,
@@ -31,19 +25,15 @@ export default function ScoresNavbar({
   view: ScoresView;
   onViewChange: (view: ScoresView) => void;
   onRefresh: () => void;
-  onShowAnalysis: () => void;
   isRefreshing: boolean;
   /** Set while a week is still loading, so the navbar keeps its shape. */
   disabled?: boolean;
-  /**
-   * Cleared once the week is over, when rescoring cannot change anything and
-   * nobody has a route left to work out. A player's name still opens the analysis.
-   */
+  /** Cleared once the week is over, when rescoring cannot change anything. */
   isWeekLive: boolean;
 }) {
-  // A week arrives loading, so these are usually on screen by the time it turns
-  // out to be decided. Kept mounted for the length of the collapse so they animate
-  // out, and a week already known to be decided never renders them at all.
+  // A week arrives loading, so this is usually on screen by the time it turns out
+  // to be decided. Kept mounted for the length of the collapse so it animates out,
+  // and a week already known to be decided never renders it at all.
   const [isLiveMounted, setLiveMounted] = useState(isWeekLive);
   if (isWeekLive && !isLiveMounted) setLiveMounted(true);
   useEffect(() => {
@@ -101,15 +91,6 @@ export default function ScoresNavbar({
               })}`}
             >
               <RefreshIcon />
-            </Button>
-            <Button
-              ariaLabel="Player Analysis"
-              color="gold"
-              disabled={disabled}
-              onClick={onShowAnalysis}
-              className="home__scores-header-button home__scores-header-analysis"
-            >
-              <EmojiEventsIcon />
             </Button>
           </div>
         </div>

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -1,6 +1,10 @@
 // Whatever the answer turns out to be, it plays in under a dialog already growing
 // to hold it.
 .analysis {
+  // What a pick chip sets its text in by, which a line under one indents by to
+  // stand under that text rather than under the chip.
+  --rak-pick-inset: 8px;
+
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -58,7 +62,7 @@
   display: flex;
   align-items: baseline;
   gap: 6px;
-  padding: 4px 8px;
+  padding: 4px var(--rak-pick-inset);
   border-radius: var(--rak-radius-sm);
   background-color: var(--rak-level1);
   font-size: 0.875rem;
@@ -126,6 +130,13 @@
   margin: 0;
   color: var(--rak-text-secondary);
   font-size: 0.875rem;
+}
+
+// Reads as part of the route it closes, so it takes the picks' ink and lines up
+// with their text. Left unbolded, since it is a condition rather than a pick.
+.analysis__route-mnf {
+  padding-inline-start: var(--rak-pick-inset);
+  color: var(--rak-text);
 }
 
 .analysis__message {

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -5,6 +5,11 @@
   // stand under that text rather than under the chip.
   --rak-pick-inset: 8px;
   --rak-pick-gap: 6px;
+  // A game label is a league letter and at most two digits. A pick is a team
+  // abbreviation of at most five characters, a space, and a spread of at most three
+  // counting its sign. Monospace, so those are widths rather than guesses.
+  --rak-pick-label-width: 3ch;
+  --rak-pick-value-width: 9ch;
 
   display: flex;
   flex-direction: column;
@@ -53,14 +58,8 @@
 // Columns rather than a wrapping row, so the same game sits at the same x down
 // every route. Each list is the same width, so each divides the same way.
 .analysis__picks {
-  // A game label is a league letter and at most two digits. A pick is a team
-  // abbreviation of at most five characters, a space, and a spread of at most
-  // three counting its sign. Monospace, so those are widths rather than guesses,
-  // and a column is only ever as wide as the widest thing it can hold.
-  --rak-pick-label-width: 3ch;
-  --rak-pick-value-width: 9ch;
-
   display: grid;
+  // A column is only ever as wide as the widest thing it can hold.
   grid-template-columns: repeat(
     auto-fit,
     minmax(
@@ -91,11 +90,16 @@
   white-space: nowrap;
 }
 
+// A word naming what follows it rather than saying anything itself.
+.analysis__pick-label,
+.analysis__term {
+  color: var(--rak-text-tertiary);
+  font-weight: 700;
+}
+
 .analysis__pick-label {
   // Held to its widest, so the teams line up down a column whatever the labels do.
   flex: 0 0 var(--rak-pick-label-width);
-  color: var(--rak-text-tertiary);
-  font-weight: 700;
 }
 
 .analysis__pick-team {
@@ -155,11 +159,24 @@
   font-size: 0.875rem;
 }
 
-// Reads as part of the route it closes, so it takes the picks' ink and lines up
-// with their text. Left unbolded, since it is a condition rather than a pick.
+// Reads as part of the route it closes, so it is set like the picks above it, in
+// under their text and labelled the way they are.
 .analysis__route-mnf {
+  display: flex;
+  align-items: baseline;
+  gap: var(--rak-pick-gap);
   padding-inline-start: var(--rak-pick-inset);
   color: var(--rak-text);
+  font-family: monospace;
+  font-weight: 600;
+}
+
+// Each half stays whole, so a screen too narrow for the line breaks between the
+// total and the players it beats rather than inside either.
+.analysis__route-mnf-terms {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 var(--rak-pick-gap);
 }
 
 .analysis__message {

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -4,6 +4,7 @@
   // What a pick chip sets its text in by, which a line under one indents by to
   // stand under that text rather than under the chip.
   --rak-pick-inset: 8px;
+  --rak-pick-gap: 6px;
 
   display: flex;
   flex-direction: column;
@@ -47,30 +48,47 @@
 // Columns rather than a wrapping row, so the same game sits at the same x down
 // every route. Each list is the same width, so each divides the same way.
 .analysis__picks {
+  // A game label is a league letter and at most two digits. A pick is a team
+  // abbreviation of at most five characters, a space, and a spread of at most
+  // three counting its sign. Monospace, so those are widths rather than guesses,
+  // and a column is only ever as wide as the widest thing it can hold.
+  --rak-pick-label-width: 3ch;
+  --rak-pick-value-width: 9ch;
+
   display: grid;
-  // The floor is what the longest pick a sheet can hold measures, so a column
-  // never has to cut one short or wrap it.
-  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
-  gap: 6px;
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(
+      calc(
+        var(--rak-pick-label-width) + var(--rak-pick-value-width) +
+          var(--rak-pick-gap) + var(--rak-pick-inset) * 2
+      ),
+      1fr
+    )
+  );
+  gap: var(--rak-pick-gap);
   margin: 0;
   padding: 0;
   list-style: none;
+  font-family: monospace;
+  font-size: 0.875rem;
 }
 
 // One pick reads as a chip of two halves: which game, then what to back in it.
 .analysis__pick {
   display: flex;
   align-items: baseline;
-  gap: 6px;
+  gap: var(--rak-pick-gap);
   padding: 4px var(--rak-pick-inset);
   border-radius: var(--rak-radius-sm);
   background-color: var(--rak-level1);
-  font-size: 0.875rem;
   font-weight: 600;
   white-space: nowrap;
 }
 
 .analysis__pick-label {
+  // Held to its widest, so the teams line up down a column whatever the labels do.
+  flex: 0 0 var(--rak-pick-label-width);
   color: var(--rak-text-tertiary);
   font-weight: 700;
 }

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -5,11 +5,9 @@
   // stand under that text rather than under the chip.
   --rak-pick-inset: 8px;
   --rak-pick-gap: 6px;
-  // A game label is a league letter and at most two digits. A pick is a team
-  // abbreviation of at most five characters, a space, and a spread of at most three
-  // counting its sign. Monospace, so those are widths rather than guesses.
+  // A game label is a league letter and at most two digits. Monospace, so that is a
+  // width rather than a guess.
   --rak-pick-label-width: 3ch;
-  --rak-pick-value-width: 9ch;
 
   display: flex;
   flex-direction: column;
@@ -59,13 +57,15 @@
 // every route. Each list is the same width, so each divides the same way.
 .analysis__picks {
   display: grid;
-  // A column is only ever as wide as the widest thing it can hold.
+  // A column is only ever as wide as the widest chip it can hold: a label, a team
+  // abbreviation of at most five characters, a space, a spread of at most three
+  // counting its sign, and the gap and padding around them.
   grid-template-columns: repeat(
     auto-fit,
     minmax(
       calc(
-        var(--rak-pick-label-width) + var(--rak-pick-value-width) +
-          var(--rak-pick-gap) + var(--rak-pick-inset) * 2
+        var(--rak-pick-label-width) + 9ch + var(--rak-pick-gap) +
+          var(--rak-pick-inset) * 2
       ),
       1fr
     )
@@ -159,11 +159,9 @@
   font-size: 0.875rem;
 }
 
-// Reads as part of the route it closes, so it is set like the picks above it, in
-// under their text and labelled the way they are.
-// Each half stays whole, so a screen too narrow for the line breaks between the
-// total and the players it beats, and the half carried down starts where the label
-// above it does rather than under the total.
+// Set like the picks above it, in under their text. A screen too narrow for the
+// line breaks after the total rather than inside it, and what is carried down
+// starts where the label above it does.
 .analysis__route-mnf {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -27,6 +27,11 @@
   color: var(--rak-text-tertiary);
   font-size: 0.875rem;
   font-style: italic;
+
+  // Reads as the end of the routes above it rather than as an aside about them.
+  &.--upright {
+    font-style: normal;
+  }
 }
 
 .analysis__section {

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -1,37 +1,37 @@
 // Whatever the answer turns out to be, it plays in under a dialog already growing
 // to hold it.
-.victory {
+.analysis {
   display: flex;
   flex-direction: column;
   gap: 16px;
 
   @media (prefers-reduced-motion: no-preference) {
-    animation: victory-in 220ms ease both;
+    animation: analysis-in 220ms ease both;
   }
 }
 
-@keyframes victory-in {
+@keyframes analysis-in {
   from {
     opacity: 0;
     transform: translateY(6px);
   }
 }
 
-.victory__note {
+.analysis__note {
   margin: 0;
   color: var(--rak-text-tertiary);
   font-size: 0.875rem;
   font-style: italic;
 }
 
-.victory__section {
+.analysis__section {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.victory__standing,
-.victory__section-title {
+.analysis__standing,
+.analysis__section-title {
   margin: 0;
   color: var(--rak-text-tertiary);
   font-size: 0.75rem;
@@ -42,7 +42,7 @@
 
 // Columns rather than a wrapping row, so the same game sits at the same x down
 // every route. Each list is the same width, so each divides the same way.
-.victory__picks {
+.analysis__picks {
   display: grid;
   // The floor is what the longest pick a sheet can hold measures, so a column
   // never has to cut one short or wrap it.
@@ -54,7 +54,7 @@
 }
 
 // One pick reads as a chip of two halves: which game, then what to back in it.
-.victory__pick {
+.analysis__pick {
   display: flex;
   align-items: baseline;
   gap: 6px;
@@ -66,16 +66,16 @@
   white-space: nowrap;
 }
 
-.victory__pick-label {
+.analysis__pick-label {
   color: var(--rak-text-tertiary);
   font-weight: 700;
 }
 
-.victory__pick-team {
+.analysis__pick-team {
   color: var(--rak-text);
 }
 
-.victory__routes {
+.analysis__routes {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -84,8 +84,8 @@
   list-style: none;
 }
 
-.victory__route,
-.victory__must-win {
+.analysis__route,
+.analysis__must-win {
   padding: 8px 10px;
   // Drawn on the left alone, so a stack of routes reads as a list of alternatives
   // rather than as a stack of boxes.
@@ -93,7 +93,7 @@
   background-color: var(--rak-level1);
 }
 
-.victory__route {
+.analysis__route {
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -101,19 +101,19 @@
 
 // Red against the routes' gold, since these games are what has to happen rather
 // than one way among several of getting there.
-.victory__must-win {
+.analysis__must-win {
   border-inline-start-color: var(--rak-danger-500);
 }
 
 // A soft button takes the color around it, so the gold is set here rather than by
 // the color prop, which only paints a solid fill.
-.victory__more {
+.analysis__more {
   align-self: flex-start;
   color: var(--rak-gold-700);
   font-weight: 700;
 }
 
-.victory__help {
+.analysis__help {
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -122,13 +122,13 @@
   list-style: none;
 }
 
-.victory__line {
+.analysis__line {
   margin: 0;
   color: var(--rak-text-secondary);
   font-size: 0.875rem;
 }
 
-.victory__message {
+.analysis__message {
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -161,22 +161,18 @@
 
 // Reads as part of the route it closes, so it is set like the picks above it, in
 // under their text and labelled the way they are.
+// Each half stays whole, so a screen too narrow for the line breaks between the
+// total and the players it beats, and the half carried down starts where the label
+// above it does rather than under the total.
 .analysis__route-mnf {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
-  gap: var(--rak-pick-gap);
+  gap: 0 var(--rak-pick-gap);
   padding-inline-start: var(--rak-pick-inset);
   color: var(--rak-text);
   font-family: monospace;
   font-weight: 600;
-}
-
-// Each half stays whole, so a screen too narrow for the line breaks between the
-// total and the players it beats rather than inside either.
-.analysis__route-mnf-terms {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0 var(--rak-pick-gap);
 }
 
 .analysis__message {

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { PathsToVictory, VictoryRoute } from "../../types/PathsToVictory";
+import { PlayerAnalysis, VictoryRoute } from "../../types/PlayerAnalysis";
 import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
-import VictorySummary, { Standing } from "./VictorySummary";
+import AnalysisSummary, { Standing } from "./AnalysisSummary";
 
 /** Routes of one game each, all different, so only their number matters. */
 function routesOf(count: number): Array<VictoryRoute> {
@@ -107,20 +107,20 @@ describe("Standing", () => {
   });
 });
 
-describe("VictorySummary", () => {
+describe("AnalysisSummary", () => {
   it("says nothing until a player is picked", () => {
-    const { container } = render(<VictorySummary />);
+    const { container } = render(<AnalysisSummary />);
 
     expect(container).toBeEmptyDOMElement();
   });
 
   it("gives an eliminated player the reason they carry", () => {
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       kind: "eliminated",
       player: "Bob",
       explanation: "Knocked out on Total Score by Alice.",
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
     expect(screen.getByText("Bob cannot win this week.")).toBeInTheDocument();
     expect(
@@ -129,7 +129,7 @@ describe("VictorySummary", () => {
   });
 
   it("says a clinched week is already won", () => {
-    render(<VictorySummary result={{ kind: "clinched", player: "Alice" }} />);
+    render(<AnalysisSummary result={{ kind: "clinched", player: "Alice" }} />);
 
     expect(
       screen.getByText("Alice has already won the week."),
@@ -137,14 +137,14 @@ describe("VictorySummary", () => {
   });
 
   it("gives a floor rather than paths on a week too big to search", () => {
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       kind: "headline",
       player: "Alice",
       remainingPickCount: 13,
       minimumWins: 6,
       needsMondayNight: true,
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
     expect(
       screen.getByText("Alice needs at least 6 of their 13 remaining picks."),
@@ -153,11 +153,11 @@ describe("VictorySummary", () => {
     const why = screen.getByText(
       "Detailed paths are worked out once ten games are left.",
     );
-    expect(why).toBe(document.querySelector(".victory")?.lastElementChild);
+    expect(why).toBe(document.querySelector(".analysis")?.lastElementChild);
   });
 
   it("lists the must-win games and the pool behind them", () => {
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       ...base,
       mustWin: [{ label: "C4", pick: "UGA -7" }],
       pool: {
@@ -170,7 +170,7 @@ describe("VictorySummary", () => {
       },
       mondayNight: { kind: "notNeeded" },
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
     expect(under("Must win")).toEqual(["C4UGA -7"]);
     expect(under("Then any 2 of these")).toEqual([
@@ -181,11 +181,11 @@ describe("VictorySummary", () => {
   });
 
   it("says something for a player the games can no longer separate", () => {
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       ...base,
       mondayNight: { kind: "range", max: 45, contenders: ["Rak"] },
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
     expect(
       screen.getByText(
@@ -195,7 +195,7 @@ describe("VictorySummary", () => {
   });
 
   it("writes a bounded Monday night range as a sentence", () => {
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       ...base,
       mustWin: [{ label: "P1", pick: "KC -3" }],
       mondayNight: {
@@ -205,7 +205,7 @@ describe("VictorySummary", () => {
         contenders: ["Rak", "Bill"],
       },
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
     expect(
       screen.getByText("38 ≤ MNF points ≤ 44 to beat Rak and Bill."),
@@ -213,12 +213,12 @@ describe("VictorySummary", () => {
   });
 
   it("writes an open-ended range from the end it is bounded on", () => {
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       ...base,
       mustWin: [{ label: "P1", pick: "KC -3" }],
       mondayNight: { kind: "range", max: 45, contenders: ["Rak"] },
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
     expect(
       screen.getByText("MNF points ≤ 45 to beat Rak."),
@@ -226,13 +226,13 @@ describe("VictorySummary", () => {
   });
 
   it("says what it takes to win without the tiebreaker at all", () => {
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       ...base,
       pool: { choose: 2, games: [{ label: "P1", pick: "KC -3" }] },
       outrightAt: 3,
       mondayNight: { kind: "range", max: 45, contenders: ["Rak"] },
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
     expect(
       screen.getByText("Winning 3 games takes it outright. Otherwise:"),
@@ -240,12 +240,12 @@ describe("VictorySummary", () => {
   });
 
   it("leads with taking the week outright, ahead of the games", () => {
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       ...base,
       mustWin: [{ label: "P1", pick: "KC -3" }],
       mondayNight: { kind: "notNeeded" },
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
     const outright = screen.getByText(/Takes the week outright/);
     const mustWin = screen.getByRole("heading", { name: "Must win" });
@@ -256,25 +256,25 @@ describe("VictorySummary", () => {
   });
 
   it("leaves the outright line off where it asks no more than the routes do", () => {
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       ...base,
       mustWin: [{ label: "P1", pick: "KC -3" }],
       outrightAt: 1,
       mondayNight: { kind: "notNeeded" },
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
     expect(screen.queryByText(/takes it outright/)).not.toBeInTheDocument();
   });
 
   it("names the team that has to miss in a game the player left blank", () => {
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       ...base,
       mustWin: [{ label: "P1", pick: "KC -3" }],
       needsHelp: [{ label: "P7", needsToMiss: ["DEN"] }],
       mondayNight: { kind: "notNeeded" },
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
     expect(
       screen.getByText(/is blank on your sheet, so DEN has to miss/),
@@ -282,7 +282,7 @@ describe("VictorySummary", () => {
   });
 
   it("lists routes of different shapes with the ones that need a total marked", () => {
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       ...base,
       routes: [
         {
@@ -299,22 +299,22 @@ describe("VictorySummary", () => {
       ],
       hiddenRouteCount: 2,
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
     // Read off the routes themselves, since each one holds a list of picks of
     // its own and reading every list item at once would flatten the two apart.
-    const routes = [...document.querySelectorAll(".victory__route")];
+    const routes = [...document.querySelectorAll(".analysis__route")];
     expect(routes.map((route) => route.textContent)).toEqual([
       "P1KC -3",
       "P2BUF -1P3SF -6MNF points ≤ 32 to beat Rak.",
     ]);
     const note = screen.getByText("2 other paths found but not shown.");
-    expect(note).toBe(document.querySelector(".victory")?.lastElementChild);
+    expect(note).toBe(document.querySelector(".analysis")?.lastElementChild);
   });
 
   it("states a total every route shares once, not on each of them", () => {
     const shared = { kind: "range" as const, max: 32, contenders: ["Rak"] };
-    const result: PathsToVictory = {
+    const result: PlayerAnalysis = {
       ...base,
       routes: [
         { games: [{ label: "P1", pick: "KC -3" }], mondayNight: shared },
@@ -322,9 +322,9 @@ describe("VictorySummary", () => {
       ],
       mondayNight: shared,
     };
-    render(<VictorySummary result={result} />);
+    render(<AnalysisSummary result={result} />);
 
-    const routes = [...document.querySelectorAll(".victory__route")];
+    const routes = [...document.querySelectorAll(".analysis__route")];
     expect(routes.map((route) => route.textContent)).toEqual([
       "P1KC -3",
       "P2BUF -1",
@@ -335,29 +335,29 @@ describe("VictorySummary", () => {
   });
 
   it("holds four routes open and folds the rest behind a button", () => {
-    const result: PathsToVictory = { ...base, routes: routesOf(8) };
-    render(<VictorySummary result={result} />);
+    const result: PlayerAnalysis = { ...base, routes: routesOf(8) };
+    render(<AnalysisSummary result={result} />);
 
-    expect(document.querySelectorAll(".victory__route")).toHaveLength(4);
+    expect(document.querySelectorAll(".analysis__route")).toHaveLength(4);
     expect(
       screen.getByRole("button", { name: "Show 4 more paths" }),
     ).toBeInTheDocument();
   });
 
   it("shows the rest once the button is clicked", async () => {
-    const result: PathsToVictory = { ...base, routes: routesOf(8) };
-    render(<VictorySummary result={result} />);
+    const result: PlayerAnalysis = { ...base, routes: routesOf(8) };
+    render(<AnalysisSummary result={result} />);
     await userEvent.click(screen.getByRole("button"));
 
-    expect(document.querySelectorAll(".victory__route")).toHaveLength(8);
+    expect(document.querySelectorAll(".analysis__route")).toHaveLength(8);
     expect(
       screen.getByRole("button", { name: "Show fewer" }),
     ).toBeInTheDocument();
   });
 
   it("leaves the button off where every route is already open", () => {
-    const result: PathsToVictory = { ...base, routes: routesOf(4) };
-    render(<VictorySummary result={result} />);
+    const result: PlayerAnalysis = { ...base, routes: routesOf(4) };
+    render(<AnalysisSummary result={result} />);
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -267,6 +267,19 @@ describe("AnalysisSummary", () => {
     expect(screen.queryByText(/takes it outright/)).not.toBeInTheDocument();
   });
 
+  it("names the player standing where nothing takes the week outright", () => {
+    const result: PlayerAnalysis = {
+      ...base,
+      mustWin: [{ label: "P1", pick: "KC -3" }],
+      mondayNight: { kind: "range", max: 45, contenders: ["Rak"] },
+    };
+    render(<AnalysisSummary result={result} />);
+
+    expect(
+      screen.getByText("Alice is still live to win the week. What it takes:"),
+    ).toBeInTheDocument();
+  });
+
   it("names the team that has to miss in a game the player left blank", () => {
     const result: PlayerAnalysis = {
       ...base,

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -149,7 +149,7 @@ describe("AnalysisSummary", () => {
     expect(
       screen.getByText("Alice needs at least 6 of their 13 remaining picks."),
     ).toBeInTheDocument();
-    expect(screen.getByText(/MNF points tiebreaker/)).toBeInTheDocument();
+    expect(screen.getByText(/MNF Points tiebreaker/)).toBeInTheDocument();
     const why = screen.getByText(
       "Detailed paths are worked out once ten games are left.",
     );
@@ -189,7 +189,7 @@ describe("AnalysisSummary", () => {
 
     expect(
       screen.getByText(
-        "No clean path to victory. The MNF points tiebreaker decides it.",
+        "No clean path to victory. The MNF Points tiebreaker decides it.",
       ),
     ).toBeInTheDocument();
   });
@@ -337,6 +337,37 @@ describe("AnalysisSummary", () => {
     const routes = [...document.querySelectorAll(".analysis__route")];
     expect(screen.getByText(note).previousElementSibling).toBe(
       routes[routes.length - 1]?.parentElement,
+    );
+  });
+
+  it("counts them straight away where no route was folded away", () => {
+    const result: PlayerAnalysis = {
+      ...base,
+      routes: routesOf(2),
+      hiddenRouteCount: 2,
+    };
+    render(<AnalysisSummary result={result} />);
+
+    expect(
+      screen.getByText("2 other paths found but not shown."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("names every player a route's total has to beat", () => {
+    const result: PlayerAnalysis = {
+      ...base,
+      routes: [
+        {
+          games: [{ label: "P1", pick: "KC -3" }],
+          mondayNight: { kind: "range", min: 30, contenders: ["Rak", "Bill"] },
+        },
+      ],
+    };
+    render(<AnalysisSummary result={result} />);
+
+    expect(document.querySelector(".analysis__route")?.textContent).toBe(
+      "P1KC -3ANDMNF Points ≥ 30TO BEAT Rak, Bill",
     );
   });
 

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -208,7 +208,7 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(
-      screen.getByText("38 ≤ MNF points ≤ 44 to beat Rak and Bill."),
+      screen.getByText("38 ≤ MNF Points ≤ 44 to beat Rak and Bill."),
     ).toBeInTheDocument();
   });
 
@@ -221,7 +221,7 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(
-      screen.getByText("MNF points ≤ 45 to beat Rak."),
+      screen.getByText("MNF Points ≤ 45 to beat Rak."),
     ).toBeInTheDocument();
   });
 
@@ -318,7 +318,7 @@ describe("AnalysisSummary", () => {
     const routes = [...document.querySelectorAll(".analysis__route")];
     expect(routes.map((route) => route.textContent)).toEqual([
       "P1KC -3",
-      "P2BUF -1P3SF -6MNF points ≤ 32 to beat Rak.",
+      "P2BUF -1P3SF -6ANDMNF Points ≤ 32TO BEAT Rak",
     ]);
   });
 
@@ -358,7 +358,7 @@ describe("AnalysisSummary", () => {
       "P2BUF -1",
     ]);
     expect(
-      screen.getByText("MNF points ≤ 32 to beat Rak."),
+      screen.getByText("MNF Points ≤ 32 to beat Rak."),
     ).toBeInTheDocument();
   });
 

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -310,7 +310,6 @@ describe("AnalysisSummary", () => {
           mondayNight: { kind: "range", max: 32, contenders: ["Rak"] },
         },
       ],
-      hiddenRouteCount: 2,
     };
     render(<AnalysisSummary result={result} />);
 
@@ -321,8 +320,24 @@ describe("AnalysisSummary", () => {
       "P1KC -3",
       "P2BUF -1P3SF -6MNF points ≤ 32 to beat Rak.",
     ]);
-    const note = screen.getByText("2 other paths found but not shown.");
-    expect(note).toBe(document.querySelector(".analysis")?.lastElementChild);
+  });
+
+  it("counts the routes left off under the last one, once they are all open", async () => {
+    const result: PlayerAnalysis = {
+      ...base,
+      routes: routesOf(8),
+      hiddenRouteCount: 2,
+    };
+    render(<AnalysisSummary result={result} />);
+
+    const note = "2 other paths found but not shown.";
+    expect(screen.queryByText(note)).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button"));
+
+    const routes = [...document.querySelectorAll(".analysis__route")];
+    expect(screen.getByText(note).previousElementSibling).toBe(
+      routes[routes.length - 1]?.parentElement,
+    );
   });
 
   it("states a total every route shares once, not on each of them", () => {

--- a/src/components/playerAnalysis/AnalysisSummary.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.tsx
@@ -142,22 +142,25 @@ function fewestWins(result: PathsResult): number {
 
 /**
  * Winning the week on points alone leads, since it settles the tiebreaker before
- * the reader has to think about it.
+ * the reader has to think about it. Where there is no such line the player is
+ * named as standing instead, so the sections below never open on their own.
  */
-function Outright({ result }: { result: PathsResult }) {
-  const line =
+function Lead({ result }: { result: PathsResult }) {
+  const outright =
     result.mondayNight?.kind === "notNeeded"
       ? "Takes the week outright, whatever the MNF points come to."
       : // Only worth saying where it asks more than the routes below already do.
         result.outrightAt != null && result.outrightAt > fewestWins(result)
         ? `Winning ${plural(result.outrightAt, "game")} takes it outright.`
         : null;
-  if (line == null) return null;
+  // Nothing below to lead into, and the closing sentence there is the answer.
+  if (outright == null && !hasGames(result)) return null;
   return (
     <p className="analysis__line">
-      {line}
+      {outright ?? `${result.player} is still live to win the week.`}
       {/* Hands over to the sections under it, which ask for less. */}
-      {hasGames(result) && " Otherwise:"}
+      {hasGames(result) &&
+        (outright != null ? " Otherwise:" : " What it takes:")}
     </p>
   );
 }
@@ -303,7 +306,7 @@ export default function AnalysisSummary({
 
   return (
     <Answer>
-      <Outright result={result} />
+      <Lead result={result} />
 
       {result.mustWin.length > 0 && (
         <Section title="Must win">

--- a/src/components/playerAnalysis/AnalysisSummary.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from "react";
+import { Fragment, ReactNode, useState } from "react";
 import {
   MondayNightOutlook,
   PlayerAnalysis,
@@ -18,6 +18,9 @@ type PathsResult = Extract<PlayerAnalysis, { kind: "paths" }>;
 
 /** The outlooks worth a sentence: a week won outright says so on its own line. */
 type DecidingOutlook = Exclude<MondayNightOutlook, { kind: "notNeeded" }>;
+
+/** The one outlook a route of its own carries, which is a total still to come. */
+type MondayNightRange = Extract<MondayNightOutlook, { kind: "range" }>;
 
 const NAMES = new Intl.ListFormat("en-US");
 
@@ -107,20 +110,45 @@ function Picks({
 }
 
 /** The MNF points that win, named the way the scoreboard column is. */
+function mondayNightPoints({ min, max }: MondayNightRange): string {
+  if (min != null && max != null) {
+    return min === max ? `MNF Points = ${min}` : `${min} ≤ MNF Points ≤ ${max}`;
+  }
+  return min != null ? `MNF Points ≥ ${min}` : `MNF Points ≤ ${max}`;
+}
+
 function mondayNightSentence(outlook: DecidingOutlook): string {
   if (outlook.kind === "settled") {
-    return "MNF points are already final, so the games above settle it.";
+    return "MNF Points are already final, so the games above settle it.";
   }
-  const { min, max } = outlook;
-  const points =
-    min != null && max != null
-      ? min === max
-        ? `MNF points = ${min}`
-        : `${min} ≤ MNF points ≤ ${max}`
-      : min != null
-        ? `MNF points ≥ ${min}`
-        : `MNF points ≤ ${max}`;
-  return `${points} to beat ${NAMES.format(outlook.contenders)}.`;
+  return `${mondayNightPoints(outlook)} to beat ${NAMES.format(outlook.contenders)}.`;
+}
+
+/**
+ * The total a route of its own asks for, set out the way its picks are: what to do
+ * in the ink they use, and the words holding it together in the ink their labels
+ * use. The two halves wrap as wholes, so a narrow screen breaks between them.
+ */
+function RouteMondayNight({ outlook }: { outlook: MondayNightRange }) {
+  return (
+    <p className="analysis__line analysis__route-mnf">
+      <span className="analysis__pick-label">AND</span>
+      <span className="analysis__route-mnf-terms">
+        <span>{mondayNightPoints(outlook)}</span>
+        <span>
+          {/* A list rather than a sentence, since the line around it is one too,
+              and what holds it together is grey the way the rest of it is. */}
+          <span className="analysis__term">TO BEAT</span>{" "}
+          {outlook.contenders.map((name, index) => (
+            <Fragment key={name}>
+              {index > 0 && <span className="analysis__term">, </span>}
+              {name}
+            </Fragment>
+          ))}
+        </span>
+      </span>
+    </p>
+  );
 }
 
 /** Whether anything below the outright line asks the player for a game. */
@@ -217,9 +245,7 @@ function Routes({
           >
             <Picks games={route.games} />
             {showMondayNight && route.mondayNight.kind === "range" && (
-              <p className="analysis__line analysis__route-mnf">
-                {mondayNightSentence(route.mondayNight)}
-              </p>
+              <RouteMondayNight outlook={route.mondayNight} />
             )}
           </li>
         ))}

--- a/src/components/playerAnalysis/AnalysisSummary.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.tsx
@@ -215,7 +215,7 @@ function Routes({
           >
             <Picks games={route.games} />
             {showMondayNight && route.mondayNight.kind === "range" && (
-              <p className="analysis__line">
+              <p className="analysis__line analysis__route-mnf">
                 {mondayNightSentence(route.mondayNight)}
               </p>
             )}

--- a/src/components/playerAnalysis/AnalysisSummary.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.tsx
@@ -127,25 +127,24 @@ function mondayNightSentence(outlook: DecidingOutlook): string {
 /**
  * The total a route of its own asks for, set out the way its picks are: what to do
  * in the ink they use, and the words holding it together in the ink their labels
- * use. The two halves wrap as wholes, so a narrow screen breaks between them.
+ * use. The total and the players it beats wrap as wholes, so a screen too narrow
+ * for the line breaks between them rather than inside either.
  */
 function RouteMondayNight({ outlook }: { outlook: MondayNightRange }) {
   return (
     <p className="analysis__line analysis__route-mnf">
       <span className="analysis__pick-label">AND</span>
-      <span className="analysis__route-mnf-terms">
-        <span>{mondayNightPoints(outlook)}</span>
-        <span>
-          {/* A list rather than a sentence, since the line around it is one too,
+      <span>{mondayNightPoints(outlook)}</span>
+      <span>
+        {/* A list rather than a sentence, since the line around it is one too,
               and what holds it together is grey the way the rest of it is. */}
-          <span className="analysis__term">TO BEAT</span>{" "}
-          {outlook.contenders.map((name, index) => (
-            <Fragment key={name}>
-              {index > 0 && <span className="analysis__term">, </span>}
-              {name}
-            </Fragment>
-          ))}
-        </span>
+        <span className="analysis__term">TO BEAT</span>{" "}
+        {outlook.contenders.map((name, index) => (
+          <Fragment key={name}>
+            {index > 0 && <span className="analysis__term">, </span>}
+            {name}
+          </Fragment>
+        ))}
       </span>
     </p>
   );

--- a/src/components/playerAnalysis/AnalysisSummary.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.tsx
@@ -227,7 +227,7 @@ function Routes({
       {/* Worked out, then left off, so the count is what the reader is missing.
           Held back until they have asked for the rest and reached the end of them. */}
       {isExpanded && hiddenCount > 0 && (
-        <p className="analysis__note">
+        <p className="analysis__note --upright">
           {plural(hiddenCount, "other path")} found but not shown.
         </p>
       )}

--- a/src/components/playerAnalysis/AnalysisSummary.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.tsx
@@ -1,20 +1,20 @@
 import { ReactNode, useState } from "react";
 import {
   MondayNightOutlook,
-  PathsToVictory,
+  PlayerAnalysis,
   RemainingPick,
   UncontrolledGame,
   VictoryRoute,
-} from "../../types/PathsToVictory";
+} from "../../types/PlayerAnalysis";
 import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
 import remainingGames from "../../utils/scoring/remainingGames";
 import Button from "../button/Button";
-import "./VictorySummary.scss";
+import "./AnalysisSummary.scss";
 
 /** How many routes stand open, the rest being a click away. */
 const ROUTES_SHOWN_AT_FIRST = 4;
 
-type PathsResult = Extract<PathsToVictory, { kind: "paths" }>;
+type PathsResult = Extract<PlayerAnalysis, { kind: "paths" }>;
 
 /** The outlooks worth a sentence: a week won outright says so on its own line. */
 type DecidingOutlook = Exclude<MondayNightOutlook, { kind: "notNeeded" }>;
@@ -57,7 +57,7 @@ export function Standing({
       : `${leader.name} leads with ${plural(top, "point")}`;
   const behind = chosen != null ? top - chosen.score.total : null;
   return (
-    <p className="victory__standing">
+    <p className="analysis__standing">
       {!hasKickedOff(players)
         ? "No finished games"
         : behind == null
@@ -73,13 +73,13 @@ export function Standing({
 
 /** Whatever the answer turns out to be, it plays in under the same wrapper. */
 function Answer({ children }: { children: ReactNode }) {
-  return <div className="victory">{children}</div>;
+  return <div className="analysis">{children}</div>;
 }
 
 function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <section className="victory__section">
-      <h3 className="victory__section-title">{title}</h3>
+    <section className="analysis__section">
+      <h3 className="analysis__section-title">{title}</h3>
       {children}
     </section>
   );
@@ -94,12 +94,12 @@ function Picks({
 }) {
   return (
     <ul
-      className={className ? `victory__picks ${className}` : "victory__picks"}
+      className={className ? `analysis__picks ${className}` : "analysis__picks"}
     >
       {games.map((game) => (
-        <li key={game.label} className="victory__pick">
-          <span className="victory__pick-label">{game.label}</span>
-          <span className="victory__pick-team">{game.pick}</span>
+        <li key={game.label} className="analysis__pick">
+          <span className="analysis__pick-label">{game.label}</span>
+          <span className="analysis__pick-team">{game.pick}</span>
         </li>
       ))}
     </ul>
@@ -154,7 +154,7 @@ function Outright({ result }: { result: PathsResult }) {
         : null;
   if (line == null) return null;
   return (
-    <p className="victory__line">
+    <p className="analysis__line">
       {line}
       {/* Hands over to the sections under it, which ask for less. */}
       {hasGames(result) && " Otherwise:"}
@@ -166,7 +166,7 @@ function MondayNight({ outlook }: { outlook?: MondayNightOutlook }) {
   if (outlook == null || outlook.kind === "notNeeded") return null;
   return (
     <Section title="MNF points">
-      <p className="victory__line">{mondayNightSentence(outlook)}</p>
+      <p className="analysis__line">{mondayNightSentence(outlook)}</p>
     </Section>
   );
 }
@@ -175,10 +175,10 @@ function NeedsHelp({ games }: { games: Array<UncontrolledGame> }) {
   if (games.length === 0) return null;
   return (
     <Section title="Out of your hands">
-      <ul className="victory__help">
+      <ul className="analysis__help">
         {games.map((game) => (
-          <li key={game.label} className="victory__line">
-            <span className="victory__pick-label">{game.label}</span> is blank
+          <li key={game.label} className="analysis__line">
+            <span className="analysis__pick-label">{game.label}</span> is blank
             on your sheet, so {NAMES.format(game.needsToMiss)} has to miss.
           </li>
         ))}
@@ -204,15 +204,15 @@ function Routes({
   const shown = isExpanded ? routes : routes.slice(0, ROUTES_SHOWN_AT_FIRST);
   return (
     <Section title={title}>
-      <ol className="victory__routes">
+      <ol className="analysis__routes">
         {shown.map((route) => (
           <li
             key={route.games.map((game) => game.label).join()}
-            className="victory__route"
+            className="analysis__route"
           >
             <Picks games={route.games} />
             {showMondayNight && route.mondayNight.kind === "range" && (
-              <p className="victory__line">
+              <p className="analysis__line">
                 {mondayNightSentence(route.mondayNight)}
               </p>
             )}
@@ -221,7 +221,7 @@ function Routes({
       </ol>
       {folded > 0 && (
         <Button
-          className="victory__more"
+          className="analysis__more"
           variant="soft"
           size="sm"
           ariaExpanded={isExpanded}
@@ -237,11 +237,11 @@ function Routes({
 /** A line absent is one the answer did not call for, so the caller can pass it. */
 function Message({ lines }: { lines: Array<string | undefined> }) {
   return (
-    <div className="victory__message">
+    <div className="analysis__message">
       {lines
         .filter((line) => line != null)
         .map((line) => (
-          <p key={line} className="victory__line">
+          <p key={line} className="analysis__line">
             {line}
           </p>
         ))}
@@ -250,10 +250,10 @@ function Message({ lines }: { lines: Array<string | undefined> }) {
 }
 
 /** What the player has to do, or why there is nothing left to do about it. */
-export default function VictorySummary({
+export default function AnalysisSummary({
   result,
 }: {
-  result?: PathsToVictory;
+  result?: PlayerAnalysis;
 }) {
   // Nothing under the search until a name is picked, which the placeholder in it
   // already asks for.
@@ -294,7 +294,7 @@ export default function VictorySummary({
           ]}
         />
         {/* Why there is nothing below it, in the place the paths count theirs. */}
-        <p className="victory__note">
+        <p className="analysis__note">
           Detailed paths are worked out once ten games are left.
         </p>
       </Answer>
@@ -307,7 +307,7 @@ export default function VictorySummary({
 
       {result.mustWin.length > 0 && (
         <Section title="Must win">
-          <Picks className="victory__must-win" games={result.mustWin} />
+          <Picks className="analysis__must-win" games={result.mustWin} />
         </Section>
       )}
 
@@ -330,7 +330,7 @@ export default function VictorySummary({
       {/* A picked player always reads a sentence. This is the one left where the
           games ask nothing and the line above said nothing either. */}
       {!hasGames(result) && result.mondayNight?.kind !== "notNeeded" && (
-        <p className="victory__line">
+        <p className="analysis__line">
           No clean path to victory. The MNF points tiebreaker decides it.
         </p>
       )}
@@ -340,7 +340,7 @@ export default function VictorySummary({
 
       {/* Worked out, then left off, so the count is what the reader is missing. */}
       {result.hiddenRouteCount > 0 && (
-        <p className="victory__note">
+        <p className="analysis__note">
           {plural(result.hiddenRouteCount, "other path")} found but not shown.
         </p>
       )}

--- a/src/components/playerAnalysis/AnalysisSummary.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.tsx
@@ -194,12 +194,14 @@ function NeedsHelp({ games }: { games: Array<UncontrolledGame> }) {
 function Routes({
   title,
   routes,
+  hiddenCount,
   // Off where every route asks the same of the tiebreaker, which the section
   // below then states once rather than on each of them.
   showMondayNight,
 }: {
   title: string;
   routes: Array<VictoryRoute>;
+  hiddenCount: number;
   showMondayNight: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -222,6 +224,13 @@ function Routes({
           </li>
         ))}
       </ol>
+      {/* Worked out, then left off, so the count is what the reader is missing.
+          Held back until they have asked for the rest and reached the end of them. */}
+      {isExpanded && hiddenCount > 0 && (
+        <p className="analysis__note">
+          {plural(hiddenCount, "other path")} found but not shown.
+        </p>
+      )}
       {folded > 0 && (
         <Button
           className="analysis__more"
@@ -326,6 +335,7 @@ export default function AnalysisSummary({
         <Routes
           title={result.mustWin.length > 0 ? "Then one of" : "One of"}
           routes={result.routes}
+          hiddenCount={result.hiddenRouteCount}
           showMondayNight={result.mondayNight == null}
         />
       )}
@@ -340,13 +350,6 @@ export default function AnalysisSummary({
 
       <NeedsHelp games={result.needsHelp} />
       <MondayNight outlook={result.mondayNight} />
-
-      {/* Worked out, then left off, so the count is what the reader is missing. */}
-      {result.hiddenRouteCount > 0 && (
-        <p className="analysis__note">
-          {plural(result.hiddenRouteCount, "other path")} found but not shown.
-        </p>
-      )}
     </Answer>
   );
 }

--- a/src/components/playerAnalysis/AnalysisSummary.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.tsx
@@ -109,7 +109,7 @@ function Picks({
   );
 }
 
-/** The MNF points that win, named the way the scoreboard column is. */
+/** The MNF Points that win, named the way the scoreboard column is. */
 function mondayNightPoints({ min, max }: MondayNightRange): string {
   if (min != null && max != null) {
     return min === max ? `MNF Points = ${min}` : `${min} ≤ MNF Points ≤ ${max}`;
@@ -126,9 +126,7 @@ function mondayNightSentence(outlook: DecidingOutlook): string {
 
 /**
  * The total a route of its own asks for, set out the way its picks are: what to do
- * in the ink they use, and the words holding it together in the ink their labels
- * use. The total and the players it beats wrap as wholes, so a screen too narrow
- * for the line breaks between them rather than inside either.
+ * in the ink they use, and the words holding it together in their labels' ink.
  */
 function RouteMondayNight({ outlook }: { outlook: MondayNightRange }) {
   return (
@@ -136,8 +134,7 @@ function RouteMondayNight({ outlook }: { outlook: MondayNightRange }) {
       <span className="analysis__pick-label">AND</span>
       <span>{mondayNightPoints(outlook)}</span>
       <span>
-        {/* A list rather than a sentence, since the line around it is one too,
-              and what holds it together is grey the way the rest of it is. */}
+        {/* A list rather than a sentence, since the line around it is one too. */}
         <span className="analysis__term">TO BEAT</span>{" "}
         {outlook.contenders.map((name, index) => (
           <Fragment key={name}>
@@ -175,7 +172,7 @@ function fewestWins(result: PathsResult): number {
 function Lead({ result }: { result: PathsResult }) {
   const outright =
     result.mondayNight?.kind === "notNeeded"
-      ? "Takes the week outright, whatever the MNF points come to."
+      ? "Takes the week outright, whatever the MNF Points come to."
       : // Only worth saying where it asks more than the routes below already do.
         result.outrightAt != null && result.outrightAt > fewestWins(result)
         ? `Winning ${plural(result.outrightAt, "game")} takes it outright.`
@@ -195,7 +192,7 @@ function Lead({ result }: { result: PathsResult }) {
 function MondayNight({ outlook }: { outlook?: MondayNightOutlook }) {
   if (outlook == null || outlook.kind === "notNeeded") return null;
   return (
-    <Section title="MNF points">
+    <Section title="MNF Points">
       <p className="analysis__line">{mondayNightSentence(outlook)}</p>
     </Section>
   );
@@ -250,8 +247,9 @@ function Routes({
         ))}
       </ol>
       {/* Worked out, then left off, so the count is what the reader is missing.
-          Held back until they have asked for the rest and reached the end of them. */}
-      {isExpanded && hiddenCount > 0 && (
+          Held back while there are routes folded away, which are the ones to read
+          before hearing what came after them. */}
+      {(isExpanded || folded <= 0) && hiddenCount > 0 && (
         <p className="analysis__note --upright">
           {plural(hiddenCount, "other path")} found but not shown.
         </p>
@@ -326,7 +324,7 @@ export default function AnalysisSummary({
           lines={[
             `${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`,
             result.needsMondayNight
-              ? "That is only enough to draw level, so the MNF points tiebreaker would still decide it."
+              ? "That is only enough to draw level, so the MNF Points tiebreaker would still decide it."
               : undefined,
           ]}
         />
@@ -369,7 +367,7 @@ export default function AnalysisSummary({
           games ask nothing and the line above said nothing either. */}
       {!hasGames(result) && result.mondayNight?.kind !== "notNeeded" && (
         <p className="analysis__line">
-          No clean path to victory. The MNF points tiebreaker decides it.
+          No clean path to victory. The MNF Points tiebreaker decides it.
         </p>
       )}
 

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -34,9 +34,12 @@ found past the eight kept, held back until the rest have been asked for.
 A player picked always reads a sentence, down to the week resting on the
 tiebreaker alone.
 
-A tiebreaker every route shares is stated once under `MNF points`, and left off
-the routes themselves. Where they disagree each route carries its own, and that
-section does not render.
+A tiebreaker every route shares is stated once under `MNF points`, as a sentence,
+and left off the routes themselves. Where they disagree each route carries its own
+and that section does not render. A route says it the way it says its picks: set
+monospace under them, with `AND`, `TO BEAT`, and the commas between the players in
+the grey a pick's label carries. The total and the players it beats wrap as wholes,
+so a narrow screen breaks between them.
 
 One suite here mounts one dialog, on purpose. Base UI leaves its scroll lock, focus
 guards, and inert markers on the document when a second one mounts, which puts the

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -1,7 +1,7 @@
 # playerAnalysis
 
 Where a player stands in a week and what they still have to do to win it, opened
-from the navbar's gold trophy button or from a player's name in either table.
+from a player's name in either table.
 
 `PlayerAnalysisDialog`: a Base UI dialog over a Base UI combobox, with
 `AnalysisSummary` under it. `playersMatching` offers every player the letters typed

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -1,20 +1,20 @@
-# pathToVictory
+# playerAnalysis
 
 What a player still has to do to win a week being played, opened from the navbar's
 gold trophy button.
 
-`PathToVictoryDialog`: a Base UI dialog over a Base UI combobox, with
-`VictorySummary` under it. `playersMatching` names a knocked out player only where
+`PlayerAnalysisDialog`: a Base UI dialog over a Base UI combobox, with
+`AnalysisSummary` under it. `playersMatching` names a knocked out player only where
 the letters typed reach nobody still standing, disabled, in
 `--rak-knocked-out-text` with the same skull the table gives them. The search is
 thousands of scenarios, so it runs on the player chosen rather than on every
 render. Only the search holds still: everything under the rule below it scrolls.
-`PathToVictoryDialog.scss` centers the one dialog as a modal and stands it on the
+`PlayerAnalysisDialog.scss` centers the one dialog as a modal and stands it on the
 bottom edge as a sheet below `compact-screen`, replacing both ends of the
 transition, since a sheet cannot inherit a centered transform. Its popup list
 takes its shape from `styles/_listbox.scss`, which the home page selects share.
 
-`VictorySummary`: renders `PathsToVictory`, working out only what it takes to say
+`AnalysisSummary`: renders `PlayerAnalysis`, working out only what it takes to say
 it. The standing leads, from `Standing`, which reads the scores rather than the
 search, and names no leader until a pick is settled. Picks sit in a
 grid rather than a wrapping row, so the same game holds the same column down every

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -11,7 +11,9 @@ carries the status icon the tables give the same player, through
 The icon says the status rather than a fill behind it, so the only fill in the popup
 is still the highlight the list draws as it is walked. A name too long for the popup
 is cut short rather than wrapped, so an entry stays one line. The search is thousands
-of scenarios, so it runs on the player chosen rather than on every render. Only the
+of scenarios, so it runs on the player chosen rather than on every render. The answer
+already on screen stays there while the next one is worked out, under a bar on the
+rule that says so, rather than being taken away and put back. Only the
 search holds still: everything under the rule below it scrolls. A `player` prop
 stands in for a choice made in the search, and remounts the combobox so the name
 reaches its input. `PlayerAnalysisDialog.scss` centers the one dialog as a modal and

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -6,18 +6,18 @@ from the navbar's gold trophy button or from a player's name in either table.
 `PlayerAnalysisDialog`: a Base UI dialog over a Base UI combobox, with
 `AnalysisSummary` under it. `playersMatching` offers every player the letters typed
 reach, knocked out or not, since a knocked out one has an answer too. An entry
-carries the fill and the status icon the tables give the same player, from
-`--rak-in-contention` or `--rak-knocked-out` and `PlayerStatusIcon`, and the darker
-half of its pair marks the entry being pointed at. A name too long for the popup is
-cut short rather than wrapped, so an entry stays one line. The search is thousands
+carries the status icon the tables give the same player, through
+`PlayerStatusIcon`, drawn in `--rak-in-contention-text` or `--rak-knocked-out-text`.
+The icon says the status rather than a fill behind it, so the only fill in the popup
+is still the highlight the list draws as it is walked. A name too long for the popup
+is cut short rather than wrapped, so an entry stays one line. The search is thousands
 of scenarios, so it runs on the player chosen rather than on every render. Only the
 search holds still: everything under the rule below it scrolls. A `player` prop
 stands in for a choice made in the search, and remounts the combobox so the name
 reaches its input. `PlayerAnalysisDialog.scss` centers the one dialog as a modal and
 stands it on the bottom edge as a sheet below `compact-screen`, replacing both ends
 of the transition, since a sheet cannot inherit a centered transform. Its popup list
-takes its shape from `styles/_listbox.scss`, which the home page selects share, and
-overrides the two states that mixin colors by neither status.
+takes its shape from `styles/_listbox.scss`, which the home page selects share.
 
 `AnalysisSummary`: renders `PlayerAnalysis`, working out only what it takes to say
 it. The standing leads, from `Standing`, which reads the scores rather than the

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -1,18 +1,23 @@
 # playerAnalysis
 
-What a player still has to do to win a week being played, opened from the navbar's
-gold trophy button.
+Where a player stands in a week and what they still have to do to win it, opened
+from the navbar's gold trophy button or from a player's name in either table.
 
 `PlayerAnalysisDialog`: a Base UI dialog over a Base UI combobox, with
-`AnalysisSummary` under it. `playersMatching` names a knocked out player only where
-the letters typed reach nobody still standing, disabled, in
-`--rak-knocked-out-text` with the same skull the table gives them. The search is
-thousands of scenarios, so it runs on the player chosen rather than on every
-render. Only the search holds still: everything under the rule below it scrolls.
-`PlayerAnalysisDialog.scss` centers the one dialog as a modal and stands it on the
-bottom edge as a sheet below `compact-screen`, replacing both ends of the
-transition, since a sheet cannot inherit a centered transform. Its popup list
-takes its shape from `styles/_listbox.scss`, which the home page selects share.
+`AnalysisSummary` under it. `playersMatching` offers every player the letters typed
+reach, knocked out or not, since a knocked out one has an answer too. An entry
+carries the fill and the status icon the tables give the same player, from
+`--rak-in-contention` or `--rak-knocked-out` and `PlayerStatusIcon`, and the darker
+half of its pair marks the entry being pointed at. A name too long for the popup is
+cut short rather than wrapped, so an entry stays one line. The search is thousands
+of scenarios, so it runs on the player chosen rather than on every render. Only the
+search holds still: everything under the rule below it scrolls. A `player` prop
+stands in for a choice made in the search, and remounts the combobox so the name
+reaches its input. `PlayerAnalysisDialog.scss` centers the one dialog as a modal and
+stands it on the bottom edge as a sheet below `compact-screen`, replacing both ends
+of the transition, since a sheet cannot inherit a centered transform. Its popup list
+takes its shape from `styles/_listbox.scss`, which the home page selects share, and
+overrides the two states that mixin colors by neither status.
 
 `AnalysisSummary`: renders `PlayerAnalysis`, working out only what it takes to say
 it. The standing leads, from `Standing`, which reads the scores rather than the

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -23,9 +23,12 @@ takes its shape from `styles/_listbox.scss`, which the home page selects share.
 it. The standing leads, from `Standing`, which reads the scores rather than the
 search, and names no leader until a pick is settled. Picks sit in a
 grid rather than a wrapping row, so the same game holds the same column down every
-route. A must-win game carries a red line where a route carries gold. Routes stand
-four deep and unfold on a click, and the dialog's own key on the player is what
-starts a new one folded. A closing note counts the routes found past the eight kept.
+route, and a pick is drawn monospace and given the width of the widest team
+abbreviation and spread a sheet can hold, so a column fits as many as it can and
+never cuts one short. A must-win game carries a red line where a route carries gold.
+Routes stand four deep and unfold on a click, and the dialog's own key on the player
+is what starts a new one folded. Under the last one opened, a note counts the routes
+found past the eight kept, held back until the rest have been asked for.
 A player picked always reads a sentence, down to the week resting on the
 tiebreaker alone.
 

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -25,7 +25,7 @@ search, and names no leader until a pick is settled. Picks sit in a
 grid rather than a wrapping row, so the same game holds the same column down every
 route. A must-win game carries a red line where a route carries gold. Routes stand
 four deep and unfold on a click, and the dialog's own key on the player is what
-starts a new one folded. A closing note counts the routes found past the ten kept.
+starts a new one folded. A closing note counts the routes found past the eight kept.
 A player picked always reads a sentence, down to the week resting on the
 tiebreaker alone.
 

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -34,7 +34,7 @@ found past the eight kept, held back until the rest have been asked for.
 A player picked always reads a sentence, down to the week resting on the
 tiebreaker alone.
 
-A tiebreaker every route shares is stated once under `MNF points`, as a sentence,
+A tiebreaker every route shares is stated once under `MNF Points`, as a sentence,
 and left off the routes themselves. Where they disagree each route carries its own
 and that section does not render. A route says it the way it says its picks: set
 monospace under them, with `AND`, `TO BEAT`, and the commas between the players in

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.scss
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.scss
@@ -110,28 +110,45 @@
 .player-analysis__list {
   @include listbox-popup;
 
+  // Held to the width of the search above it, so a long name is cut short rather
+  // than widening the popup past the input it hangs off.
+  max-width: var(--anchor-width);
   max-height: min(240px, var(--available-height));
 }
 
+// A name here is filled and marked the way the tables fill and mark the same
+// player's cell, so the search reads as the standings do.
 .player-analysis__option {
   @include listbox-item;
 
-  gap: 8px;
+  justify-content: space-between;
+  gap: var(--rak-player-icon-gap);
+  color: black;
+  background-color: var(--rak-in-contention);
 
-  // Only ever offered where nobody still standing shares the letters typed. Named
-  // in the color the tables fill the same player's cell with, so it reads as the
-  // answer rather than as a choice.
-  &.--knocked-out,
-  &.--knocked-out[data-highlighted] {
-    background-color: transparent;
-    color: var(--rak-knocked-out-text);
-    cursor: default;
+  &.--knocked-out {
+    background-color: var(--rak-knocked-out);
   }
 
-  // As tall as the name beside it, which is the proportion the tables draw the
-  // same skull at.
-  > svg {
-    font-size: 1em;
+  // The darker half of the same pair, which is what the tables stripe their even
+  // rows with. Named after the mixin's own states, which color by neither.
+  &[data-highlighted],
+  &[data-selected] {
+    background-color: var(--rak-in-contention-dark);
+  }
+
+  &.--knocked-out[data-highlighted],
+  &.--knocked-out[data-selected] {
+    background-color: var(--rak-knocked-out-dark);
+  }
+
+  // One line however long the name is. The popup is not monospace, so it is cut
+  // to the room left beside the icon rather than to a count of characters.
+  .player-analysis__option-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.scss
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.scss
@@ -151,10 +151,14 @@
 // has no more room to give. Measured without the padding and the rule, which
 // `content-box` keeps outside the height set on it.
 .player-analysis__body {
+  // How far the answer stands off the rule above it, which the progress bar reads
+  // back to sit on that rule without moving the answer.
+  --rak-analysis-inset: 16px;
+
   box-sizing: content-box;
   flex: 0 1 auto;
   min-height: 0;
-  padding-top: 16px;
+  padding-top: var(--rak-analysis-inset);
   // Everything under here scrolls. Only the search above it holds still.
   border-top: 1px solid var(--rak-border);
   overflow-y: auto;
@@ -172,24 +176,53 @@
   gap: 8px;
 }
 
-.player-analysis__searching {
-  display: flex;
-  justify-content: center;
-  padding: 24px 0;
+// A bar on the rule above it while the next answer is worked out, in place of
+// anything that would move the answer still on screen. Stuck to the rule so
+// scrolling cannot carry it off, and pulled back out of the flow by its own height,
+// so what the body measures is the answer alone.
+.player-analysis__progress {
+  --rak-analysis-bar-height: 2px;
+
+  position: sticky;
+  // Measured from where the answer starts, which is the inset below the rule.
+  top: calc(-1 * var(--rak-analysis-inset));
+  z-index: 1;
+  display: block;
+  height: var(--rak-analysis-bar-height);
+  // Pulled up onto the rule, and the room it took given back underneath, so the
+  // answer sits where it would with no bar there at all.
+  margin-top: calc(-1 * var(--rak-analysis-inset));
+  margin-bottom: calc(
+    var(--rak-analysis-inset) - var(--rak-analysis-bar-height)
+  );
+  overflow: hidden;
+  background-color: var(--rak-neutral-200);
+
+  &::after {
+    content: "";
+    display: block;
+    width: 40%;
+    height: 100%;
+    background-color: var(--rak-primary-500);
+    animation: player-analysis-sweep 900ms ease-in-out infinite;
+  }
+
+  // Still says work is under way, without a thing crossing the screen to say it.
+  @media (prefers-reduced-motion: reduce) {
+    &::after {
+      width: 100%;
+      animation: none;
+    }
+  }
 }
 
-.player-analysis__spinner {
-  width: 24px;
-  height: 24px;
-  border: 3px solid var(--rak-neutral-200);
-  border-top-color: var(--rak-primary-500);
-  border-radius: 50%;
-  animation: player-analysis-spin 700ms linear infinite;
-}
+@keyframes player-analysis-sweep {
+  from {
+    transform: translateX(-100%);
+  }
 
-@keyframes player-analysis-spin {
   to {
-    transform: rotate(1turn);
+    transform: translateX(250%);
   }
 }
 

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.scss
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.scss
@@ -114,35 +114,20 @@
   // than widening the popup past the input it hangs off.
   max-width: var(--anchor-width);
   max-height: min(240px, var(--available-height));
-  // Every entry here is filled, so the mixin's own top and bottom padding would
-  // read as a white band inside the border rather than as room.
-  padding-block: 0;
 }
 
-// A name here is filled and marked the way the tables fill and mark the same
-// player's cell, so the search reads as the standings do.
+// An entry carries the status icon the tables give the same player, in the hue
+// they fill that player's cell with. The icon rather than the entry, so the
+// highlight the list draws as it is walked is still the only fill in the popup.
 .player-analysis__option {
   @include listbox-item;
 
   justify-content: space-between;
   gap: var(--rak-player-icon-gap);
-  color: black;
-  background-color: var(--rak-in-contention);
+  --rak-player-icon-fill: var(--rak-in-contention-text);
 
   &.--knocked-out {
-    background-color: var(--rak-knocked-out);
-  }
-
-  // The darker half of the same pair, which is what the tables stripe their even
-  // rows with. Named after the mixin's own states, which color by neither.
-  &[data-highlighted],
-  &[data-selected] {
-    background-color: var(--rak-in-contention-dark);
-  }
-
-  &.--knocked-out[data-highlighted],
-  &.--knocked-out[data-selected] {
-    background-color: var(--rak-knocked-out-dark);
+    --rak-player-icon-fill: var(--rak-knocked-out-text);
   }
 
   // One line however long the name is. The popup is not monospace, so it is cut

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.scss
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.scss
@@ -4,7 +4,7 @@
 // Base UI ships the dialog and the combobox unstyled, so these rules carry the
 // whole look of both. State comes off the data attributes they set, the same way
 // the select on the home page reads `[data-highlighted]`.
-.path-to-victory__backdrop {
+.player-analysis__backdrop {
   position: fixed;
   inset: 0;
   z-index: 1000;
@@ -17,7 +17,7 @@
   }
 }
 
-.path-to-victory__popup {
+.player-analysis__popup {
   position: fixed;
   z-index: 1001;
   display: flex;
@@ -49,21 +49,21 @@
   }
 }
 
-.path-to-victory__header {
+.player-analysis__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
 }
 
-.path-to-victory__title {
+.player-analysis__title {
   margin: 0;
   color: var(--rak-primary-700);
   font-size: 1.25rem;
   font-weight: 700;
 }
 
-.path-to-victory__search {
+.player-analysis__search {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -79,7 +79,7 @@
   }
 }
 
-.path-to-victory__input {
+.player-analysis__input {
   flex: 1;
   min-width: 0;
   padding: 3px 0;
@@ -95,25 +95,25 @@
   }
 }
 
-.path-to-victory__input-icon {
+.player-analysis__input-icon {
   display: flex;
   align-items: center;
   color: var(--rak-text-tertiary);
 }
 
-.path-to-victory__positioner {
+.player-analysis__positioner {
   // Above the dialog it opens inside of, which the backdrop already sits under.
   z-index: 1002;
   max-height: var(--available-height);
 }
 
-.path-to-victory__list {
+.player-analysis__list {
   @include listbox-popup;
 
   max-height: min(240px, var(--available-height));
 }
 
-.path-to-victory__option {
+.player-analysis__option {
   @include listbox-item;
 
   gap: 8px;
@@ -135,7 +135,7 @@
   }
 }
 
-.path-to-victory__empty {
+.player-analysis__empty {
   padding: 8px 12px;
   color: var(--rak-text-tertiary);
   font-size: 0.875rem;
@@ -145,7 +145,7 @@
 // and shrinks with the answer. Shrinking is what makes it scroll, once the popup
 // has no more room to give. Measured without the padding and the rule, which
 // `content-box` keeps outside the height set on it.
-.path-to-victory__body {
+.player-analysis__body {
   box-sizing: content-box;
   flex: 0 1 auto;
   min-height: 0;
@@ -161,28 +161,28 @@
 
 // The standing reads as a title over what follows, so it sits the same distance
 // from it as a section title sits from its own contents.
-.path-to-victory__content {
+.player-analysis__content {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.path-to-victory__searching {
+.player-analysis__searching {
   display: flex;
   justify-content: center;
   padding: 24px 0;
 }
 
-.path-to-victory__spinner {
+.player-analysis__spinner {
   width: 24px;
   height: 24px;
   border: 3px solid var(--rak-neutral-200);
   border-top-color: var(--rak-primary-500);
   border-radius: 50%;
-  animation: path-to-victory-spin 700ms linear infinite;
+  animation: player-analysis-spin 700ms linear infinite;
 }
 
-@keyframes path-to-victory-spin {
+@keyframes player-analysis-spin {
   to {
     transform: rotate(1turn);
   }
@@ -192,7 +192,7 @@
   // A sheet on the bottom edge, where a centered window would leave no margin
   // either side of it. The same dialog, told apart here rather than in the
   // component, because every other screen split in the app is drawn this way.
-  .path-to-victory__popup {
+  .player-analysis__popup {
     top: auto;
     left: 0;
     right: 0;

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.scss
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.scss
@@ -114,6 +114,9 @@
   // than widening the popup past the input it hangs off.
   max-width: var(--anchor-width);
   max-height: min(240px, var(--available-height));
+  // Every entry here is filled, so the mixin's own top and bottom padding would
+  // read as a white band inside the border rather than as room.
+  padding-block: 0;
 }
 
 // A name here is filled and marked the way the tables fill and mark the same

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.scss
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.scss
@@ -180,21 +180,19 @@
 // anything that would move the answer still on screen. Stuck to the rule so
 // scrolling cannot carry it off, and pulled back out of the flow by its own height,
 // so what the body measures is the answer alone.
-.player-analysis__progress {
-  --rak-analysis-bar-height: 2px;
+$bar-height: 2px;
 
+.player-analysis__progress {
   position: sticky;
   // Measured from where the answer starts, which is the inset below the rule.
   top: calc(-1 * var(--rak-analysis-inset));
   z-index: 1;
   display: block;
-  height: var(--rak-analysis-bar-height);
+  height: $bar-height;
   // Pulled up onto the rule, and the room it took given back underneath, so the
   // answer sits where it would with no bar there at all.
   margin-top: calc(-1 * var(--rak-analysis-inset));
-  margin-bottom: calc(
-    var(--rak-analysis-inset) - var(--rak-analysis-bar-height)
-  );
+  margin-bottom: calc(var(--rak-analysis-inset) - #{$bar-height});
   overflow: hidden;
   background-color: var(--rak-neutral-200);
 

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
@@ -5,10 +5,10 @@ import {
   PlayerScore,
   RakMadnessScores,
 } from "../../types/RakMadnessScores";
-import PathToVictoryDialog, {
+import PlayerAnalysisDialog, {
   playerOptions,
   playersMatching,
-} from "./PathToVictoryDialog";
+} from "./PlayerAnalysisDialog";
 
 function proPick(pick: string): PickResult {
   return {
@@ -90,13 +90,13 @@ describe("playersMatching", () => {
  * one dialog and toggles `open` on it.
  *
  * So this covers the wiring once, and what each result reads like is covered
- * against `VictorySummary` instead.
+ * against `AnalysisSummary` instead.
  */
-describe("PathToVictoryDialog", () => {
+describe("PlayerAnalysisDialog", () => {
   it("works out the route of the player picked from the search", async () => {
     const user = userEvent.setup();
     render(
-      <PathToVictoryDialog
+      <PlayerAnalysisDialog
         open
         onOpenChange={() => undefined}
         scores={scores}

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
@@ -22,7 +22,7 @@ function player(
   name: string,
   total: number,
   pick: string,
-  isKnockedOut = false,
+  explanation?: string,
 ): PlayerScore {
   return {
     name,
@@ -30,7 +30,11 @@ function player(
     tiebreaker: {},
     college: [],
     pro: [proPick(pick)],
-    status: { hasNoPicks: false, isKnockedOut },
+    status: {
+      hasNoPicks: false,
+      isKnockedOut: explanation != null,
+      explanation,
+    },
   };
 }
 
@@ -42,16 +46,17 @@ const scores: RakMadnessScores = {
   scores: [
     player("Alice", 3, "KC -3"),
     player("Bob", 3, "DEN +3"),
-    player("Bobby", 0, "DEN +3", true),
+    player("Bobby", 0, "DEN +3", "Knocked out on Total Score by Alice."),
   ],
 };
 
 describe("playersMatching", () => {
   const options = playerOptions(scores);
 
-  it("holds a knocked out player back while anyone standing matches", () => {
+  it("offers a knocked out player alongside anyone standing", () => {
     expect(playersMatching(options, "Bob")).toEqual([
       { name: "Bob", isKnockedOut: false },
+      { name: "Bobby", isKnockedOut: true },
     ]);
   });
 
@@ -61,18 +66,12 @@ describe("playersMatching", () => {
     ]);
   });
 
-  it("offers everyone still standing before anything is typed", () => {
+  it("offers everyone before anything is typed, in the order ranked", () => {
     expect(playersMatching(options, "").map((it) => it.name)).toEqual([
       "Alice",
       "Bob",
+      "Bobby",
     ]);
-  });
-
-  it("names nobody knocked out before anything is typed", () => {
-    const allOut = playerOptions({
-      scores: [player("Bobby", 0, "DEN +3", true)],
-    });
-    expect(playersMatching(allOut, "")).toEqual([]);
   });
 
   it("has nobody to offer before a week is scored", () => {
@@ -93,9 +92,9 @@ describe("playersMatching", () => {
  * against `AnalysisSummary` instead.
  */
 describe("PlayerAnalysisDialog", () => {
-  it("works out the route of the player picked from the search", async () => {
+  it("answers for the player picked from the search, and for one named", async () => {
     const user = userEvent.setup();
-    render(
+    const { rerender } = render(
       <PlayerAnalysisDialog
         open
         onOpenChange={() => undefined}
@@ -118,5 +117,25 @@ describe("PlayerAnalysisDialog", () => {
     );
     expect(pick).toHaveTextContent("P1");
     expect(pick).toHaveTextContent("KC -3");
+
+    // A name from outside stands in for the same choice, knocked out or not.
+    rerender(
+      <PlayerAnalysisDialog
+        open
+        onOpenChange={() => undefined}
+        player="Bobby"
+        scores={scores}
+      />,
+    );
+
+    expect(
+      await screen.findByText("Bobby cannot win this week."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Knocked out on Total Score by Alice."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Player" })).toHaveValue(
+      "Bobby",
+    );
   });
 });

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
@@ -110,7 +110,7 @@ describe("PlayerAnalysisDialog", () => {
     await user.type(search, "Ali");
     await user.click(await screen.findByRole("option", { name: "Alice" }));
 
-    // The search runs a frame after the spinner it replaces.
+    // The search runs a frame after the bar that says it is under way.
     const mustWin = await screen.findByRole("heading", { name: "Must win" });
     const pick = within(mustWin.parentElement as HTMLElement).getByRole(
       "listitem",

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -73,7 +73,7 @@ export default function PlayerAnalysisDialog({
   }
 
   // The search is thousands of scenarios and holds the thread while it runs, so
-  // it waits for the spinner beside it to paint first.
+  // it waits for the bar that says so to paint first.
   useEffect(() => {
     if (scores == null || player == null) return;
     let timer = 0;
@@ -197,7 +197,9 @@ export default function PlayerAnalysisDialog({
               />
             )}
             <div className="player-analysis__content" ref={measure}>
-              <Standing scores={scores} player={shown?.name} />
+              {/* Read off the scores, so it answers for the player picked before
+                  their routes have been worked out. */}
+              <Standing scores={scores} player={player?.name} />
               {/* Keyed on the player, so the answer to a new one plays in rather
                   than replacing the last one in place. */}
               <AnalysisSummary key={shown?.name} result={shown?.paths} />

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -1,14 +1,14 @@
 import { Combobox } from "@base-ui-components/react/combobox";
 import { Dialog } from "@base-ui-components/react/dialog";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { PathsToVictory } from "../../types/PathsToVictory";
+import { PlayerAnalysis } from "../../types/PlayerAnalysis";
 import { RakMadnessScores } from "../../types/RakMadnessScores";
 import getClasses from "../../utils/getClasses";
-import getPathsToVictory from "../../utils/scoring/getPathsToVictory";
+import getPlayerAnalysis from "../../utils/scoring/getPlayerAnalysis";
 import Button from "../button/Button";
 import { CloseRoundedIcon, SkullIcon, UnfoldMoreIcon } from "../icon/Icon";
-import VictorySummary, { Standing } from "./VictorySummary";
-import "./PathToVictoryDialog.scss";
+import AnalysisSummary, { Standing } from "./AnalysisSummary";
+import "./PlayerAnalysisDialog.scss";
 
 export type PlayerOption = { name: string; isKnockedOut: boolean };
 
@@ -45,7 +45,7 @@ export function playersMatching(
  * are the one Base UI dialog, told apart in the stylesheet, because that is where
  * the rest of the app draws the same line.
  */
-export default function PathToVictoryDialog({
+export default function PlayerAnalysisDialog({
   open,
   onOpenChange,
   scores,
@@ -59,7 +59,7 @@ export default function PathToVictoryDialog({
   const [found, setFound] = useState<{
     scores: RakMadnessScores;
     name: string;
-    paths?: PathsToVictory;
+    paths?: PlayerAnalysis;
   }>();
 
   // Held still between renders, since the combobox reads the chosen player back
@@ -77,7 +77,7 @@ export default function PathToVictoryDialog({
         setFound({
           scores,
           name: player.name,
-          paths: getPathsToVictory(scores, player.name),
+          paths: getPlayerAnalysis(scores, player.name),
         }),
       );
     });
@@ -107,11 +107,11 @@ export default function PathToVictoryDialog({
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Backdrop className="path-to-victory__backdrop" />
-        <Dialog.Popup className="path-to-victory__popup">
-          <header className="path-to-victory__header">
-            <Dialog.Title className="path-to-victory__title">
-              Path to Victory
+        <Dialog.Backdrop className="player-analysis__backdrop" />
+        <Dialog.Popup className="player-analysis__popup">
+          <header className="player-analysis__header">
+            <Dialog.Title className="player-analysis__title">
+              Player Analysis
             </Dialog.Title>
             <Button
               ariaLabel="Close"
@@ -141,23 +141,23 @@ export default function PathToVictoryDialog({
             // highlighted saves an arrow key before Enter.
             autoHighlight
           >
-            <div className="path-to-victory__search">
+            <div className="player-analysis__search">
               <Combobox.Input
                 placeholder="Search players..."
                 aria-label="Player"
-                className="path-to-victory__input"
+                className="player-analysis__input"
               />
-              <Combobox.Icon className="path-to-victory__input-icon">
+              <Combobox.Icon className="player-analysis__input-icon">
                 <UnfoldMoreIcon />
               </Combobox.Icon>
             </div>
             <Combobox.Portal>
               <Combobox.Positioner
-                className="path-to-victory__positioner"
+                className="player-analysis__positioner"
                 sideOffset={4}
               >
-                <Combobox.Popup className="path-to-victory__list">
-                  <Combobox.Empty className="path-to-victory__empty">
+                <Combobox.Popup className="player-analysis__list">
+                  <Combobox.Empty className="player-analysis__empty">
                     No matching players
                   </Combobox.Empty>
                   <Combobox.List>
@@ -166,7 +166,7 @@ export default function PathToVictoryDialog({
                         key={option.name}
                         value={option}
                         disabled={option.isKnockedOut}
-                        className={`path-to-victory__option ${getClasses({
+                        className={`player-analysis__option ${getClasses({
                           "--knocked-out": option.isKnockedOut,
                         })}`}
                       >
@@ -180,21 +180,21 @@ export default function PathToVictoryDialog({
             </Combobox.Portal>
           </Combobox.Root>
 
-          <div className="path-to-victory__body" ref={body}>
-            <div className="path-to-victory__content" ref={measure}>
+          <div className="player-analysis__body" ref={body}>
+            <div className="player-analysis__content" ref={measure}>
               <Standing scores={scores} player={player?.name} />
               {isSearching ? (
                 <div
-                  className="path-to-victory__searching"
+                  className="player-analysis__searching"
                   role="status"
                   aria-label="Working out the paths"
                 >
-                  <span className="path-to-victory__spinner" />
+                  <span className="player-analysis__spinner" />
                 </div>
               ) : (
                 // Keyed on the player, so the answer to a new one plays in rather
                 // than replacing the last one in place.
-                <VictorySummary key={player?.name} result={result} />
+                <AnalysisSummary key={player?.name} result={result} />
               )}
             </div>
           </div>

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -92,9 +92,11 @@ export default function PlayerAnalysisDialog({
     };
   }, [scores, player]);
 
-  const isCurrent = found?.scores === scores && found?.name === player?.name;
-  const isSearching = player != null && !isCurrent;
-  const result = isCurrent ? found?.paths : undefined;
+  // The answer already on screen stays there while the next one is worked out, so
+  // moving between players reads as one answer replacing another rather than as the
+  // dialog emptying and filling again. Only a rescore takes it away.
+  const shown = found?.scores === scores ? found : undefined;
+  const isSearching = player != null && shown?.name !== player.name;
 
   const body = useRef<HTMLDivElement>(null);
   // The dialog grows to what the answer measures rather than jumping to it. Only
@@ -187,21 +189,18 @@ export default function PlayerAnalysisDialog({
           </Combobox.Root>
 
           <div className="player-analysis__body" ref={body}>
+            {isSearching && (
+              <span
+                className="player-analysis__progress"
+                role="status"
+                aria-label="Working out the paths"
+              />
+            )}
             <div className="player-analysis__content" ref={measure}>
-              <Standing scores={scores} player={player?.name} />
-              {isSearching ? (
-                <div
-                  className="player-analysis__searching"
-                  role="status"
-                  aria-label="Working out the paths"
-                >
-                  <span className="player-analysis__spinner" />
-                </div>
-              ) : (
-                // Keyed on the player, so the answer to a new one plays in rather
-                // than replacing the last one in place.
-                <AnalysisSummary key={player?.name} result={result} />
-              )}
+              <Standing scores={scores} player={shown?.name} />
+              {/* Keyed on the player, so the answer to a new one plays in rather
+                  than replacing the last one in place. */}
+              <AnalysisSummary key={shown?.name} result={shown?.paths} />
             </div>
           </div>
         </Dialog.Popup>

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -6,7 +6,8 @@ import { RakMadnessScores } from "../../types/RakMadnessScores";
 import getClasses from "../../utils/getClasses";
 import getPlayerAnalysis from "../../utils/scoring/getPlayerAnalysis";
 import Button from "../button/Button";
-import { CloseRoundedIcon, SkullIcon, UnfoldMoreIcon } from "../icon/Icon";
+import { CloseRoundedIcon, UnfoldMoreIcon } from "../icon/Icon";
+import PlayerStatusIcon from "../table/playerName/PlayerStatusIcon";
 import AnalysisSummary, { Standing } from "./AnalysisSummary";
 import "./PlayerAnalysisDialog.scss";
 
@@ -21,25 +22,18 @@ export function playerOptions(scores?: RakMadnessScores): Array<PlayerOption> {
   );
 }
 
-/**
- * The players a query offers. A knocked out one is named only where the letters
- * typed reach nobody still standing, since their only answer is "no".
- */
+/** The players a query offers, in the order the tables rank them. */
 export function playersMatching(
   options: Array<PlayerOption>,
   query: string,
 ): Array<PlayerOption> {
   const needle = query.trim().toLowerCase();
-  const matches = options.filter((option) =>
-    option.name.toLowerCase().includes(needle),
-  );
-  const standing = matches.filter((option) => !option.isKnockedOut);
-  if (needle.length === 0 || standing.length > 0) return standing;
-  return matches;
+  return options.filter((option) => option.name.toLowerCase().includes(needle));
 }
 
 /**
- * What a player still has to do to win the week on screen.
+ * Where a player stands in the week on screen, and what they still have to do to
+ * win it.
  *
  * A centered modal by default and a sheet up from the bottom edge on a phone. Both
  * are the one Base UI dialog, told apart in the stylesheet, because that is where
@@ -48,10 +42,13 @@ export function playersMatching(
 export default function PlayerAnalysisDialog({
   open,
   onOpenChange,
+  player: named,
   scores,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Set where the dialog was opened on one player, by clicking their name. */
+  player?: string;
   scores?: RakMadnessScores;
 }) {
   const [player, setPlayer] = useState<PlayerOption>();
@@ -65,7 +62,15 @@ export default function PlayerAnalysisDialog({
   // Held still between renders, since the combobox reads the chosen player back
   // off this list by identity.
   const options = useMemo(() => playerOptions(scores), [scores]);
-  const standing = useMemo(() => playersMatching(options, ""), [options]);
+
+  // A name arriving from outside stands in for a choice made in the search. Taken
+  // during the render that brings it, so the answer is worked out in the same pass
+  // rather than a beat behind it.
+  const [lastNamed, setLastNamed] = useState(named);
+  if (named !== lastNamed) {
+    setLastNamed(named);
+    setPlayer(options.find((option) => option.name === named));
+  }
 
   // The search is thousands of scenarios and holds the thread while it runs, so
   // it waits for the spinner beside it to paint first.
@@ -124,15 +129,15 @@ export default function PlayerAnalysisDialog({
           </header>
 
           <Combobox.Root
-            // Only the players still standing, since the combobox falls back to
-            // this list whole once a name has been chosen, rather than to the
-            // filtered one below.
-            items={standing}
+            // Remounted on a name arriving from outside, which is what puts that
+            // name in the input. The combobox keeps the choice itself, and handing
+            // it a value it started without reads as a controlled input arriving
+            // late, so a fresh one starts on the right player instead.
+            key={named ?? ""}
+            defaultValue={player}
+            items={options}
             filteredItems={playersMatching(options, query)}
             itemToStringLabel={(option: PlayerOption) => option.name}
-            // The combobox keeps the choice itself. Naming it here as well would
-            // hand it a value it started without, which it reads as a controlled
-            // input arriving late.
             onValueChange={(chosen: PlayerOption | null) =>
               setPlayer(chosen ?? undefined)
             }
@@ -165,13 +170,14 @@ export default function PlayerAnalysisDialog({
                       <Combobox.Item
                         key={option.name}
                         value={option}
-                        disabled={option.isKnockedOut}
                         className={`player-analysis__option ${getClasses({
                           "--knocked-out": option.isKnockedOut,
                         })}`}
                       >
-                        {option.name}
-                        {option.isKnockedOut && <SkullIcon />}
+                        <span className="player-analysis__option-name">
+                          {option.name}
+                        </span>
+                        <PlayerStatusIcon isKnockedOut={option.isKnockedOut} />
                       </Combobox.Item>
                     )}
                   </Combobox.List>

--- a/src/components/results/CLAUDE.md
+++ b/src/components/results/CLAUDE.md
@@ -13,7 +13,8 @@ the app has, fed the `scores` `ResultsLayout` passes down. One dialog toggled ra
 than one mounted per opening, because Base UI ties its scroll lock and focus guards
 to a dialog being open.
 
-The navbar opens it on nobody. A player's name opens it on them, through the
-`PlayerAnalysisContextProvider` wrapped around the tables, since they arrive through
-a routed `Outlet` and cannot be handed a callback on the way. The name it was opened
-on is cleared as it closes, so the same name again is a change the dialog can see.
+A player's name is the only way in, through the `PlayerAnalysisContextProvider`
+wrapped around the tables, since they arrive through a routed `Outlet` and cannot be
+handed a callback on the way. So the name held is what says the dialog is open, and
+it is cleared as the dialog closes, which makes the same name again a change the
+dialog can see.

--- a/src/components/results/CLAUDE.md
+++ b/src/components/results/CLAUDE.md
@@ -9,6 +9,11 @@ throttle. `ScoreboardRoute` and `PicksRoute` each render one table from context.
 `CurrentWeekRedirect` render into, and `ResultsFrame.scss` colors the scores area
 so the gap below it reads as part of the table. It reads `useIsWeekDecided` to
 pass `ScoresNavbar` its `isWeekLive` prop, and holds the one `PlayerAnalysisDialog`
-the app has, opened from that navbar and fed the `scores` `ResultsLayout` passes
-down. One dialog toggled rather than one mounted per opening, because Base UI ties
-its scroll lock and focus guards to a dialog being open.
+the app has, fed the `scores` `ResultsLayout` passes down. One dialog toggled rather
+than one mounted per opening, because Base UI ties its scroll lock and focus guards
+to a dialog being open.
+
+The navbar opens it on nobody. A player's name opens it on them, through the
+`PlayerAnalysisContextProvider` wrapped around the tables, since they arrive through
+a routed `Outlet` and cannot be handed a callback on the way. The name it was opened
+on is cleared as it closes, so the same name again is a change the dialog can see.

--- a/src/components/results/CLAUDE.md
+++ b/src/components/results/CLAUDE.md
@@ -8,7 +8,7 @@ throttle. `ScoreboardRoute` and `PicksRoute` each render one table from context.
 `ResultsFrame` is the page and wireframe both `ResultsLayout` and
 `CurrentWeekRedirect` render into, and `ResultsFrame.scss` colors the scores area
 so the gap below it reads as part of the table. It reads `useIsWeekDecided` to
-pass `ScoresNavbar` its `isWeekLive` prop, and holds the one `PathToVictoryDialog`
+pass `ScoresNavbar` its `isWeekLive` prop, and holds the one `PlayerAnalysisDialog`
 the app has, opened from that navbar and fed the `scores` `ResultsLayout` passes
 down. One dialog toggled rather than one mounted per opening, because Base UI ties
 its scroll lock and focus guards to a dialog being open.

--- a/src/components/results/ResultsFrame.tsx
+++ b/src/components/results/ResultsFrame.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useCallback, useState } from "react";
+import { PropsWithChildren, useState } from "react";
 import { useNavigate } from "react-router";
 import { useIsWeekDecided } from "../../context/AppDataContext";
 import { PlayerAnalysisContextProvider } from "../../context/PlayerAnalysisContext";
@@ -43,13 +43,8 @@ export default function ResultsFrame({
   // Once every game is final there is nothing left to fetch, so the refresh button
   // and the divider beside it go rather than sit there doing nothing.
   const isWeekDecided = useIsWeekDecided();
-  const [isAnalysisOpen, setAnalysisOpen] = useState(false);
+  // A name is the only way in, so the dialog is open exactly while one is held.
   const [analysisPlayer, setAnalysisPlayer] = useState<string>();
-
-  const showPlayerAnalysis = useCallback((playerName: string) => {
-    setAnalysisPlayer(playerName);
-    setAnalysisOpen(true);
-  }, []);
 
   return (
     <PageLayout
@@ -73,16 +68,15 @@ export default function ResultsFrame({
       }
     >
       <div className={`home__scores ${getClasses({ "--loading": !isReady })}`}>
-        <PlayerAnalysisContextProvider showPlayerAnalysis={showPlayerAnalysis}>
+        <PlayerAnalysisContextProvider showPlayerAnalysis={setAnalysisPlayer}>
           {isReady ? children : <SkeletonTable view={view} />}
         </PlayerAnalysisContextProvider>
       </div>
       <PlayerAnalysisDialog
-        open={isAnalysisOpen}
+        open={analysisPlayer != null}
         // Cleared on the way out, so naming the same player again is a change the
         // dialog can see.
         onOpenChange={(open) => {
-          setAnalysisOpen(open);
           if (!open) setAnalysisPlayer(undefined);
         }}
         player={analysisPlayer}

--- a/src/components/results/ResultsFrame.tsx
+++ b/src/components/results/ResultsFrame.tsx
@@ -40,10 +40,8 @@ export default function ResultsFrame({
   scores?: RakMadnessScores;
 }>) {
   const navigate = useNavigate();
-  // Once every game is final there is nothing left to fetch, and the analysis of
-  // every player is settled, so the refresh and analysis buttons and the divider
-  // beside them go rather than sit there doing nothing. A player's name still
-  // opens the analysis, which then reads as the week's result.
+  // Once every game is final there is nothing left to fetch, so the refresh button
+  // and the divider beside it go rather than sit there doing nothing.
   const isWeekDecided = useIsWeekDecided();
   const [isAnalysisOpen, setAnalysisOpen] = useState(false);
   const [analysisPlayer, setAnalysisPlayer] = useState<string>();
@@ -70,10 +68,6 @@ export default function ResultsFrame({
           isWeekLive={!isWeekDecided}
           onViewChange={onViewChange}
           onRefresh={onRefresh}
-          onShowAnalysis={() => {
-            setAnalysisPlayer(undefined);
-            setAnalysisOpen(true);
-          }}
           isRefreshing={isRefreshing}
         />
       }

--- a/src/components/results/ResultsFrame.tsx
+++ b/src/components/results/ResultsFrame.tsx
@@ -6,7 +6,7 @@ import getClasses from "../../utils/getClasses";
 import LogoButton from "../navbar/LogoButton/LogoButton";
 import ScoresNavbar, { ScoresView } from "../navbar/ScoresNavbar";
 import PageLayout from "../PageLayout";
-import PathToVictoryDialog from "../pathToVictory/PathToVictoryDialog";
+import PlayerAnalysisDialog from "../playerAnalysis/PlayerAnalysisDialog";
 import SkeletonTable from "../table/SkeletonTable";
 import "./ResultsFrame.scss";
 
@@ -43,7 +43,7 @@ export default function ResultsFrame({
   // to victory left, so the refresh and path buttons and the divider beside them
   // go rather than sit there doing nothing.
   const isWeekDecided = useIsWeekDecided();
-  const [isPathsOpen, setPathsOpen] = useState(false);
+  const [isAnalysisOpen, setAnalysisOpen] = useState(false);
 
   return (
     <PageLayout
@@ -62,7 +62,7 @@ export default function ResultsFrame({
           isWeekLive={!isWeekDecided}
           onViewChange={onViewChange}
           onRefresh={onRefresh}
-          onShowPaths={() => setPathsOpen(true)}
+          onShowAnalysis={() => setAnalysisOpen(true)}
           isRefreshing={isRefreshing}
         />
       }
@@ -70,9 +70,9 @@ export default function ResultsFrame({
       <div className={`home__scores ${getClasses({ "--loading": !isReady })}`}>
         {isReady ? children : <SkeletonTable view={view} />}
       </div>
-      <PathToVictoryDialog
-        open={isPathsOpen}
-        onOpenChange={setPathsOpen}
+      <PlayerAnalysisDialog
+        open={isAnalysisOpen}
+        onOpenChange={setAnalysisOpen}
         scores={scores}
       />
     </PageLayout>

--- a/src/components/results/ResultsFrame.tsx
+++ b/src/components/results/ResultsFrame.tsx
@@ -1,6 +1,7 @@
-import { PropsWithChildren, useState } from "react";
+import { PropsWithChildren, useCallback, useState } from "react";
 import { useNavigate } from "react-router";
 import { useIsWeekDecided } from "../../context/AppDataContext";
+import { PlayerAnalysisContextProvider } from "../../context/PlayerAnalysisContext";
 import { RakMadnessScores } from "../../types/RakMadnessScores";
 import getClasses from "../../utils/getClasses";
 import LogoButton from "../navbar/LogoButton/LogoButton";
@@ -35,15 +36,22 @@ export default function ResultsFrame({
   onViewChange?: (view: ScoresView) => void;
   onRefresh?: () => void;
   isRefreshing?: boolean;
-  /** What the path to victory is worked out from. Absent while a week loads. */
+  /** What the player analysis is worked out from. Absent while a week loads. */
   scores?: RakMadnessScores;
 }>) {
   const navigate = useNavigate();
-  // Once every game is final there is nothing left to fetch and nobody has a path
-  // to victory left, so the refresh and path buttons and the divider beside them
-  // go rather than sit there doing nothing.
+  // Once every game is final there is nothing left to fetch, and the analysis of
+  // every player is settled, so the refresh and analysis buttons and the divider
+  // beside them go rather than sit there doing nothing. A player's name still
+  // opens the analysis, which then reads as the week's result.
   const isWeekDecided = useIsWeekDecided();
   const [isAnalysisOpen, setAnalysisOpen] = useState(false);
+  const [analysisPlayer, setAnalysisPlayer] = useState<string>();
+
+  const showPlayerAnalysis = useCallback((playerName: string) => {
+    setAnalysisPlayer(playerName);
+    setAnalysisOpen(true);
+  }, []);
 
   return (
     <PageLayout
@@ -62,17 +70,28 @@ export default function ResultsFrame({
           isWeekLive={!isWeekDecided}
           onViewChange={onViewChange}
           onRefresh={onRefresh}
-          onShowAnalysis={() => setAnalysisOpen(true)}
+          onShowAnalysis={() => {
+            setAnalysisPlayer(undefined);
+            setAnalysisOpen(true);
+          }}
           isRefreshing={isRefreshing}
         />
       }
     >
       <div className={`home__scores ${getClasses({ "--loading": !isReady })}`}>
-        {isReady ? children : <SkeletonTable view={view} />}
+        <PlayerAnalysisContextProvider showPlayerAnalysis={showPlayerAnalysis}>
+          {isReady ? children : <SkeletonTable view={view} />}
+        </PlayerAnalysisContextProvider>
       </div>
       <PlayerAnalysisDialog
         open={isAnalysisOpen}
-        onOpenChange={setAnalysisOpen}
+        // Cleared on the way out, so naming the same player again is a change the
+        // dialog can see.
+        onOpenChange={(open) => {
+          setAnalysisOpen(open);
+          if (!open) setAnalysisPlayer(undefined);
+        }}
+        player={analysisPlayer}
         scores={scores}
       />
     </PageLayout>

--- a/src/components/table/CLAUDE.md
+++ b/src/components/table/CLAUDE.md
@@ -7,9 +7,10 @@ row tall in the header's color, plus `env(safe-area-inset-bottom)` where the dev
 reports one, publishes `--rak-table-row-height` for `useFillerRows` to measure
 against, and holds the shared `.table` styles (sticky header and player column, the
 touch feedback both clickable cells share, striped rows). Every measurement the
-wireframe has to reproduce is a custom property on `.table`: cell padding, cell
-borders, and the size of the icon beside a player's name. Change one there, not in
-two files.
+wireframe has to reproduce is a custom property on `.table`: cell padding and cell
+borders. Change one there, not in two files. The size of the icon beside a player's
+name is in `src/index.scss` instead, because the player analysis search draws the
+same icon and is nowhere near a table.
 
 An edge that carries no border is `0 solid var(--rak-primary-800)`, never `none`.
 The shorthand resets the color to `currentColor`, and Dark Reader forces a
@@ -29,5 +30,5 @@ reads as a header where a real heading fits on one.
 ## Subdirectories
 
 - [`picks/`](picks/CLAUDE.md) — picks table, per-pick toasts
-- [`playerName/`](playerName/CLAUDE.md) — name cell, knockout icon
+- [`playerName/`](playerName/CLAUDE.md) — name cell, shared status icon
 - [`scores/`](scores/CLAUDE.md) — ranked score table, default view

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -22,10 +22,6 @@
   // `currentColor`: Dark Reader forces a zero-width border visible, and white is
   // what it would then draw between the rank and the player.
   --rak-table-no-border: 0 solid var(--rak-primary-800);
-  // The status icon beside a player's name, in `PlayerName.scss`. Sized here
-  // because the wireframe has to leave the same room without drawing one.
-  --rak-player-icon-size: 16px;
-  --rak-player-icon-gap: 8px;
 
   .table__header {
     z-index: 20;
@@ -109,7 +105,7 @@
       }
 
       &:not(.--knocked-out) {
-        background-color: #9edbfa;
+        background-color: var(--rak-in-contention);
       }
     }
 
@@ -119,7 +115,7 @@
       }
 
       &:not(.--knocked-out) {
-        background-color: #7cbede;
+        background-color: var(--rak-in-contention-dark);
       }
     }
 

--- a/src/components/table/picks/CLAUDE.md
+++ b/src/components/table/picks/CLAUDE.md
@@ -1,4 +1,5 @@
 # picks
 
 `PicksTable`: college/pro pick grid with a per-pick explanation toast on click.
-Renders `PlayerName` per row, headers via `rangeWithPrefix` (C1..., P1...), uses `ToastContext`.
+Renders `PlayerName` per row, whose own click opens the player analysis instead,
+headers via `rangeWithPrefix` (C1..., P1...), uses `ToastContext`.

--- a/src/components/table/picks/PicksTable.test.tsx
+++ b/src/components/table/picks/PicksTable.test.tsx
@@ -8,6 +8,7 @@ import {
   Status,
 } from "../../../types/RakMadnessScores";
 import { Toast, useToastActions } from "../../../context/ToastContext";
+import { PlayerAnalysisContextProvider } from "../../../context/PlayerAnalysisContext";
 import PicksTable from "./PicksTable";
 
 const showToast = vi.fn();
@@ -213,12 +214,16 @@ describe("PlayerName, rendered through the table", () => {
     );
   });
 
-  it("explains a player's status on click", async () => {
+  it("opens the player analysis on click", async () => {
     const user = userEvent.setup();
-    render(<PicksTable scores={scores} />);
+    const showPlayerAnalysis = vi.fn();
+    render(
+      <PlayerAnalysisContextProvider showPlayerAnalysis={showPlayerAnalysis}>
+        <PicksTable scores={scores} />
+      </PlayerAnalysisContextProvider>,
+    );
     await user.click(screen.getByText("Bob"));
-    expect(clearToasts).toHaveBeenCalledTimes(1);
-    expect(showToast.mock.calls[0][0].header).toBe("Bob");
-    expect(showToast.mock.calls[0][0].message).toBe("Bob is out");
+    expect(showPlayerAnalysis).toHaveBeenCalledWith("Bob");
+    expect(showToast).not.toHaveBeenCalled();
   });
 });

--- a/src/components/table/playerName/CLAUDE.md
+++ b/src/components/table/playerName/CLAUDE.md
@@ -8,4 +8,5 @@ monospace font makes exactly `20ch`. So every row is one line tall.
 `PlayerStatusIcon`: that icon on its own (`Skull`, or `EmojiEvents` once the week is
 decided and `SentimentVerySatisfied` before it), sized from `--rak-player-icon-size`.
 The player analysis search names the same players, so it renders this rather than
-choosing an icon of its own.
+choosing an icon of its own. Black on the table's own fills; a caller with no fill
+behind it sets `--rak-player-icon-fill` to say the status in the icon instead.

--- a/src/components/table/playerName/CLAUDE.md
+++ b/src/components/table/playerName/CLAUDE.md
@@ -1,6 +1,11 @@
 # playerName
 
-`PlayerName`: table cell (`<td>`), player name + knocked-out status icon (`Skull`/`SentimentVerySatisfied`).
-Click shows status explanation via `ToastContext`.
+`PlayerName`: table cell (`<td>`), player name + status icon. Click opens the player
+analysis on that player, through `PlayerAnalysisContext`.
 Name never wraps: cut short with an ellipsis past 20 characters, which the cell's
 monospace font makes exactly `20ch`. So every row is one line tall.
+
+`PlayerStatusIcon`: that icon on its own (`Skull`, or `EmojiEvents` once the week is
+decided and `SentimentVerySatisfied` before it), sized from `--rak-player-icon-size`.
+The player analysis search names the same players, so it renders this rather than
+choosing an icon of its own.

--- a/src/components/table/playerName/PlayerName.scss
+++ b/src/components/table/playerName/PlayerName.scss
@@ -3,7 +3,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  // Both from `Table.scss`, so the wireframe can leave the same room for an icon
+  // From `src/index.scss`, so the wireframe can leave the same room for an icon
   // it never draws.
   gap: var(--rak-player-icon-gap);
 

--- a/src/components/table/playerName/PlayerName.scss
+++ b/src/components/table/playerName/PlayerName.scss
@@ -9,24 +9,12 @@
 
   // The cell's font is monospace, so 20ch is exactly 20 characters. A longer name
   // is cut short rather than wrapped, because a wrapped name would make its row
-  // taller than every other row in the table. The whole name is in the toast the
-  // cell opens.
+  // taller than every other row in the table. The whole name is in the player
+  // analysis the cell opens.
   .player-name__name {
     max-width: 20ch;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  .player-name__status-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    > svg {
-      fill: black;
-      width: var(--rak-player-icon-size);
-      height: var(--rak-player-icon-size);
-    }
   }
 }

--- a/src/components/table/playerName/PlayerName.tsx
+++ b/src/components/table/playerName/PlayerName.tsx
@@ -1,26 +1,12 @@
 import { memo } from "react";
 import { PlayerScore } from "../../../types/RakMadnessScores";
 import getClasses from "../../../utils/getClasses";
-import {
-  EmojiEventsIcon,
-  SentimentVerySatisfiedIcon,
-  SkullIcon,
-} from "../../icon/Icon";
-import { useIsWeekDecided } from "../../../context/AppDataContext";
-import { useToastActions, Toast } from "../../../context/ToastContext";
+import { useShowPlayerAnalysis } from "../../../context/PlayerAnalysisContext";
+import PlayerStatusIcon from "./PlayerStatusIcon";
 import "./PlayerName.scss";
 
-/** Still standing at the end of the week, which is what winning the week is. */
-function statusIcon(player: PlayerScore, isWeekDecided: boolean) {
-  if (player.status.isKnockedOut) {
-    return <SkullIcon />;
-  }
-  return isWeekDecided ? <EmojiEventsIcon /> : <SentimentVerySatisfiedIcon />;
-}
-
 function PlayerName({ player }: { player: PlayerScore }) {
-  const { showToast, clearToasts } = useToastActions();
-  const isWeekDecided = useIsWeekDecided();
+  const showPlayerAnalysis = useShowPlayerAnalysis();
 
   return (
     <td
@@ -28,18 +14,11 @@ function PlayerName({ player }: { player: PlayerScore }) {
         "--knocked-out": player.status.isKnockedOut,
       })}`}
       role="button"
-      onClick={() => {
-        clearToasts();
-        showToast(
-          new Toast("neutral", player.name, player.status.explanation ?? ""),
-        );
-      }}
+      onClick={() => showPlayerAnalysis(player.name)}
     >
       <div className="player-name">
         <span className="player-name__name">{player.name}</span>
-        <span className="player-name__status-icon">
-          {statusIcon(player, isWeekDecided)}
-        </span>
+        <PlayerStatusIcon isKnockedOut={player.status.isKnockedOut} />
       </div>
     </td>
   );

--- a/src/components/table/playerName/PlayerStatusIcon.scss
+++ b/src/components/table/playerName/PlayerStatusIcon.scss
@@ -1,0 +1,13 @@
+.player-status-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  > svg {
+    // Black rather than the text color, because every fill it is drawn on is a
+    // light one and the icon carries the same weight as the name beside it.
+    fill: black;
+    width: var(--rak-player-icon-size);
+    height: var(--rak-player-icon-size);
+  }
+}

--- a/src/components/table/playerName/PlayerStatusIcon.scss
+++ b/src/components/table/playerName/PlayerStatusIcon.scss
@@ -4,9 +4,10 @@
   justify-content: center;
 
   > svg {
-    // Black rather than the text color, because every fill it is drawn on is a
-    // light one and the icon carries the same weight as the name beside it.
-    fill: black;
+    // Black on the tables' own fills, where the icon carries the same weight as
+    // the name beside it. Somewhere with no fill behind it to say which status
+    // this is, the caller sets `--rak-player-icon-fill` to say it in the icon.
+    fill: var(--rak-player-icon-fill, black);
     width: var(--rak-player-icon-size);
     height: var(--rak-player-icon-size);
   }

--- a/src/components/table/playerName/PlayerStatusIcon.test.tsx
+++ b/src/components/table/playerName/PlayerStatusIcon.test.tsx
@@ -1,0 +1,36 @@
+import { Mock } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useIsWeekDecided } from "../../../context/AppDataContext";
+import PlayerStatusIcon from "./PlayerStatusIcon";
+
+vi.mock("../../../context/AppDataContext", () => ({
+  useIsWeekDecided: vi.fn(),
+}));
+
+const mockIsWeekDecided = useIsWeekDecided as Mock;
+
+describe("PlayerStatusIcon", () => {
+  it("marks a knocked out player with the skull, week over or not", () => {
+    mockIsWeekDecided.mockReturnValue(false);
+    const { rerender } = render(<PlayerStatusIcon isKnockedOut />);
+    expect(screen.getByTestId("SkullIcon")).toBeInTheDocument();
+
+    mockIsWeekDecided.mockReturnValue(true);
+    rerender(<PlayerStatusIcon isKnockedOut />);
+    expect(screen.getByTestId("SkullIcon")).toBeInTheDocument();
+  });
+
+  it("smiles while the week is still being played", () => {
+    mockIsWeekDecided.mockReturnValue(false);
+    render(<PlayerStatusIcon isKnockedOut={false} />);
+    expect(
+      screen.getByTestId("SentimentVerySatisfiedIcon"),
+    ).toBeInTheDocument();
+  });
+
+  it("crowns whoever is left standing once the week is over", () => {
+    mockIsWeekDecided.mockReturnValue(true);
+    render(<PlayerStatusIcon isKnockedOut={false} />);
+    expect(screen.getByTestId("EmojiEventsIcon")).toBeInTheDocument();
+  });
+});

--- a/src/components/table/playerName/PlayerStatusIcon.tsx
+++ b/src/components/table/playerName/PlayerStatusIcon.tsx
@@ -1,0 +1,28 @@
+import { useIsWeekDecided } from "../../../context/AppDataContext";
+import {
+  EmojiEventsIcon,
+  SentimentVerySatisfiedIcon,
+  SkullIcon,
+} from "../../icon/Icon";
+import "./PlayerStatusIcon.scss";
+
+/**
+ * Where a player stands, in one icon. Shared by the tables' name cells and the
+ * player analysis search, so the same player is marked the same way in both.
+ *
+ * Still standing at the end of the week is what winning the week is.
+ */
+export default function PlayerStatusIcon({
+  isKnockedOut,
+}: {
+  isKnockedOut: boolean;
+}) {
+  const isWeekDecided = useIsWeekDecided();
+
+  function icon() {
+    if (isKnockedOut) return <SkullIcon />;
+    return isWeekDecided ? <EmojiEventsIcon /> : <SentimentVerySatisfiedIcon />;
+  }
+
+  return <span className="player-status-icon">{icon()}</span>;
+}

--- a/src/components/table/playerName/PlayerStatusIcon.tsx
+++ b/src/components/table/playerName/PlayerStatusIcon.tsx
@@ -19,10 +19,15 @@ export default function PlayerStatusIcon({
 }) {
   const isWeekDecided = useIsWeekDecided();
 
-  function icon() {
-    if (isKnockedOut) return <SkullIcon />;
-    return isWeekDecided ? <EmojiEventsIcon /> : <SentimentVerySatisfiedIcon />;
-  }
-
-  return <span className="player-status-icon">{icon()}</span>;
+  return (
+    <span className="player-status-icon">
+      {isKnockedOut ? (
+        <SkullIcon />
+      ) : isWeekDecided ? (
+        <EmojiEventsIcon />
+      ) : (
+        <SentimentVerySatisfiedIcon />
+      )}
+    </span>
+  );
 }

--- a/src/components/table/scores/ScoresTable.test.tsx
+++ b/src/components/table/scores/ScoresTable.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { PlayerScore, RakMadnessScores } from "../../../types/RakMadnessScores";
-import { ToastContextProvider } from "../../../context/ToastContext";
-import Toaster from "../../toaster/Toaster";
+import { PlayerAnalysisContextProvider } from "../../../context/PlayerAnalysisContext";
 import ScoresTable from "./ScoresTable";
+
+const showPlayerAnalysis = vi.fn();
 
 function player(overrides: Partial<PlayerScore> = {}): PlayerScore {
   return {
@@ -30,10 +31,9 @@ const knockedOutBob = player({
 
 function mountTable(scores?: RakMadnessScores) {
   return render(
-    <ToastContextProvider>
+    <PlayerAnalysisContextProvider showPlayerAnalysis={showPlayerAnalysis}>
       <ScoresTable scores={scores} />
-      <Toaster />
-    </ToastContextProvider>,
+    </PlayerAnalysisContextProvider>,
   );
 }
 
@@ -110,11 +110,9 @@ describe("ScoresTable", () => {
     expect(bob.className).toContain("--knocked-out");
   });
 
-  it("explains a player's status when their name is clicked", async () => {
+  it("opens the player analysis when a name is clicked", async () => {
     mountTable(bothPlayers);
     await userEvent.click(screen.getByRole("button", { name: /Bob/ }));
-    expect(
-      screen.getByText("Knocked out on Total Score by Alice."),
-    ).toBeInTheDocument();
+    expect(showPlayerAnalysis).toHaveBeenCalledWith("Bob");
   });
 });

--- a/src/context/CLAUDE.md
+++ b/src/context/CLAUDE.md
@@ -10,3 +10,8 @@ picks, since ESPN calls a season current as soon as the last one ends. Publishes
 every loading flag.
 
 `ToastContext`: splits the toast list from its actions, for the same reason.
+
+`PlayerAnalysisContext`: how a player's name in a table opens the player analysis on
+them. One callback, a no-op with no provider above, so a table still renders on its
+own. `ResultsFrame` provides it; the routed `Outlet` between them is why it is a
+context rather than a prop.

--- a/src/context/PlayerAnalysisContext.tsx
+++ b/src/context/PlayerAnalysisContext.tsx
@@ -1,0 +1,29 @@
+import { createContext, PropsWithChildren, useContext } from "react";
+
+const doNothing = () => undefined;
+
+/**
+ * How anything under the results routes opens the player analysis on one player.
+ *
+ * Its own context rather than a prop threaded down, because the tables reach the
+ * page through a routed `Outlet` and cannot be handed a callback on the way. A
+ * no-op with no provider above, so a table can still be rendered on its own with
+ * scores handed straight to it.
+ */
+const PlayerAnalysisContext =
+  createContext<(playerName: string) => void>(doNothing);
+
+export function PlayerAnalysisContextProvider({
+  showPlayerAnalysis,
+  children,
+}: PropsWithChildren<{ showPlayerAnalysis: (playerName: string) => void }>) {
+  return (
+    <PlayerAnalysisContext.Provider value={showPlayerAnalysis}>
+      {children}
+    </PlayerAnalysisContext.Provider>
+  );
+}
+
+export function useShowPlayerAnalysis(): (playerName: string) => void {
+  return useContext(PlayerAnalysisContext);
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -37,12 +37,10 @@
   --rak-danger-600: #a51818;
   --rak-danger-700: #7d1212;
   --rak-warning-500: #9a5b13;
-  // The trophy button's accent. Its own hue rather than a step on any scale above,
-  // so the one affordance that is neither a view switch nor a result reads as
-  // neither. Light enough that text on it is `--rak-primary-800`, not
-  // `--rak-on-solid`.
+  // The player analysis routes' accent, on the line each one carries and on the
+  // button that unfolds the rest. Its own hue rather than a step on any scale
+  // above, so a way to win the week reads as neither a warning nor a result.
   --rak-gold-500: #d9a02b;
-  --rak-gold-600: #bd8a20;
   --rak-gold-700: #9a7018;
 
   // Soft fills, used by the toasts.

--- a/src/index.scss
+++ b/src/index.scss
@@ -75,12 +75,17 @@
   --rak-pick-no-dark: #de7c7c;
   --rak-pick-error: #edfaa0;
   --rak-pick-error-dark: #cfde7c;
-  // A player who can no longer win, wherever they are named. The -dark value
-  // stripes the even rows of the tables. The -text value is the same hue taken
-  // far enough down to read on white, which the fill itself cannot.
+  // A player, wherever they are named: the tables' name cells and the player
+  // analysis search both fill from these. The -dark value stripes the even rows
+  // of the tables, and marks the entry the search is pointing at.
   --rak-knocked-out: #fac99e;
   --rak-knocked-out-dark: #deaa7c;
-  --rak-knocked-out-text: #8a4a12;
+  --rak-in-contention: #9edbfa;
+  --rak-in-contention-dark: #7cbede;
+  // The status icon beside a player's name, drawn the same size wherever the
+  // name is. The wireframe leaves this much room without drawing one.
+  --rak-player-icon-size: 16px;
+  --rak-player-icon-gap: 8px;
 
   --rak-disabled-bg: #f0f4f8;
   --rak-disabled-text: #9fa6ad;

--- a/src/index.scss
+++ b/src/index.scss
@@ -75,13 +75,16 @@
   --rak-pick-no-dark: #de7c7c;
   --rak-pick-error: #edfaa0;
   --rak-pick-error-dark: #cfde7c;
-  // A player, wherever they are named: the tables' name cells and the player
-  // analysis search both fill from these. The -dark value stripes the even rows
-  // of the tables, and marks the entry the search is pointing at.
+  // A player, by whether they can still win. The tables fill a name cell with
+  // these, and the -dark value stripes their even rows. The -text value is the
+  // same hue taken far enough down to read on white, which the fill itself
+  // cannot: it is what the player analysis search draws a status icon in.
   --rak-knocked-out: #fac99e;
   --rak-knocked-out-dark: #deaa7c;
+  --rak-knocked-out-text: #8a4a12;
   --rak-in-contention: #9edbfa;
   --rak-in-contention-dark: #7cbede;
+  --rak-in-contention-text: #126287;
   // The status icon beside a player's name, drawn the same size wherever the
   // name is. The wireframe leaves this much room without drawing one.
   --rak-player-icon-size: 16px;

--- a/src/styles/CLAUDE.md
+++ b/src/styles/CLAUDE.md
@@ -5,6 +5,6 @@ Sass partials, no CSS of their own. `_breakpoints.scss` holds three mixins,
 room for the navbar to label its buttons), and `compact-screen` (too little room to
 center a dialog, so it rises from the bottom edge as a sheet), which have to be Sass
 because custom properties do not work inside a media query. `_listbox.scss` holds
-`listbox-popup` and `listbox-item`, the shape the home page selects and the path to
-victory combobox both give a Base UI popup list. Design tokens live in
+`listbox-popup` and `listbox-item`, the shape the home page selects and the player
+analysis combobox both give a Base UI popup list. Design tokens live in
 `src/index.scss` instead.

--- a/src/styles/_listbox.scss
+++ b/src/styles/_listbox.scss
@@ -1,5 +1,5 @@
 // The shape every Base UI popup list in the app shares: the season and week
-// selects on the home page, and the player combobox in the path to victory
+// selects on the home page, and the player combobox in the player analysis
 // dialog. Mixins only, so this emits no CSS of its own however many files pull it
 // in. Each caller adds what makes its own list different.
 

--- a/src/types/CLAUDE.md
+++ b/src/types/CLAUDE.md
@@ -1,3 +1,3 @@
 # src/types
 
-ESPN scoreboard shapes (EspnEvent, EspnCompetitor, GameStatus); League/SeasonType/WeekInfo/LeagueInfo; LeagueResult/Possession; GameScore pick-scoring result; RakMadnessScores/PlayerScore/PickResult/Status; PathsToVictory, a union over eliminated, clinched, headline, and paths, so a summary cannot render a field that was never worked out.
+ESPN scoreboard shapes (EspnEvent, EspnCompetitor, GameStatus); League/SeasonType/WeekInfo/LeagueInfo; LeagueResult/Possession; GameScore pick-scoring result; RakMadnessScores/PlayerScore/PickResult/Status; PlayerAnalysis, a union over eliminated, clinched, headline, and paths, so a summary cannot render a field that was never worked out.

--- a/src/types/PlayerAnalysis.ts
+++ b/src/types/PlayerAnalysis.ts
@@ -47,7 +47,7 @@ export type VictoryRoute = {
  * `applyKnockouts` leaves a genuine tie standing and calls both players the winner,
  * and this follows it.
  */
-export type PathsToVictory =
+export type PlayerAnalysis =
   /** `explanation` is the reason `applyKnockouts` already wrote. */
   | { kind: "eliminated"; player: string; explanation?: string }
   /** No result left can take the week off them. */

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -32,5 +32,5 @@ sequences. `getPlayerAnalysis` is a second entry point, reading those results ba
   walks every way the contested ones can fall, and reduces the winning ones to the
   games that must go right, the pool the rest come from, and the Monday night totals
   that settle a dead heat on points. Where they do not reduce to a pool it lists the
-  ten routes asking least of the player and counts the rest. Above ten games it gives
+  eight routes asking least of the player and counts the rest. Above ten games it gives
   a floor from a closed form instead, since the search doubles per game

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -24,10 +24,13 @@ sequences. `getPlayerAnalysis` is a second entry point, reading those results ba
   so one row alone would drop a game that row's player skipped. Both halves of the
   question below read it
 - `applyKnockouts`: who can still win, and why not
-- `getPlayerAnalysis`: the other half of `applyKnockouts`, for a player still
-  standing, once ten or fewer games are left. Walks every way the contested ones
-  can fall, and reduces the winning ones to the games that must go right, the pool
-  the rest come from, and the Monday night totals that settle a dead heat on
-  points. Where they do not reduce to a pool it lists the ten routes asking least
-  of the player and counts the rest. Above ten games it gives a floor from a closed
-  form instead, since the search doubles per game
+- `getPlayerAnalysis`: the other half of `applyKnockouts`, for any player named. One
+  already knocked out reads back the reason they carry, and a decided week is
+  answered from `isWeekDecided` rather than searched, since the knockouts have
+  already settled it and the search reads the lower tiers in an order of its own.
+  For a player still standing in a live week, once ten or fewer games are left, it
+  walks every way the contested ones can fall, and reduces the winning ones to the
+  games that must go right, the pool the rest come from, and the Monday night totals
+  that settle a dead heat on points. Where they do not reduce to a pool it lists the
+  ten routes asking least of the player and counts the rest. Above ten games it gives
+  a floor from a closed form instead, since the search doubles per game

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -2,7 +2,7 @@
 
 The picks-to-scoreboard pipeline, one concern per file. `getPlayerScores` is the only
 entry point the app calls for a week's results; everything else is a step it
-sequences. `getPathsToVictory` is a second entry point, reading those results back.
+sequences. `getPlayerAnalysis` is a second entry point, reading those results back.
 
 - `parsePicksWorkbook`: xlsx buffer to rows, column keys, and per-game matchups.
   Async because it imports `xlsx-js-style` on demand, which is over half the bundle.
@@ -24,7 +24,7 @@ sequences. `getPathsToVictory` is a second entry point, reading those results ba
   so one row alone would drop a game that row's player skipped. Both halves of the
   question below read it
 - `applyKnockouts`: who can still win, and why not
-- `getPathsToVictory`: the other half of `applyKnockouts`, for a player still
+- `getPlayerAnalysis`: the other half of `applyKnockouts`, for a player still
   standing, once ten or fewer games are left. Walks every way the contested ones
   can fall, and reduces the winning ones to the games that must go right, the pool
   the rest come from, and the Monday night totals that settle a dead heat on

--- a/src/utils/scoring/getPlayerAnalysis.test.ts
+++ b/src/utils/scoring/getPlayerAnalysis.test.ts
@@ -1,11 +1,11 @@
-import { PathsToVictory } from "../../types/PathsToVictory";
+import { PlayerAnalysis } from "../../types/PlayerAnalysis";
 import {
   PickResult,
   PlayerScore,
   RakMadnessScores,
   Status,
 } from "../../types/RakMadnessScores";
-import getPathsToVictory from "./getPathsToVictory";
+import getPlayerAnalysis from "./getPlayerAnalysis";
 
 /** A game still to be played unless a status says otherwise. */
 function pick(text: string, status: Status = "incomplete"): PickResult {
@@ -58,20 +58,20 @@ function week(
 }
 
 /** Narrows to the routes result, so a case can read the fields it is about. */
-function paths(result: PathsToVictory | undefined) {
+function paths(result: PlayerAnalysis | undefined) {
   expect(result?.kind).toBe("paths");
-  return result as Extract<PathsToVictory, { kind: "paths" }>;
+  return result as Extract<PlayerAnalysis, { kind: "paths" }>;
 }
 
 function labels(games: Array<{ label: string }>): Array<string> {
   return games.map((game) => game.label);
 }
 
-describe("getPathsToVictory, whether there is anything to work out", () => {
+describe("getPlayerAnalysis, whether there is anything to work out", () => {
   it("has no answer for a name the sheet does not hold", () => {
     const scores = week([player({ name: "Alice" })]);
 
-    expect(getPathsToVictory(scores, "Nobody")).toBeUndefined();
+    expect(getPlayerAnalysis(scores, "Nobody")).toBeUndefined();
   });
 
   it("gives a knocked out player the reason they already carry", () => {
@@ -86,7 +86,7 @@ describe("getPathsToVictory, whether there is anything to work out", () => {
     scores.scores[1].status.explanation =
       "Knocked out on Total Score by Alice.";
 
-    expect(getPathsToVictory(scores, "Bob")).toEqual({
+    expect(getPlayerAnalysis(scores, "Bob")).toEqual({
       kind: "eliminated",
       player: "Bob",
       explanation: "Knocked out on Total Score by Alice.",
@@ -101,7 +101,7 @@ describe("getPathsToVictory, whether there is anything to work out", () => {
       player({ name: "Bob", total: 3, pro: [pick("KC -3")] }),
     ]);
 
-    expect(getPathsToVictory(scores, "Alice")).toEqual({
+    expect(getPlayerAnalysis(scores, "Alice")).toEqual({
       kind: "clinched",
       player: "Alice",
     });
@@ -118,21 +118,21 @@ describe("getPathsToVictory, whether there is anything to work out", () => {
       }),
     ]);
 
-    expect(getPathsToVictory(scores, "Alice")).toEqual({
+    expect(getPlayerAnalysis(scores, "Alice")).toEqual({
       kind: "clinched",
       player: "Alice",
     });
   });
 });
 
-describe("getPathsToVictory, the routes", () => {
+describe("getPlayerAnalysis, the routes", () => {
   it("names the one game a player has to win", () => {
     const scores = week([
       player({ name: "Alice", total: 3, pro: [pick("KC -3")] }),
       player({ name: "Bob", total: 3, pro: [pick("DEN +3")] }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
+    const result = paths(getPlayerAnalysis(scores, "Alice"));
     expect(result.mustWin).toEqual([{ label: "P1", pick: "KC -3" }]);
     expect(result.pool).toBeUndefined();
     expect(result.routes).toBeUndefined();
@@ -150,7 +150,7 @@ describe("getPathsToVictory, the routes", () => {
       player({ name: "Bob", total: 2, pro: bob.map((it) => pick(it)) }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
+    const result = paths(getPlayerAnalysis(scores, "Alice"));
     expect(result.mustWin).toEqual([]);
     expect(result.pool?.choose).toBe(2);
     expect(labels(result.pool?.games ?? [])).toEqual(["P1", "P2", "P3", "P4"]);
@@ -178,7 +178,7 @@ describe("getPathsToVictory, the routes", () => {
       }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
+    const result = paths(getPlayerAnalysis(scores, "Alice"));
     expect(result.mustWin).toEqual([{ label: "P1", pick: "KC -3" }]);
     expect(result.pool?.choose).toBe(1);
     expect(labels(result.pool?.games ?? [])).toEqual(["P2", "P3"]);
@@ -200,7 +200,7 @@ describe("getPathsToVictory, the routes", () => {
       }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
+    const result = paths(getPlayerAnalysis(scores, "Alice"));
     expect(result.mustWin).toEqual([]);
     expect(result.pool).toBeUndefined();
     expect(result.routes?.map((route) => labels(route.games))).toEqual([
@@ -211,7 +211,7 @@ describe("getPathsToVictory, the routes", () => {
   });
 });
 
-describe("getPathsToVictory, the Monday night tiebreaker", () => {
+describe("getPlayerAnalysis, the Monday night tiebreaker", () => {
   it("bounds the totals that win from above when the player guessed lower", () => {
     // Level on points with nothing left to separate them but the guess. Alice is
     // closer than Bob on every total under the midpoint of 45.5.
@@ -230,7 +230,7 @@ describe("getPathsToVictory, the Monday night tiebreaker", () => {
       }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
+    const result = paths(getPlayerAnalysis(scores, "Alice"));
     expect(result.mustWin).toEqual([]);
     expect(result.mondayNight).toEqual({
       kind: "range",
@@ -257,7 +257,7 @@ describe("getPathsToVictory, the Monday night tiebreaker", () => {
       }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
+    const result = paths(getPlayerAnalysis(scores, "Alice"));
     expect(result.mondayNight).toEqual({
       kind: "range",
       min: 46,
@@ -286,7 +286,7 @@ describe("getPathsToVictory, the Monday night tiebreaker", () => {
       }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
+    const result = paths(getPlayerAnalysis(scores, "Alice"));
     expect(result.mondayNight).toEqual({
       kind: "range",
       min: 45,
@@ -315,7 +315,7 @@ describe("getPathsToVictory, the Monday night tiebreaker", () => {
       }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
+    const result = paths(getPlayerAnalysis(scores, "Alice"));
     expect(result.mustWin).toEqual([]);
     expect(result.outrightAt).toBe(1);
     expect(result.mondayNight).toBeUndefined();
@@ -354,7 +354,7 @@ describe("getPathsToVictory, the Monday night tiebreaker", () => {
       }),
     ]);
 
-    expect(getPathsToVictory(scores, "Alice")).toEqual({
+    expect(getPlayerAnalysis(scores, "Alice")).toEqual({
       kind: "clinched",
       player: "Alice",
     });
@@ -383,20 +383,20 @@ describe("getPathsToVictory, the Monday night tiebreaker", () => {
       47,
     );
 
-    const result = paths(getPathsToVictory(scores, "Bob"));
+    const result = paths(getPlayerAnalysis(scores, "Bob"));
     expect(result.mustWin).toEqual([{ label: "C1", pick: "BAMA +7" }]);
     expect(result.mondayNight).toEqual({ kind: "settled" });
   });
 });
 
-describe("getPathsToVictory, games out of the player's hands", () => {
+describe("getPlayerAnalysis, games out of the player's hands", () => {
   it("names the team that has to miss where the player left a game blank", () => {
     const scores = week([
       player({ name: "Alice", total: 3, pro: [pick("")] }),
       player({ name: "Bob", total: 3, pro: [pick("KC -3")] }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
+    const result = paths(getPlayerAnalysis(scores, "Alice"));
     expect(result.mustWin).toEqual([]);
     expect(result.needsHelp).toEqual([{ label: "P1", needsToMiss: ["KC"] }]);
   });
@@ -423,7 +423,7 @@ describe("getPathsToVictory, games out of the player's hands", () => {
       }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
+    const result = paths(getPlayerAnalysis(scores, "Alice"));
     expect(result.mustWin).toEqual([{ label: "P1", pick: "KC -3" }]);
     expect(result.routes).toEqual([
       { games: [], mondayNight: { kind: "notNeeded" } },
@@ -441,14 +441,14 @@ describe("getPathsToVictory, games out of the player's hands", () => {
       player({ name: "Bob", total: 3, pro: [pick("KC -3")] }),
     ]);
 
-    expect(getPathsToVictory(scores, "Alice")).toEqual({
+    expect(getPlayerAnalysis(scores, "Alice")).toEqual({
       kind: "clinched",
       player: "Alice",
     });
   });
 });
 
-describe("getPathsToVictory, weeks too big to search", () => {
+describe("getPlayerAnalysis, weeks too big to search", () => {
   /** Two sides of one game, on the same spread, so no tiebreaker tier splits them. */
   function opposed(count: number, prefix: string, spread: string) {
     return Array.from({ length: count }, (_, index) =>
@@ -474,7 +474,7 @@ describe("getPathsToVictory, weeks too big to search", () => {
       }),
     ]);
 
-    expect(getPathsToVictory(scores, "Alice")).toEqual({
+    expect(getPlayerAnalysis(scores, "Alice")).toEqual({
       kind: "headline",
       player: "Alice",
       remainingPickCount: 11,
@@ -493,7 +493,7 @@ describe("getPathsToVictory, weeks too big to search", () => {
       player({ name: "Bob", total: 4, pro: opposed(count, "B", "+3") }),
     ]);
 
-    expect(getPathsToVictory(scores, "Alice")).toEqual({
+    expect(getPlayerAnalysis(scores, "Alice")).toEqual({
       kind: "headline",
       player: "Alice",
       remainingPickCount: 11,
@@ -514,7 +514,7 @@ describe("getPathsToVictory, weeks too big to search", () => {
       player({ name: "Bob", total: 1, pro: [...agreed, pick("DEN +3")] }),
     ]);
 
-    expect(getPathsToVictory(scores, "Alice")?.kind).toBe("headline");
+    expect(getPlayerAnalysis(scores, "Alice")?.kind).toBe("headline");
   });
 
   it("works the routes out at ten", () => {
@@ -524,7 +524,7 @@ describe("getPathsToVictory, weeks too big to search", () => {
       player({ name: "Bob", total: 0, pro: opposed(count, "B", "+3") }),
     ]);
 
-    const result = paths(getPathsToVictory(scores, "Alice"));
+    const result = paths(getPlayerAnalysis(scores, "Alice"));
     expect(result.pool?.choose).toBe(5);
     expect(result.pool?.games).toHaveLength(10);
   });

--- a/src/utils/scoring/getPlayerAnalysis.test.ts
+++ b/src/utils/scoring/getPlayerAnalysis.test.ts
@@ -123,6 +123,49 @@ describe("getPlayerAnalysis, whether there is anything to work out", () => {
       player: "Alice",
     });
   });
+
+  it("calls both winners of a decided week clinched", () => {
+    // Level on every tier, which the knockouts leave standing together.
+    const scores = week(
+      [
+        player({ name: "Alice", total: 5, pro: [pick("KC -3", "yes")] }),
+        player({ name: "Bob", total: 5, pro: [pick("KC -3", "yes")] }),
+      ],
+      41,
+    );
+
+    expect(getPlayerAnalysis(scores, "Alice")).toEqual({
+      kind: "clinched",
+      player: "Alice",
+    });
+    expect(getPlayerAnalysis(scores, "Bob")).toEqual({
+      kind: "clinched",
+      player: "Bob",
+    });
+  });
+
+  it("still gives a knocked out player their reason once a week is decided", () => {
+    const scores = week(
+      [
+        player({ name: "Alice", total: 5, pro: [pick("KC -3", "yes")] }),
+        player({
+          name: "Bob",
+          total: 3,
+          pro: [pick("DEN +3", "no")],
+          isKnockedOut: true,
+        }),
+      ],
+      41,
+    );
+    scores.scores[1].status.explanation =
+      "Knocked out on Total Score by Alice.";
+
+    expect(getPlayerAnalysis(scores, "Bob")).toEqual({
+      kind: "eliminated",
+      player: "Bob",
+      explanation: "Knocked out on Total Score by Alice.",
+    });
+  });
 });
 
 describe("getPlayerAnalysis, the routes", () => {

--- a/src/utils/scoring/getPlayerAnalysis.ts
+++ b/src/utils/scoring/getPlayerAnalysis.ts
@@ -7,6 +7,7 @@ import {
 } from "../../types/PlayerAnalysis";
 import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
 import { comparePlayerScoresOnMerit } from "./comparePlayerScores";
+import isWeekDecided from "./isWeekDecided";
 import remainingGames, {
   pickDifference,
   RemainingGame,
@@ -503,10 +504,11 @@ function reduceRoutes(
 }
 
 /**
- * What a player still has to do to win a week that is being played.
+ * Where a player stands in a week, and what they still have to do to win it.
  *
- * Undefined where the sheet holds nobody by that name, which is the only way the
- * question has no answer at all.
+ * Answers for every player, knocked out or not, and for a week already decided as
+ * well as one being played. Undefined where the sheet holds nobody by that name,
+ * which is the only way the question has no answer at all.
  */
 export default function getPlayerAnalysis(
   scores: RakMadnessScores,
@@ -519,6 +521,14 @@ export default function getPlayerAnalysis(
   const player = players[playerIndex];
   if (player.status.isKnockedOut) {
     return eliminated(player);
+  }
+
+  // Nothing is left to play, so the knockouts have already settled the week and
+  // whoever they left standing has won it. Said here rather than searched for,
+  // because the search reads the lower tiers in an order of its own, and on a
+  // week nobody can change it would sometimes disagree with the standings.
+  if (isWeekDecided(scores)) {
+    return { kind: "clinched", player: player.name };
   }
 
   // A knocked out player cannot take the week off anyone, so they are not measured

--- a/src/utils/scoring/getPlayerAnalysis.ts
+++ b/src/utils/scoring/getPlayerAnalysis.ts
@@ -1,10 +1,10 @@
 import {
   MondayNightOutlook,
-  PathsToVictory,
+  PlayerAnalysis,
   RemainingPick,
   UncontrolledGame,
   VictoryRoute,
-} from "../../types/PathsToVictory";
+} from "../../types/PlayerAnalysis";
 import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
 import { comparePlayerScoresOnMerit } from "./comparePlayerScores";
 import remainingGames, {
@@ -297,7 +297,7 @@ function picksIn(
 }
 
 /** Carries the reason `applyKnockouts` already wrote, rather than writing another. */
-function eliminated(player: PlayerScore): PathsToVictory {
+function eliminated(player: PlayerScore): PlayerAnalysis {
   return {
     kind: "eliminated",
     player: player.name,
@@ -342,7 +342,7 @@ function headline(
   playerIndex: number,
   rivals: Array<{ player: PlayerScore; index: number }>,
   games: Array<RemainingGame>,
-): PathsToVictory {
+): PlayerAnalysis {
   const counts = rivals.map((rival) => {
     const gap = rival.player.score.total - player.score.total;
     const at = (clear: boolean) =>
@@ -351,7 +351,7 @@ function headline(
   });
 
   // `toLevel` is only absent where `applyKnockouts` has already knocked the player
-  // out on total score, which `getPathsToVictory` answers before reaching here.
+  // out on total score, which `getPlayerAnalysis` answers before reaching here.
   const minimumWins = Math.max(
     0,
     ...counts.map((count) => count.toLevel).filter((count) => count != null),
@@ -439,7 +439,7 @@ function uncontrolledGames(
 }
 
 type RouteShape = Pick<
-  Extract<PathsToVictory, { kind: "paths" }>,
+  Extract<PlayerAnalysis, { kind: "paths" }>,
   "mustWin" | "pool" | "routes" | "hiddenRouteCount" | "mondayNight"
 >;
 
@@ -508,10 +508,10 @@ function reduceRoutes(
  * Undefined where the sheet holds nobody by that name, which is the only way the
  * question has no answer at all.
  */
-export default function getPathsToVictory(
+export default function getPlayerAnalysis(
   scores: RakMadnessScores,
   playerName: string,
-): PathsToVictory | undefined {
+): PlayerAnalysis | undefined {
   const players = scores.scores;
   const playerIndex = players.findIndex((it) => it.name === playerName);
   if (playerIndex < 0) return undefined;

--- a/src/utils/scoring/getPlayerAnalysis.ts
+++ b/src/utils/scoring/getPlayerAnalysis.ts
@@ -20,7 +20,7 @@ import remainingGames, {
 const MAX_SEARCHED_GAMES = 10;
 
 /** How many routes are carried before the rest are only counted. */
-const MAX_LISTED_ROUTES = 10;
+const MAX_LISTED_ROUTES = 8;
 
 /**
  * Where a player takes a point, as one bit per open game.


### PR DESCRIPTION
## What

Clicking a player's name in either table opens the analysis dialog on that player,
in place of the toast. It is renamed Player Analysis, since it answers for everyone
now, not only for a player who can win.

## Screenshots

| A name click, on a player still in it | The search |
| --- | --- |
| ![Routes](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/player-analysis/shot-routes.png) | ![Search](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/player-analysis/shot-search.png) |

| A player knocked out | The picks view, on a phone |
| --- | --- |
| ![Eliminated](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/player-analysis/shot-eliminated.png) | ![Sheet](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/player-analysis/shot-sheet.png) |

## Changes

- A name is the only way in, so the navbar's trophy button goes, and with it the
  `--gold` button color nothing else used. The name held says the dialog is open,
  and reaches it through `PlayerAnalysisContext`, past the routed `Outlet` between
  them.
- The search offers knocked-out players and lets one be picked. Only the picker was
  in the way: `getPlayerAnalysis` already answered for them.
- `getPlayerAnalysis` returns `clinched` once `isWeekDecided`. Its search reads the
  lower tiers its own way, and would sometimes call a winner eliminated on a week
  the knockouts had settled.
- `PlayerStatusIcon` comes out of `PlayerName`, so the search marks a player the
  way the tables do.
- The answer holds while the next is worked out, under a bar on the rule. A pick is
  monospace, sized to the widest abbreviation and spread.

## Notes / Follow-ups

The screenshots live on the `pr-assets` branch, which holds nothing else.

🕵️ Encoded by [Agent Numbuh 1](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
