### PR TITLE
feat(docs): hold every CLAUDE.md to a 120-word ceiling

### DIFF
--- a/.claude/scripts/lint_claude_md.py
+++ b/.claude/scripts/lint_claude_md.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Plan and check a repository's bottom-up CLAUDE.md navigation tree.
+
+One file on purpose: agentified repos vendor it into `.claude/scripts/` so their
+`make lint-docs` and CI work with nothing installed, and a single file is a single
+thing to re-copy when this one changes.
+
+Subcommands:
+
+  plan       <root>   JSON plan of the tree: every meaningful directory, deepest
+                      first, with its direct files, its meaningful children, and
+                      precomputed markdown link parts. Drives the writing step.
+  structure  <root>   Findings where the tree does not match the plan.
+  dupes      <root>   Findings where a parent link restates its child's summary.
+  length     <root>   Findings where a file's own prose exceeds the word ceiling.
+  check      <root>   structure, dupes, length, all three always run.
+
+`<root>` defaults to ".". Exit 0 = clean, 1 = findings, 2 = could not run.
+
+A directory is "meaningful" (gets its own CLAUDE.md) when it is the repo root,
+directly contains 2+ files, contains a Claude-functionality marker file (a skill
+`SKILL.md` etc., see CLAUDE_MARKER_FILES), or has at least one meaningful
+descendant. The marker rule ensures a skill/hook/plugin directory is always
+indexed even when it holds a single manifest file. This skips near-empty leaf
+folders that would only add noise. Test and build-support directories (gradle
+wrapper etc.) are excluded: only source, script, and documentation directories are
+indexed. Pass-through directories (no direct files of their own, any number of
+children, e.g. `skills/` or a Java/Kotlin package prefix) are collapsed: they get
+no CLAUDE.md and parents link through them.
+
+File scope comes from `git ls-files` when available (respects .gitignore and lists
+only tracked files); otherwise it falls back to os.walk with a skip list.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+# Directory names never traversed, even if not gitignored (e.g. committed deps).
+SKIP_DIRS = {
+    "node_modules", "vendor", "dist", "build", "target", "out",
+    "__pycache__", ".venv", "venv", ".tox", ".mypy_cache", ".pytest_cache",
+    "coverage", ".next", ".nuxt", ".gradle", "bin", "obj",
+}
+
+# Test directories excluded from the tree: index source, scripts, and docs only.
+TEST_DIRS = {
+    "test", "tests", "__tests__", "spec", "specs", "e2e",
+    "testdata", "test-data", "__mocks__", "integration-tests",
+}
+
+# Build-support directories excluded from the tree (wrappers, build tooling).
+SUPPORT_DIRS = {"gradle", "buildSrc", "mvn"}
+
+# Marker files that denote a Claude-functionality directory (skill, plugin,
+# etc.). A directory containing any of these is always meaningful, even with
+# fewer than 2 files, so its CLAUDE.md documents the unit for navigation.
+CLAUDE_MARKER_FILES = {"SKILL.md"}
+
+CLAUDE_MD = "CLAUDE.md"
+
+
+# --- file scope ------------------------------------------------------------
+
+
+def tracked_files(root):
+    """Return repo-relative file paths from git, or None if not a git repo."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", root, "ls-files"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return [line for line in out.splitlines() if line]
+
+
+def excluded(name):
+    """True for a directory the tree never enters."""
+    return (name.startswith(".") or name in SKIP_DIRS
+            or name in TEST_DIRS or name in SUPPORT_DIRS)
+
+
+def in_skipped_path(rel_path):
+    """True if any segment of the path is an excluded directory."""
+    return any(excluded(part) for part in rel_path.split(os.sep))
+
+
+def walk_in_scope(root):
+    """Yield (repo-relative dir, filenames) per in-scope dir, excluded ones pruned."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if not excluded(d)]
+        rel = os.path.relpath(dirpath, root)
+        yield ("" if rel == "." else rel), filenames
+
+
+def plan_files(root):
+    """Files the plan considers: git's list when there is one, minus exclusions."""
+    files = tracked_files(root)
+    if files is None:
+        files = [os.path.join(rel, name) if rel else name
+                 for rel, names in walk_in_scope(root) for name in names]
+    return [f for f in files if not in_skipped_path(f)]
+
+
+def claude_md_dirs(root):
+    """In-scope dirs holding a CLAUDE.md, read from disk so uncommitted ones count."""
+    return [rel for rel, names in walk_in_scope(root) if CLAUDE_MD in names]
+
+
+# --- plan ------------------------------------------------------------------
+
+
+def build(root):
+    """The tree plan: meaningful dirs deepest-first, with files and child links."""
+    # Map each directory -> its direct files (relative names only).
+    direct_files = {}
+    all_dirs = set([""])  # "" is the repo root
+    for f in plan_files(root):
+        base = os.path.basename(f)
+        if base == CLAUDE_MD:
+            continue
+        d = os.path.dirname(f)
+        direct_files.setdefault(d, []).append(base)
+        # Register every ancestor directory.
+        parts = d.split(os.sep) if d else []
+        for i in range(len(parts) + 1):
+            all_dirs.add(os.sep.join(parts[:i]))
+
+    # Immediate children of each directory.
+    children = {d: [] for d in all_dirs}
+    for d in all_dirs:
+        if d == "":
+            continue
+        children[os.path.dirname(d)].append(d)
+
+    def depth(d):
+        return 0 if d == "" else d.count(os.sep) + 1
+
+    # Deepest first; path as a stable tiebreaker so output is deterministic
+    # (all_dirs is a set, whose iteration order varies with hash seeding).
+    ordered = sorted(all_dirs, key=lambda d: (-depth(d), d))
+
+    # Meaningful: 2+ direct files, a marker file, any meaningful descendant, or
+    # the root. Computed bottom-up, so a child's verdict is already known.
+    meaningful = {}
+    for d in ordered:
+        has_files = len(direct_files.get(d, [])) >= 2
+        has_marker = any(f in CLAUDE_MARKER_FILES for f in direct_files.get(d, []))
+        has_meaningful_child = any(meaningful.get(c) for c in children[d])
+        meaningful[d] = d == "" or has_files or has_marker or has_meaningful_child
+
+    # Collapse pass-through dirs: a non-root dir with no direct files gets no
+    # CLAUDE.md of its own, and its parent links straight through to whatever is
+    # below (e.g. src/main/kotlin/com/yahoo -> the real package root).
+    #
+    # Any child count, not just one. A dir with nothing of its own to describe can
+    # only restate its children, which is a hop that costs a file read and adds no
+    # information. `skills/` holding four skill dirs is the case in point.
+    def collapsed(d):
+        return d != "" and not direct_files.get(d)
+
+    def resolve(d):
+        """The dirs a parent should link in place of child d, post-collapse."""
+        if not collapsed(d):
+            return [d]
+        out = []
+        for c in children[d]:
+            if meaningful[c]:
+                out.extend(resolve(c))
+        return out
+
+    result = []
+    for d in ordered:
+        if not meaningful[d] or collapsed(d):
+            continue
+        kids = sorted({k for c in children[d] if meaningful[c] for k in resolve(c)})
+        abs_dir = root if d == "" else os.path.join(root, d)
+        # Precomputed markdown link parts, relative to this dir; collapsed
+        # pass-through chains make these multi-segment (kotlin/com/yahoo/...).
+        child_links = [
+            {
+                "path": c,
+                "text": "%s/" % os.path.relpath(c, d or "."),
+                "href": "%s/%s" % (os.path.relpath(c, d or "."), CLAUDE_MD),
+            }
+            for c in kids
+        ]
+        result.append({
+            "path": d,
+            "files": sorted(direct_files.get(d, [])),
+            "children": kids,
+            "child_links": child_links,
+            "has_claude_md": os.path.isfile(os.path.join(abs_dir, CLAUDE_MD)),
+        })
+
+    return {"root": os.path.abspath(root), "dirs": result}
+
+
+# --- structure -------------------------------------------------------------
+
+HEADING = "## Subdirectories"
+ANY_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+
+def structure_findings(root):
+    """Where the tree on disk does not match the plan.
+
+    Companion to the duplication check. That one catches a parent repeating a
+    child's summary; this one catches a parent not linking the child at all,
+    which is what breaks navigation.
+    """
+    tree = build(root)
+    problems = []
+
+    for entry in tree["dirs"]:
+        rel = entry["path"]
+        md = os.path.join(root, rel, CLAUDE_MD) if rel else os.path.join(root, CLAUDE_MD)
+        where = (rel + "/" if rel else "") + CLAUDE_MD
+
+        if not os.path.isfile(md):
+            problems.append("%s: missing, but the dir is meaningful" % where)
+            continue
+
+        links = entry["child_links"]
+        if not links:
+            continue
+
+        with open(md, encoding="utf-8") as fh:
+            text = fh.read()
+        hrefs = set(ANY_LINK.findall(text))
+
+        if HEADING not in text:
+            problems.append("%s: has %d child dir(s) but no `%s` heading"
+                            % (where, len(links), HEADING))
+
+        for link in links:
+            if link["href"] not in hrefs:
+                problems.append("%s: does not link child `%s` (expected `%s`)"
+                                % (where, link["text"], link["href"]))
+
+        # A link is only navigation if its target exists.
+        for href in sorted(hrefs):
+            if not href.endswith(CLAUDE_MD):
+                continue
+            target = os.path.normpath(os.path.join(os.path.dirname(md), href))
+            if not os.path.isfile(target):
+                problems.append("%s: link `%s` points at a file that does not exist"
+                                % (where, href))
+
+    # The other direction: a CLAUDE.md the plan never asked for, in a dir that was
+    # collapsed or called too thin. Its content is a hop the parent could hold.
+    # Excluded dirs (dot-dirs, tests, build support) are out of scope either way.
+    listed = {e["path"] for e in tree["dirs"]}
+    for rel in claude_md_dirs(root):
+        if rel not in listed:
+            problems.append("%s: in a dir the plan skipped, so fold it into the "
+                            "parent and delete it" % os.path.join(rel, CLAUDE_MD))
+
+    return problems
+
+
+def report_structure(root):
+    problems = structure_findings(root)
+    if not problems:
+        print("OK: every meaningful dir has a CLAUDE.md indexing its children")
+        return 0
+    print("CLAUDE.md tree structure problems:")
+    for p in problems:
+        print("  - " + p)
+    return 1
+
+
+# --- duplication -----------------------------------------------------------
+
+# A "pointer" longer than this many chars is almost certainly a pasted summary.
+MAX_POINTER_CHARS = 70
+# Word-overlap (Jaccard) at or above this between pointer and child summary =
+# near-copy. A correct short pointer reuses the child's role words (child leads
+# with the same phrase), so a subset alone is fine; only high overlap = a copy.
+JACCARD_FLAG = 0.6
+
+# - [`child/`](child/CLAUDE.md) — description text
+SUB_LINK = re.compile(r"^\s*-\s*\[[^\]]+\]\(([^)]+)\)\s*[-—:]+\s*(.*\S)\s*$")
+STOP = {
+    "a", "an", "the", "and", "or", "of", "for", "to", "in", "on", "by", "with",
+    "per", "via", "its", "plus",
+}
+
+
+def words(text):
+    """Lowercase content words, punctuation and stop words dropped."""
+    toks = re.findall(r"[A-Za-z0-9_]+", text.lower())
+    return {t for t in toks if t not in STOP and len(t) > 1}
+
+
+def summary_line(path):
+    """First non-empty body line of a CLAUDE.md (the dir's own summary)."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        return s
+    return None
+
+
+def sub_links(path):
+    """(child_claude_md_path, description) for each Subdirectories link."""
+    out = []
+    in_sub = False
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            s = line.strip()
+            if s.startswith("## "):
+                in_sub = s.lower().startswith("## subdirectories")
+                continue
+            if not in_sub:
+                continue
+            m = SUB_LINK.match(line)
+            if m:
+                out.append((m.group(1), m.group(2)))
+    return out
+
+
+def jaccard(a, b):
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def report_dupes(root):
+    """Flag parent links that restate the child's own summary.
+
+    The tree's rule: a directory's authoritative summary lives only in its own
+    CLAUDE.md. A parent's Subdirectories link must be a SHORT POINTER (the
+    child's role in a few words), never a paste of the child's summary. Agents
+    writing the tree keep violating that by prose alone, hence this backstop.
+    """
+    findings = []
+    for rel in claude_md_dirs(root):
+        parent = os.path.join(root, rel, CLAUDE_MD)
+        for href, desc in sub_links(parent):
+            child_summary = summary_line(
+                os.path.normpath(os.path.join(root, rel, href)))
+            if child_summary is None:
+                continue
+            dw, cw = words(desc), words(child_summary)
+            j = jaccard(dw, cw)
+            too_long = len(desc) > MAX_POINTER_CHARS
+            if j >= JACCARD_FLAG or too_long:
+                reason = (
+                    "identical words" if dw == cw
+                    else "%.0f%% word overlap" % (j * 100) if j >= JACCARD_FLAG
+                    else "%d chars (pointer should be <= %d)"
+                    % (len(desc), MAX_POINTER_CHARS)
+                )
+                findings.append((parent, href, reason, desc, child_summary))
+
+    if not findings:
+        print("OK: no parent/child duplication found")
+        return 0
+
+    print("Duplication found in %d link(s):\n" % len(findings))
+    for parent, href, reason, desc, child_summary in findings:
+        print("  %s" % parent)
+        print("    link -> %s  (%s)" % (href, reason))
+        print("    parent pointer: %s" % desc)
+        print("    child summary : %s" % child_summary)
+        print("    fix: shorten the parent pointer to the child's role only.\n")
+    return 1
+
+
+# --- length ----------------------------------------------------------------
+
+# Hard ceiling on a CLAUDE.md's own prose, in words. Exempt: the Subdirectories
+# list and the root's maintenance note, which grow with the repo rather than with
+# what the file chose to say. A ceiling, not a target. Most files stay far under
+# it: a one-line summary plus links is the format.
+BODY_WORD_LIMIT = 120
+
+EXEMPT_HEADINGS = {"subdirectories", "maintaining this tree"}
+
+HEADING_RE = re.compile(r"^(#+)\s+(.*\S)\s*$")
+
+
+def body_words(path):
+    """Word count of a CLAUDE.md outside the exempt sections.
+
+    A heading at level 1 or 2 opens or closes an exemption; deeper headings stay
+    inside whatever section they belong to.
+    """
+    count = 0
+    exempt = False
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            m = HEADING_RE.match(line.strip())
+            if m and len(m.group(1)) <= 2:
+                exempt = m.group(2).lower() in EXEMPT_HEADINGS
+            if not exempt:
+                count += len(line.split())
+    return count
+
+
+def length_findings(root):
+    """(path, word count) per CLAUDE.md over the ceiling."""
+    findings = []
+    for rel in sorted(claude_md_dirs(root)):
+        path = os.path.join(root, rel, CLAUDE_MD)
+        count = body_words(path)
+        if count > BODY_WORD_LIMIT:
+            findings.append((path, count))
+    return findings
+
+
+def report_length(root):
+    findings = length_findings(root)
+    if not findings:
+        print("OK: every CLAUDE.md is within %d words" % BODY_WORD_LIMIT)
+        return 0
+    print("%d CLAUDE.md file(s) over the %d-word ceiling:\n"
+          % (len(findings), BODY_WORD_LIMIT))
+    for path, count in findings:
+        print("  %s" % path)
+        print("    %d words, %d over (Subdirectories and the root's maintenance "
+              "note excluded)" % (count, count - BODY_WORD_LIMIT))
+        print("    fix: cut prose, or move what is read only during one kind of "
+              "work into a repo skill under .claude/skills/.\n")
+    return 1
+
+
+# --- cli -------------------------------------------------------------------
+
+
+def report_plan(root):
+    print(json.dumps(build(root), indent=2))
+    return 0
+
+
+def report_check(root):
+    """Every check, always all of them, so one invocation reports everything."""
+    codes = [report_structure(root), report_dupes(root), report_length(root)]
+    return 1 if any(codes) else 0
+
+
+COMMANDS = {
+    "plan": report_plan,
+    "structure": report_structure,
+    "dupes": report_dupes,
+    "length": report_length,
+    "check": report_check,
+}
+
+
+def main(argv):
+    if len(argv) > 1 and argv[1] in ("-h", "--help"):
+        print(__doc__.strip())
+        return 0
+    if len(argv) < 2 or argv[1] not in COMMANDS:
+        print("error: expected one of %s (try --help)" % ", ".join(COMMANDS),
+              file=sys.stderr)
+        return 2
+    root = argv[2] if len(argv) > 2 else "."
+    if not os.path.isdir(root):
+        print("error: not a directory: %s" % root, file=sys.stderr)
+        return 2
+    return COMMANDS[argv[1]](root)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,7 +50,8 @@
       "Bash(npm -v)",
       "Bash(npm audit)",
       "Bash(git *)",
-      "Bash(gh *)"
+      "Bash(gh *)",
+      "Bash(.claude/scripts/lint_claude_md.py *)"
     ],
     "ask": ["Bash(wrangler *)", "Bash(npx wrangler *)"],
     "deny": [

--- a/.claude/skills/build-run-test/SKILL.md
+++ b/.claude/skills/build-run-test/SKILL.md
@@ -7,6 +7,8 @@ description: How to build, run, and test this repo. Read before any npm, make, t
 
 `make help` lists targets. Run targets, not raw npm scripts.
 
+`make check` also runs `make lint-docs`, which holds every CLAUDE.md to the 120-word ceiling the root file states. Python 3 only, no npm. It runs the `length` check alone: the structure and duplication checks want a CLAUDE.md in `public/`, which stays out because that directory is served to the web.
+
 ## Toolchain
 
 - Vite 8, React 19, TypeScript 6, Vitest 4, ESLint 9 flat config, wrangler 4.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,17 @@
 # rak-madness-calculator
 
-Auto-scoring web app for the Rak Madness football pool. Vite + React 19 + TypeScript, react-router, Base UI, SCSS. Vitest for tests, ESLint flat config. Scores an uploaded weekly picks spreadsheet against ESPN game results, exports XLSX. Home page at `/`, a week's results at `/:season/:week/scoreboard` and `/:season/:week/picks`, and `/scoreboard` and `/picks` redirect to the latest week worth showing. Deployed to Cloudflare Pages (`wrangler`); `functions/api/picks/index.ts` lists the seasons that have picks, and `functions/api/picks/[year]/[week].ts` serves one season's week.
+Auto-scoring web app for the Rak Madness football pool. Vite + React 19 +
+TypeScript, react-router, Base UI, SCSS. Vitest for tests, ESLint flat config.
+Scores an uploaded weekly picks spreadsheet against ESPN game results, exports XLSX.
+Home page at `/`, a week's results at `/:season/:week/scoreboard` and
+`/:season/:week/picks`, and `/scoreboard` and `/picks` redirect to the latest week
+worth showing. Deployed to Cloudflare Pages (`wrangler`);
+`functions/api/picks/index.ts` lists the seasons that have picks, and
+`functions/api/picks/[year]/[week].ts` serves one season's week.
 
 `public/` holds the static assets Vite copies to the build root, referenced by
-absolute path: `manifest.json` PWA metadata, the `favicon.ico` and `logo*.png`
-icons, and `robots.txt`, which disallows every crawler. The HTML shell is
-`index.html` at the repo root, not in there. It carries no `CLAUDE.md` of its own,
-because everything in it is published, and a note to Claude is not for the web.
+absolute path: `manifest.json`, the `favicon.ico` and `logo*.png` icons, and
+`robots.txt`. The HTML shell is `index.html` at the repo root.
 
 ## Subdirectories
 
@@ -15,5 +20,9 @@ because everything in it is published, and a note to Claude is not for the web.
 ## Maintaining this tree
 
 Navigation index. Changed a dir: update its CLAUDE.md summary and the parent's
-link. New meaningful dir: add a CLAUDE.md, link it. Pointer <= 70 chars.
-`public/` is the exception: it is served as-is, so it is described above instead.
+link. New meaningful dir: add a CLAUDE.md, link it. Pointer <= 70 chars. Every
+CLAUDE.md: 120 words max outside its Subdirectories list and this block. Ceiling,
+not target, and `make lint-docs` enforces it. Over it, the detail belongs at the
+point of definition, in a comment or docblock beside the code. A skill under
+`.claude/skills/` is for what no one file can hold. `public/` is the exception to
+the tree: it is served as-is, so it is described above instead.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help setup build run test check lint typecheck format
+.PHONY: help setup build run test check lint lint-docs typecheck format
 
 # Override to run a second dev server alongside the first, e.g. make run PORT=3001
 PORT ?= 3000
@@ -22,11 +22,17 @@ run: ## Start the Vite dev server (PORT=3000 by default)
 test: ## Run the Vitest suite once (no watch mode)
 	npm test
 
-check: lint typecheck test ## Lint, typecheck, test, and format-check everything
+check: lint lint-docs typecheck test ## Lint, typecheck, test, and format-check everything
 	npm run prettier
 
 lint: ## ESLint over the repo
 	npm run lint
+
+# Length only. The structure and duplication checks want a CLAUDE.md in public/,
+# which stays out on purpose: that directory is served to the web.
+lint-docs: ## Hold every CLAUDE.md to its word ceiling
+	@command -v python3 >/dev/null || { echo "Missing python3"; exit 1; }
+	.claude/scripts/lint_claude_md.py length .
 
 typecheck: ## tsc --noEmit for src/ and functions/ separately
 	npm run typecheck

--- a/src/components/button/CLAUDE.md
+++ b/src/components/button/CLAUDE.md
@@ -1,17 +1,9 @@
 # button
 
-`Button`: the app's only button, icon-only buttons included. Wraps Base UI's unstyled
-`Button` and adds the `--solid`/`--soft` variants, the
-`--primary`/`--success`/`--danger` colors, `--sm`, `--icon`, and `--compact`. Every
-prop is documented on the component itself.
+`Button`: the app's only button, icon-only buttons included. Wraps Base UI's
+unstyled `Button` and adds the `--solid`/`--soft` variants, the
+`--primary`/`--success`/`--danger` colors, `--sm`, `--icon`, `--compact`,
+`selected`, and `busy`. Every prop is documented on the component itself.
 
-`selected` says which one of a set is chosen with a rule on the button's bottom edge,
-because a fill one step from its neighbours' cannot be told apart. Solid primary
-darkens a step as well, having the room for it.
-
-Every color rule is scoped to `:not(:disabled)`. The variant selectors are more
-specific than `&:disabled`, so without that scoping a disabled button keeps its solid
-fill. Every `:hover` sits behind `can-hover`, because touch reports a hover on the
-last thing tapped and holds it there, which reads as a selection the app does not
-have. `busy` draws the sheen from `styles/_skeleton.scss`, the same one the wireframe
-tables sweep with.
+`Button.scss` scopes every color rule to `:not(:disabled)` and every `:hover` to
+`can-hover`, and takes its busy sheen from `styles/_skeleton.scss`.

--- a/src/components/icon/CLAUDE.md
+++ b/src/components/icon/CLAUDE.md
@@ -2,23 +2,11 @@
 
 Every icon the app draws, as one `<svg>` each. Path data copied verbatim from
 `@mui/icons-material` (Material Design icons, Apache 2.0), inlined because those
-components drag `@mui/material` and emotion in behind them. `Icon.scss` holds the
-24px box. A caller wanting another size overrides `width`/`height` from an
-`--rak-icon-*` token: `PlayerStatusIcon.scss` through `--rak-player-icon-size`, and
-the note covering a phone on its side through `--rak-icon-lg`.
+components drag `@mui/material` and emotion in behind them. `SkullIcon` comes from
+Material Symbols instead, same licence, rescaled onto the 24px grid.
 
-Each icon carries the `data-testid` its MUI counterpart had, which is how the
-toaster suite finds them.
+`Icon.scss` holds the 24px box. A caller wanting another size overrides
+`width`/`height` from an `--rak-icon-*` token.
 
-`SkullIcon` comes from Material Symbols, which `@mui/icons-material` does not
-carry. Same licence, its path data rescaled from Symbols' `0 -960 960 960` box onto
-the standard 24px one so it sits on the same grid as every other icon here.
-
-`ScreenRotationIcon` is drawn nowhere but the note covering a phone held sideways,
-where it leads the screen rather than sitting beside a word.
-
-The app is drawn in filled icons, except the three a player's status wears:
-`SkullOutlinedIcon`, `EmojiEventsOutlinedIcon`, and `SentimentVerySatisfiedIcon`,
-which is only drawn as an outline. Those sit at the end of a line of text at 16px,
-where a filled shape reads as a blot rather than as a skull or a trophy. The filled
-`EmojiEventsIcon` is still what the footer's standings link carries.
+Each icon keeps the `data-testid` its MUI counterpart had, which is how the toaster
+suite finds them.

--- a/src/components/navbar/CLAUDE.md
+++ b/src/components/navbar/CLAUDE.md
@@ -1,17 +1,13 @@
 # navbar
 
-`Navbar`: `<header>` with `left`/`right` `ReactNode` slots, solid primary fill.
-Owns the padding and the phone-sized touch target of every button it contains,
-trading its own padding for theirs on a narrow screen.
-`ScoresNavbar`: the scoreboard/picks switch plus the refresh a week still being
-played gets, for the results routes. Clearing `isWeekLive` collapses the refresh
-button and the divider before it, since rescoring cannot change a finished week.
-They share one collapsing wrapper, fade and narrow out over
-`COLLAPSE_DURATION_MS`, then unmount, and cancel `Navbar`'s `--navbar-gap` with a
-negative margin so no gap is left where they were.
+- `Navbar`: `<header>` with `left`/`right` `ReactNode` slots, solid primary fill.
+  Owns the padding and the phone-sized touch target of every button it contains.
+- `ScoresNavbar`: the scoreboard/picks switch plus the refresh a week still being
+  played gets, for the results routes. Clearing `isWeekLive` collapses the refresh
+  button and the divider before it.
 
-Nothing here opens the player analysis. A player's name does, in either table, on
-a finished week as well as a live one.
+Nothing here opens the player analysis. A player's name does, in either table, on a
+finished week as well as a live one.
 
 ## Subdirectories
 

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -3,74 +3,11 @@
 Where a player stands in a week and what they still have to do to win it, opened
 from a player's name in either table.
 
-`PlayerAnalysisDialog`: a Base UI dialog over a Base UI combobox, with
-`AnalysisSummary` under it. A `player` prop stands in for a choice made in the search,
-and remounts the combobox so the name reaches its input.
-
-The search is thousands of scenarios, so it runs on the player chosen rather than on
-every render. The answer already on screen stays there while the next one is worked
-out, under a bar on the rule that says so, rather than being taken away and put back.
-Only the search holds still: everything under that rule scrolls.
-
-`playersMatching` offers every player the letters typed reach, knocked out or not,
-since a knocked out one has an answer too. An entry carries the status icon the tables
-give the same player, through `PlayerStatusIcon`, and so does the input itself, so the
-search says where a player stands before their answer has been worked out. Both set
-`--rak-player-icon-fill` to `--rak-in-contention-on-light` or
-`--rak-knocked-out-on-light`. The icon says the status rather than a fill behind it, so
-the only fill in the popup is the highlight the list draws as it is walked. A name too
-long for the popup is cut short rather than wrapped, so an entry stays one line.
-
-`PlayerAnalysisDialog.scss` stands the one dialog on the bottom edge as a sheet, and
-stands it up as a centered modal at `wide-screen`, replacing both ends of the
-transition, since a window cannot inherit a sheet's slide. Its popup list takes its
-shape from `styles/_listbox.scss`, which the home page's selects share, and its search
-takes the focus ring from `styles/_focus.scss` on `:focus-within`, so the ring goes
-round the shell rather than the bare input. Two things are held still against a layout
-shift: the answer keeps its scrollbar gutter whether or not it has a scrollbar, and the
-list's empty message drops its padding while empty, which is a live region Base UI
-keeps mounted and would otherwise stand over the first name.
-
-`AnalysisSummary`: renders `PlayerAnalysis`, working out only what it takes to say it.
-
-`Standing` leads, read off the scores rather than the search. It answers for the player
-picked and nobody else, since the dialog is opened on a name and holds one from then
-on. Until a pick is settled it says no game has been played. `isWeekOver` is what tells
-it the week has a result to state, the same predicate the dialog reads for
-`AnalysisSummary`, so the two cannot disagree. Then the line reads as a result rather
-than a standing: the player picked is the winner rather than tied for the lead, and the
-tail says the week is complete instead of counting no games. Who won is settled with
-`comparePlayerScoresOnMerit`, so two players level on points that the tiebreakers
-separate leave one winner rather than a tie; points alone still say who leads a week
-still being played.
-
-`Standing` also takes the analysis once it lands, read only for a clinch, and only
-where it answers for the player named, since the last answer stays on screen while the
-next is worked out. A clinched player is called the winner outright even with games
-left. Then the body names the week they won, and adds that nothing left to play can
-undo it only while something is.
-
-Nothing an `eliminated` or `headline` result says repeats the header. A player already
-called `Knocked out` is left to the explanation below. One still trailing keeps the
-pick count the `headline` kind answers with, since that counts only their own remaining
-picks and can differ from the header's count of every game left.
-
-Picks sit in a grid rather than a wrapping row, so the same game holds the same column
-down every route, and a pick is drawn monospace at the width of the widest team
-abbreviation and spread a sheet can hold, so a column fits as many as it can and never
-cuts one short. A must-win game carries a red line where a route carries gold. Routes
-stand four deep and unfold on a click, and the dialog's own key on the player is what
-starts a new one folded. Under the last one opened, a note counts the routes found past
-the eight kept, held back until the rest have been asked for. A player picked always
-reads a sentence, down to the week resting on the tiebreaker alone.
-
-A tiebreaker every route shares is stated once under `MNF Points`, as a sentence, and
-left off the routes themselves. Where they disagree each route carries its own and that
-section does not render. A route says it the way it says its picks: set monospace under
-them, with `AND`, `TO BEAT`, and the commas between the players in the grey a pick's
-label carries. The total and the players it beats wrap as wholes, so a narrow screen
-breaks between them.
-
-One suite here mounts one dialog, on purpose. Base UI leaves its scroll lock, focus
-guards, and inert markers on the document when a second one mounts, which puts the
-input of every other case out of reach. The app holds one dialog and toggles `open`.
+- `PlayerAnalysisDialog`: a Base UI dialog over a Base UI combobox, with
+  `AnalysisSummary` under it. `playersMatching` offers every player the typed
+  letters reach, and both the entries and the input carry `PlayerStatusIcon`.
+- `PlayerAnalysisDialog.scss`: a bottom sheet, stood up as a centered modal at
+  `wide-screen`. Popup list from `styles/_listbox.scss`, focus ring from
+  `styles/_focus.scss`.
+- `AnalysisSummary`: renders `PlayerAnalysis`. Holds `Standing`, the pick grid, the
+  routes, and the `MNF Points` section.

--- a/src/components/results/CLAUDE.md
+++ b/src/components/results/CLAUDE.md
@@ -1,20 +1,14 @@
 # results
 
 The `/:season/:week` routes, plus `CurrentWeekRedirect`, which backs `/scoreboard`
-and `/picks` by redirecting to the latest week worth showing. `ResultsLayout` is
-the layout route: it runs `useWeekRouteGuard`, keeps the URL and the selected week
-in step, and holds the navbar so switching views does not restart the refresh
-throttle. `ScoreboardRoute` and `PicksRoute` each render one table from context.
-`ResultsFrame` is the page and wireframe both `ResultsLayout` and
-`CurrentWeekRedirect` render into, and `ResultsFrame.scss` colors the scores area
-so the gap below it reads as part of the table. It reads `useIsWeekDecided` to
-pass `ScoresNavbar` its `isWeekLive` prop, and holds the one `PlayerAnalysisDialog`
-the app has, fed the `scores` `ResultsLayout` passes down. One dialog toggled rather
-than one mounted per opening, because Base UI ties its scroll lock and focus guards
-to a dialog being open.
+and `/picks` by redirecting to the latest week worth showing.
 
-A player's name is the only way in, through the `PlayerAnalysisContextProvider`
-wrapped around the tables, since they arrive through a routed `Outlet` and cannot be
-handed a callback on the way. So the name held is what says the dialog is open, and
-it is cleared as the dialog closes, which makes the same name again a change the
-dialog can see.
+- `ResultsLayout`: the layout route. Runs `useWeekRouteGuard`, keeps the URL and the
+  selected week in step, and holds the navbar.
+- `ScoreboardRoute` and `PicksRoute`: one table each, from context.
+- `ResultsFrame`: the page and wireframe both `ResultsLayout` and
+  `CurrentWeekRedirect` render into. Holds the app's one `PlayerAnalysisDialog` and
+  the `PlayerAnalysisContextProvider` around the tables, and reads
+  `useIsWeekDecided` for `ScoresNavbar`'s `isWeekLive`.
+- `ResultsFrame.scss`: colors the scores area so the gap below reads as part of the
+  table.

--- a/src/components/table/CLAUDE.md
+++ b/src/components/table/CLAUDE.md
@@ -1,47 +1,14 @@
 # table
 
-`TableShell`: the frame both results tables share, the filler rows that carry a
-short table down to the bottom of the viewport, and the trailing row that keeps the
-last real row clear of a phone's rounded corners. `Table.scss` makes that row one
-row tall in the header's color, plus `env(safe-area-inset-bottom)` where the device
-reports one, publishes `--rak-table-row-height` for `useFillerRows` to measure
-against, and holds the shared `.table` styles (sticky header and player column, the
-touch feedback both clickable cells share, striped rows). Every measurement the
-wireframe has to reproduce is a custom property on `.table`: cell padding and cell
-borders. Change one there, not in two files. The size of the icon beside a player's
-name is in `src/index.scss` instead, because the player analysis search draws the
-same icon and is nowhere near a table.
-
-Takes an optional visually-hidden `caption`, the table's accessible name, and
-`ariaBusy`/`ariaHidden`, which only `SkeletonTable` sets. A cell that opens
-something is a real `<button className="table__cell-button">` inside its `<td>`,
-so a keyboard can reach it and a screen reader announces it as a control. The `<td>`
-keeps the fill, the border, and now `padding: 0`; the button carries that padding
-instead and fills the cell edge to edge, so the whole cell is inside its own hit
-area and the look is unchanged. `.table` no longer sets `user-select: none`: a real
-button does not lose a tap to a drag the way a `role="button"` cell did, so table
-text is selectable again. Status conveyed by fill color alone also gets a
-`.table__sr-only` span (the `visually-hidden` mixin from `src/styles/_a11y.scss`)
-inside the button, read by a screen reader and drawn nowhere.
-
-An edge that carries no border is `0 solid var(--rak-primary-800)`, never `none`.
-The shorthand resets the color to `currentColor`, which in the header is white.
-
-`SkeletonTable`: the wireframe shown while a week's results are being worked out,
-shaped like the view it stands in for. Its bar fill, its sweeping sheen, and the way
-it reserves room come from `styles/_skeleton.scss`, which the button's busy state
-draws from too. Its cells hold no text: each
-carries a `data-skeleton-text` stand-in that the stylesheet draws invisibly, so the
-table's own `max-content` sizing gives the wireframe a real table's measurements at
-any font size, and no placeholder reaches the page's text. No stand-in for a value
-wraps, because no real value does either, so a wireframe row is one line tall like
-a real one. Its header wraps on its own, with a floor of two lines so it still
-reads as a header where a real heading fits on one.
-
-Passes `ariaBusy` and `ariaHidden` to `TableShell`, so a screen reader skips the
-wireframe entirely rather than reading ~1500 empty cells, and reads a
-`role="status"` sibling span (`Loading picks results` / `Loading scoreboard
-results`) instead.
+- `TableShell`: the frame both results tables share, the filler rows carrying a
+  short table to the bottom of the viewport, and the trailing row keeping the last
+  real row clear of a phone's rounded corners. Takes `caption`, `ariaBusy` and
+  `ariaHidden`.
+- `Table.scss`: the shared `.table` styles, sticky header and player column, touch
+  feedback, striped rows, the trailing row, the `.table__cell-button` a clickable
+  cell holds, and the custom properties the wireframe measures against.
+- `SkeletonTable`: the wireframe shown while a week's results are worked out,
+  shaped like the view it stands in for, drawn from `styles/_skeleton.scss`.
 
 ## Subdirectories
 

--- a/src/components/table/playerName/CLAUDE.md
+++ b/src/components/table/playerName/CLAUDE.md
@@ -1,19 +1,11 @@
 # playerName
 
-`PlayerName`: table cell (`<td>`), holding a `.table__cell-button` with the player
+`PlayerName`: table cell (`<td>`) holding a `.table__cell-button` with the player
 name and status icon. Click opens the player analysis on that player, through
-`PlayerAnalysisContext`. The `<td>` keeps the fill and the `--knocked-out` class,
-since `--rak-cell-fill` has to live on the cell the stripe rule reads it back from;
-the button just fills that cell edge to edge.
-Name never wraps: cut short with an ellipsis past 18 characters, which the cell's
-monospace font makes exactly `18ch`. So every row is one line tall.
+`PlayerAnalysisContext`. Name is cut short with an ellipsis rather than wrapped, so
+every row is one line tall. A `.table__sr-only` span carries the words for the fill
+color.
 
-A `.table__sr-only` span carries "Knocked out" or "Still in contention", the words
-for the fill color (`--rak-in-contention-300`/`--rak-knocked-out-300`) that a
-sighted reader gets instead.
-
-`PlayerStatusIcon`: that icon on its own (`Skull`, or `EmojiEvents` once the week is
-decided and `SentimentVerySatisfied` before it), sized from `--rak-player-icon-size`.
-The player analysis search names the same players, so it renders this rather than
-choosing an icon of its own. Black on the table's own fills; a caller with no fill
-behind it sets `--rak-player-icon-fill` to say the status in the icon instead.
+`PlayerStatusIcon`: that icon on its own, sized from `--rak-player-icon-size`. The
+player analysis search renders it too, so the same player wears the same icon in
+both places.

--- a/src/context/CLAUDE.md
+++ b/src/context/CLAUDE.md
@@ -1,17 +1,8 @@
 # context
 
-`AppDataContext`: the season list, week list, picks, and scores, held above the
-routes. Derives the season and week from the pathname on every render.
-`selectableSeasons` is the seasons with picks plus the one running now, which is
-offered whether or not it has any: its weeks are scored from a spreadsheet the user
-uploads until its picks reach the database. It still opens on the newest season with
-picks, since ESPN calls a season current as soon as the last one ends. Publishes
-`WeekDecidedContext` separately, so a table cell reading it does not re-render on
-every loading flag.
-
-`ToastContext`: splits the toast list from its actions, for the same reason.
-
-`PlayerAnalysisContext`: how a player's name in a table opens the player analysis on
-them. One callback, a no-op with no provider above, so a table still renders on its
-own. `ResultsFrame` provides it; the routed `Outlet` between them is why it is a
-context rather than a prop.
+- `AppDataContext`: the season list, week list, picks, and scores, held above the
+  routes, with the season and week derived from the pathname. Publishes
+  `WeekDecidedContext` separately.
+- `ToastContext`: the toast list, split from its actions.
+- `PlayerAnalysisContext`: how a player's name in a table opens the player analysis
+  on them. One callback, a no-op with no provider above.

--- a/src/hooks/CLAUDE.md
+++ b/src/hooks/CLAUDE.md
@@ -4,24 +4,12 @@ The app's data layer. Everything that talks to ESPN, the picks API, or the scori
 pipeline lives here, so components only render. The first four are mounted once, in
 `AppDataContext`, above the routes.
 
-- `usePicksSeasons`: the seasons that have picks, from `/api/picks`, newest first.
-- `useCurrentSeason`: the season running now, asked of ESPN with no season named.
-  Its own lookup, because the picker has to offer that season whether or not it has
-  picks yet, and the list above holds only the ones that do.
-- `useLeagueWeeks`: the season's weeks from ESPN, and which one is selected. Takes
-  the week the URL names and the season to fetch, so a results URL is not preceded
-  by scoring the wrong week, and stays disabled until the season is known. The
-  week is read when the calendar lands, so changing it costs no lookup.
-  `seasonYear` says which season the week list actually describes.
-  `selectableWeeks` holds the calendar's own `WeekInfo` objects, because the week
-  picker compares options by reference.
-- `usePlayerScores`: the scores for a week, from the API, the local cache of an
-  earlier upload, or a file the user picked. Owns the refresh throttle.
-  `settledWeek` says which week it has finished trying, which is what lets the
-  route guard tell "no results" from "not yet".
-- `useExportScores`: downloads the current scores as a workbook.
-- `useWeekRouteGuard`: whether a `/:season/:week` URL has anything to show, and the
-  redirect home when it does not.
-- `useFillerRows`: how many empty rows a table needs to reach the bottom of the
-  viewport. `fillerRowCount` is the measurement on its own, which is where the
-  behavior is tested.
+- `usePicksSeasons`: the seasons that have picks, from `/api/picks`, newest first
+- `useCurrentSeason`: the season running now, asked of ESPN
+- `useLeagueWeeks`: the season's weeks from ESPN, and which one is selected
+- `usePlayerScores`: a week's scores from the API, cache, or an uploaded file.
+  Owns the refresh throttle
+- `useExportScores`: downloads the current scores as a workbook
+- `useWeekRouteGuard`: whether a `/:season/:week` URL has anything to show, and
+  the redirect home
+- `useFillerRows`: the empty rows a table needs to reach the viewport's bottom

--- a/src/styles/CLAUDE.md
+++ b/src/styles/CLAUDE.md
@@ -1,32 +1,14 @@
 # styles
 
-Sass partials. Mixins and variables only, so a partial emits no CSS however many
+Sass partials, mixins and variables only, so a partial emits no CSS however many
 files `@use` it. `_skeleton.scss` is the one exception, and says so: it holds
-keyframes, which a Sass module writes out once however many callers there are.
-Design tokens live in `src/index.scss` instead.
+keyframes. Design tokens live in `src/index.scss` instead.
 
-`_breakpoints.scss`: every mixin is `min-width`. A phone gets the base rules and a
-wider screen opts into what the room allows, so the floor a finger needs is the
-default rather than the exception. `roomy-screen` loosens the tables and the navbar,
-`labelled-navbar` is room enough to label the navbar's buttons, `wide-screen` is room
-enough to center a dialog rather than stand it on the bottom edge as a sheet, and
-`can-hover` guards a hover fill, which touch would otherwise leave stuck on the last
-thing tapped. `phone-landscape` is the one that is not about width: a phone on its
-side, told apart from a tablet by being under 500px tall, which `PageLayout` covers
-with a note asking for the phone back upright. These have to be Sass, because custom
-properties do not work inside a media query.
-
-`_focus.scss`: `focus-ring`, the one focus ring in the app. It takes the state that
-draws it, `:focus-visible` by default, so a shell around a control can ask for
-`:focus-within` and still draw the same ring.
-`_a11y.scss`: `visually-hidden`, for text only a screen reader reads.
-`_field.scss`: `field-shell` and `field-icon`, the box the home page's two selects
-share. The analysis dialog's search is not one of them: it sits inside a popup and is
-shorter than a page-level control, so it keeps its own box.
-`_listbox.scss`: `listbox-popup` and `listbox-item`, the shape the selects and that
-search give a Base UI popup list. Each caller adds what makes its own list different.
-`_skeleton.scss`: `skeleton-surface`, `skeleton-sheen`, and `skeleton-reserve`, the
-one way the app says it is still working. A wireframe stands in for content that is
-not there yet, and a sheen crosses content that is there but stale. Nothing spins.
-`SkeletonTable.scss` takes all three and `Button.scss` takes the sheen, so the sweep
-is written down once.
+- `_breakpoints.scss`: `roomy-screen`, `labelled-navbar`, `wide-screen`,
+  `can-hover`, `phone-landscape`
+- `_focus.scss`: `focus-ring`, the app's one focus ring
+- `_a11y.scss`: `visually-hidden`
+- `_field.scss`: `field-shell` and `field-icon`, the home page selects' box
+- `_listbox.scss`: `listbox-popup` and `listbox-item`, the shape of a Base UI popup
+  list
+- `_skeleton.scss`: `skeleton-surface`, `skeleton-sheen`, `skeleton-reserve`

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -1,7 +1,15 @@
 # src/utils
 
-getLeagueInfo/getLeagueResults: ESPN API fetch, calendar/week mapping. getRegularSeasonWeekCount reads a season's regular-season week count from the ESPN calendar and caches it per league and season; the `WEEKS_*_REGULAR_SEASON` constants in getLeagueResults are fallbacks only. buildSpreadsheetBuffer: xlsx-js-style workbook export, and the xlsx content type. pickStatusFill: pick colors for the export, the same success, danger, and warning ramps `index.scss` draws them in, with a suite holding the two in step. picksCache: localStorage cache of an uploaded workbook, keyed by season and week, so a results URL survives a reload. debugLog: scoring traces, silent outside a dev server. getClasses: conditional className join. rangeWithPrefix: labeled index arrays (C1, C2…). readFileToBuffer: an uploaded spreadsheet's bytes, kept a module so suites can mock it.
-leagueResultFixtures: `finalGame`/`upcomingGame` builders shared by the tests here.
+- `getLeagueInfo` / `getLeagueResults`: ESPN API fetch, calendar and week mapping
+- `getRegularSeasonWeekCount`: a season's week count, cached per league and season
+- `buildSpreadsheetBuffer`: the xlsx-js-style workbook export and its content type
+- `pickStatusFill`: pick colors for the export
+- `picksCache`: localStorage cache of an uploaded workbook, per season and week
+- `debugLog`: scoring traces, silent outside a dev server
+- `getClasses`: conditional className join
+- `rangeWithPrefix`: labeled index arrays (C1, C2…)
+- `readFileToBuffer`: an uploaded spreadsheet's bytes
+- `leagueResultFixtures`: `finalGame`/`upcomingGame` builders for the tests here
 
 ## Subdirectories
 

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -1,49 +1,19 @@
 # scoring
 
-The picks-to-scoreboard pipeline, one concern per file. `getPlayerScores` is the only
-entry point that turns a workbook into a week's results; everything else is a step it
-sequences. Three more read those results back for the UI: `getPlayerAnalysis`,
-`isWeekOver`, and `unscoreableGames`.
+The picks-to-scoreboard pipeline, one concern per file. `getPlayerScores` sequences
+the rest. `getPlayerAnalysis`, `isWeekOver`, `unscoreableGames` read results back.
 
-- `parsePicksWorkbook`: xlsx buffer to rows, column keys, and per-game matchups.
-  Async because it imports `xlsx-js-style` on demand, which is over half the bundle.
-  Reads its column keys from the header row, not the first player's row, because
-  `sheet_to_json` drops a blank cell from the object it builds
-- `parsePick`: one cell to a team abbreviation and a spread. Anchors the spread to
-  the end of the cell, so an abbreviation with a hyphen (`M-OH`) survives
-- `validateSpreads`: the games whose rows contradict each other about the spread
-- `getPickResults`: scores picks against game results, plus `getStatus`. Exports
-  `MISSING_PICK`, the explanation header a blank cell carries, which is how
-  `unscoreableGames` tells one from a game the app could not score
-- `gameColumns`: `LEAGUES`, the order a week's games are walked in, and `gameLabels`,
-  the `C1`/`P11` column labels the picks table gives them
-- `getTiebreakerScore`: the Monday night game's real total, once it is final
+- `parsePicksWorkbook`: xlsx buffer to rows, keys, matchups
+- `parsePick`: one cell to a team and a spread
+- `validateSpreads`: rows that disagree on a spread
+- `getPickResults`: picks scored, plus `getStatus`
+- `gameColumns`: `LEAGUES` and `gameLabels`
+- `getTiebreakerScore`: the Monday night total
 - `scorePlayers`: per-player totals, sorted
-- `comparePlayerScores`: the rank order. `comparePlayerScoresOnMerit` is every
-  tiebreaker tier without the name that settles a dead heat, since two players the
-  tiers leave tied have both won the week
-- `isWeekDecided`: whether every game and the tiebreaker are settled, which is when
-  whoever the knockouts left standing has won
-- `remainingGames`: the open games a column at a time, each row's cell parsed. Read
-  a column at a time because a blank cell scores "error" rather than "incomplete",
-  so one row alone would drop a game that row's player skipped. Both halves of the
-  question below read it
-- `unscoreableGames`: the games nobody can be scored on, by the picks table's own
-  label. A contradicted spread or a game the results do not hold is a hole in the
-  week, so a week carrying one is not finished however many of its games are. A
-  blank cell is not one of those, and every week has some
-- `isWeekOver`: whether a week has a result to state, which is nothing left to play
-  and no such hole. The one place that question is answered, so the analysis header
-  and the answer under it cannot disagree about it. Not `isWeekDecided`, which asks
-  whether the knockouts have settled who won
+- `comparePlayerScores`: rank order, and on merit
+- `isWeekDecided`: whether the knockouts settled it
+- `remainingGames`: the open games
+- `unscoreableGames`: games nobody can be scored on
+- `isWeekOver`: whether the week has a result
 - `applyKnockouts`: who can still win, and why not
-- `getPlayerAnalysis`: the other half of `applyKnockouts`, for any player named. One
-  already knocked out reads back the reason they carry, and a decided week is
-  answered from `isWeekDecided` rather than searched, since the knockouts have
-  already settled it and the search reads the lower tiers in an order of its own.
-  For a player still standing in a live week, once ten or fewer games are left, it
-  walks every way the contested ones can fall, and reduces the winning ones to the
-  games that must go right, the pool the rest come from, and the Monday night totals
-  that settle a dead heat on points. Where they do not reduce to a pool it lists the
-  eight routes asking least of the player and counts the rest. Above ten games it gives
-  a floor from a closed form instead, since the search doubles per game
+- `getPlayerAnalysis`: what a named player must do


### PR DESCRIPTION
## What

Every CLAUDE.md here is now held to 120 words of its own prose, checked by `make lint-docs` inside `make check`. Twelve files were over.

## Why

The tree is a navigation index the root file loads every session. Its files had grown into documentation, one to 887 words, restating reasoning the source already carries.

## Changes

- The checker is vendored at `.claude/scripts/lint_claude_md.py`, copied from agentify-docs. Re-copy it rather than editing it here.
- Only the `length` check runs. Structure and duplication want a CLAUDE.md in `public/`, which stays out because that directory is served to the web.
- Each trimmed file is now the index its parent links. Nothing moved: the reasoning was already beside the code, from `isWeekOver.ts` telling itself apart from `isWeekDecided` to `PlayerName.scss` on `18ch`.
- The maintenance block now says where overflow goes: a comment at the point of definition, a skill only for what no one file can hold.
- That block and the `## Subdirectories` list do not count against the ceiling.

## Verification

`make lint-docs` and prettier pass. No source file changed, so lint, typecheck and tests are untouched.
