### PR TITLE
fix(playerAnalysis): keep the search clear of a phone's keyboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <!-- viewport-fit=cover is what makes the safe-area insets non-zero, which
-         Table.scss uses to size the row below the scores. interactive-widget
-         hands a keyboard's height back to the layout viewport, so `dvh` measures
-         what is left rather than the whole screen. Chrome honours it; Safari does
-         not, which is what src/hooks/useViewportInsets.ts is there for. -->
+         Table.scss uses to size the row below the scores. No interactive-widget:
+         handing a keyboard's height back to the layout viewport can leave a small
+         phone wider than it is tall, which reads as landscape and raises the
+         rotate overlay. src/hooks/useViewportInsets.ts measures it instead. -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
     <!-- Matches --rak-primary-500 in src/index.scss, the navbar's own fill. -->
     <meta name="theme-color" content="#375267" />

--- a/index.html
+++ b/index.html
@@ -4,10 +4,13 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <!-- viewport-fit=cover is what makes the safe-area insets non-zero, which
-         Table.scss uses to size the row below the scores. -->
+         Table.scss uses to size the row below the scores. interactive-widget
+         hands a keyboard's height back to the layout viewport, so `dvh` measures
+         what is left rather than the whole screen. Chrome honours it; Safari does
+         not, which is what src/hooks/useViewportInsets.ts is there for. -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <!-- Matches --rak-primary-500 in src/index.scss, the navbar's own fill. -->
     <meta name="theme-color" content="#375267" />

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -9,7 +9,7 @@ under an opening dialog. No theme provider: Base UI is unstyled, so tokens plus 
 
 - [`components/`](components/CLAUDE.md) — React UI, layout, routes
 - [`context/`](context/CLAUDE.md) — app data, toast, and analysis providers
-- [`hooks/`](hooks/CLAUDE.md) — picks, scoring, export, route guard
+- [`hooks/`](hooks/CLAUDE.md) — picks, scoring, export, guard, measurement
 - [`styles/`](styles/CLAUDE.md) — Sass mixins: breakpoints, listbox shape
 - [`types/`](types/CLAUDE.md) — ESPN, league, and scoring types
 - [`utils/`](utils/CLAUDE.md) — scoring, ESPN, export, picks cache

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -8,6 +8,7 @@ from a player's name in either table.
   letters reach, and both the entries and the input carry `PlayerStatusIcon`.
 - `PlayerAnalysisDialog.scss`: a bottom sheet, stood up as a centered modal at
   `wide-screen`. Popup list from `styles/_listbox.scss`, focus ring from
-  `styles/_focus.scss`.
+  `styles/_focus.scss`. Sized and stood against `useViewportInsets`, so the
+  keyboard the search opens does not cover it.
 - `AnalysisSummary`: renders `PlayerAnalysis`. Holds `Standing`, the pick grid, the
   routes, and the `MNF Points` section.

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.scss
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.scss
@@ -21,6 +21,12 @@
 // A sheet on the bottom edge, which is what a screen too narrow to leave a margin
 // either side of a centered window gets. Told apart here rather than in the
 // component, because every other screen split in the app is drawn this way.
+//
+// The three custom properties below are `useViewportInsets`, held only while the
+// dialog is open. A keyboard opened by the search covers the bottom of the screen
+// without shrinking `dvh`, so the sheet stands on top of the keyboard rather than
+// running on behind it, and is capped by what is left rather than by the screen.
+// Every one falls back to the whole screen, which is where they started.
 .player-analysis__popup {
   position: fixed;
   z-index: calc(var(--rak-z-modal) + 1);
@@ -29,11 +35,16 @@
   gap: 16px;
   left: 0;
   right: 0;
-  bottom: 0;
+  bottom: var(--rak-keyboard-inset, 0px);
   width: 100%;
-  max-height: 85dvh;
+  max-height: min(85dvh, var(--rak-viewport-height, 85dvh));
   padding: 20px;
-  padding-bottom: calc(20px + env(safe-area-inset-bottom));
+  // Room for the home indicator, given back once the sheet is standing on a
+  // keyboard rather than on the bottom edge the indicator is drawn over.
+  padding-bottom: calc(
+    20px +
+      max(0px, env(safe-area-inset-bottom) - var(--rak-keyboard-inset, 0px))
+  );
   border-radius: var(--rak-radius-lg) var(--rak-radius-lg) 0 0;
   background-color: var(--rak-surface);
   box-shadow: var(--rak-shadow-modal);
@@ -249,12 +260,16 @@ $bar-height: 2px;
 // and centers itself.
 @include wide-screen {
   .player-analysis__popup {
-    top: 50%;
+    // Centered on what is on screen rather than on the screen, so a keyboard
+    // pushes the window up instead of leaving its lower half behind one.
+    top: calc(
+      var(--rak-viewport-offset, 0px) + var(--rak-viewport-height, 100dvh) / 2
+    );
     left: 50%;
     right: auto;
     bottom: auto;
     width: min(640px, calc(100vw - 32px));
-    max-height: min(680px, calc(100dvh - 64px));
+    max-height: min(680px, calc(var(--rak-viewport-height, 100dvh) - 64px));
     padding-bottom: 20px;
     border-radius: var(--rak-radius-lg);
     transform: translate(-50%, -50%);

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -1,6 +1,7 @@
 import { Combobox } from "@base-ui-components/react/combobox";
 import { Dialog } from "@base-ui-components/react/dialog";
 import { useEffect, useMemo, useState } from "react";
+import useViewportInsets from "../../hooks/useViewportInsets";
 import { PlayerAnalysis } from "../../types/PlayerAnalysis";
 import { RakMadnessScores } from "../../types/RakMadnessScores";
 import getClasses from "../../utils/getClasses";
@@ -66,6 +67,11 @@ export default function PlayerAnalysisDialog({
   // Held still between renders, since the combobox reads the chosen player back
   // off this list by identity.
   const options = useMemo(() => playerOptions(scores), [scores]);
+
+  // Tapping the search opens a keyboard over the bottom of the screen, which the
+  // sheet is sized and stood against. Only while the dialog is up, since nothing
+  // else on any page has an input to open one.
+  useViewportInsets(open);
 
   // A name arriving from outside stands in for a choice made in the search. Taken
   // during the render that brings it, so the answer is worked out in the same pass

--- a/src/components/toaster/Toaster.scss
+++ b/src/components/toaster/Toaster.scss
@@ -11,8 +11,9 @@ $toasterWidth: min(calc(100% - 48px), 400px);
   bottom: 0;
   left: 50%;
   transform: translateX(-50%);
+  // The gap either side is in the width, so a margin on top of it would push the
+  // stack off center rather than inset it.
   width: $toasterWidth;
-  margin: var(--rak-space-6);
   // `Toaster` is mounted beside the app rather than inside it, so it is outside
   // the wrapper that holds the page back from the unsafe areas and has to keep
   // itself off the home indicator on its own.

--- a/src/hooks/CLAUDE.md
+++ b/src/hooks/CLAUDE.md
@@ -1,8 +1,7 @@
 # hooks
 
-The app's data layer. Everything that talks to ESPN, the picks API, or the scoring
-pipeline lives here, so components only render. The first four are mounted once, in
-`AppDataContext`, above the routes.
+The app's data layer, and the two hooks that measure the page. The first four mount
+once, in `AppDataContext`, above the routes.
 
 - `usePicksSeasons`: the seasons that have picks, from `/api/picks`, newest first
 - `useCurrentSeason`: the season running now, asked of ESPN
@@ -13,3 +12,4 @@ pipeline lives here, so components only render. The first four are mounted once,
 - `useWeekRouteGuard`: whether a `/:season/:week` URL has anything to show, and
   the redirect home
 - `useFillerRows`: the empty rows a table needs to reach the viewport's bottom
+- `useViewportInsets`: what a virtual keyboard covers, as root `--rak-*` properties

--- a/src/hooks/useViewportInsets.test.ts
+++ b/src/hooks/useViewportInsets.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { viewportInsets } from "./useViewportInsets";
+
+const SCREEN = 800;
+
+function insets({
+  layoutHeight = SCREEN,
+  viewportHeight = SCREEN,
+  offsetTop = 0,
+  scale = 1,
+}: {
+  layoutHeight?: number;
+  viewportHeight?: number;
+  offsetTop?: number;
+  scale?: number;
+}) {
+  return viewportInsets({ layoutHeight, viewportHeight, offsetTop, scale });
+}
+
+describe("viewportInsets", () => {
+  it("reports nothing covered while the whole screen is visible", () => {
+    expect(insets({})).toEqual({
+      height: SCREEN,
+      offset: 0,
+      keyboardInset: 0,
+    });
+  });
+
+  it("measures the keyboard as the screen the visual viewport gave up", () => {
+    // The keyboard takes the bottom 340px, which is what the sheet has to clear.
+    expect(insets({ viewportHeight: 460 })).toEqual({
+      height: 460,
+      offset: 0,
+      keyboardInset: 340,
+    });
+  });
+
+  it("counts the screen above the visible area as covered too", () => {
+    // iOS scrolls the page up to keep the focused input in view, so the visible
+    // area starts below the top of the layout viewport.
+    expect(insets({ viewportHeight: 460, offsetTop: 120 })).toEqual({
+      height: 460,
+      offset: 120,
+      keyboardInset: 220,
+    });
+  });
+
+  it("asks for no inset when the visible area runs past the layout viewport", () => {
+    expect(insets({ viewportHeight: 820 }).keyboardInset).toBe(0);
+  });
+
+  it("leaves a zoomed page the way it found it", () => {
+    // Pinching shrinks the visual viewport the way a keyboard does, and resizing
+    // the dialog around a reader who zoomed in is not what they asked for.
+    expect(insets({ viewportHeight: 300, offsetTop: 200, scale: 2 })).toEqual({
+      height: SCREEN,
+      offset: 0,
+      keyboardInset: 0,
+    });
+  });
+});

--- a/src/hooks/useViewportInsets.ts
+++ b/src/hooks/useViewportInsets.ts
@@ -55,10 +55,8 @@ export default function useViewportInsets(enabled: boolean): void {
     if (!enabled || viewport == null) return;
 
     const root = document.documentElement;
-    let frame = 0;
 
     const measure = () => {
-      frame = 0;
       const { height, offset, keyboardInset } = viewportInsets({
         layoutHeight: window.innerHeight,
         viewportHeight: viewport.height,
@@ -70,19 +68,12 @@ export default function useViewportInsets(enabled: boolean): void {
       root.style.setProperty(KEYBOARD_INSET_VAR, `${keyboardInset}px`);
     };
 
-    // A keyboard opening fires both events several times as it slides in, and
-    // each one would otherwise write to the root mid-frame.
-    const schedule = () => {
-      if (frame === 0) frame = requestAnimationFrame(measure);
-    };
-
     measure();
-    viewport.addEventListener("resize", schedule);
-    viewport.addEventListener("scroll", schedule);
+    viewport.addEventListener("resize", measure);
+    viewport.addEventListener("scroll", measure);
     return () => {
-      if (frame !== 0) cancelAnimationFrame(frame);
-      viewport.removeEventListener("resize", schedule);
-      viewport.removeEventListener("scroll", schedule);
+      viewport.removeEventListener("resize", measure);
+      viewport.removeEventListener("scroll", measure);
       root.style.removeProperty(VIEWPORT_HEIGHT_VAR);
       root.style.removeProperty(VIEWPORT_OFFSET_VAR);
       root.style.removeProperty(KEYBOARD_INSET_VAR);

--- a/src/hooks/useViewportInsets.ts
+++ b/src/hooks/useViewportInsets.ts
@@ -1,0 +1,91 @@
+import { useEffect } from "react";
+
+/** The height actually on screen, which `dvh` does not shrink to. */
+export const VIEWPORT_HEIGHT_VAR = "--rak-viewport-height";
+
+/** How far down the layout viewport the visible area starts. */
+export const VIEWPORT_OFFSET_VAR = "--rak-viewport-offset";
+
+/** How much of the bottom edge something like a keyboard covers. */
+export const KEYBOARD_INSET_VAR = "--rak-keyboard-inset";
+
+/**
+ * What is on screen, out of what the layout is sized against.
+ *
+ * A virtual keyboard shrinks the visual viewport and leaves the layout viewport
+ * alone, so `dvh` still measures the whole screen and anything sized in it runs
+ * on under the keyboard. This is the difference, for the stylesheet to subtract.
+ *
+ * Pinching zooms the visual viewport the same way a keyboard shrinks it, and a
+ * reader who zoomed in did not ask for the dialog to be resized around them, so
+ * a zoomed page reports the layout viewport back unchanged.
+ */
+export function viewportInsets({
+  layoutHeight,
+  viewportHeight,
+  offsetTop,
+  scale,
+}: {
+  layoutHeight: number;
+  viewportHeight: number;
+  offsetTop: number;
+  scale: number;
+}): { height: number; offset: number; keyboardInset: number } {
+  if (scale > 1) {
+    return { height: layoutHeight, offset: 0, keyboardInset: 0 };
+  }
+  return {
+    height: viewportHeight,
+    offset: offsetTop,
+    keyboardInset: Math.max(layoutHeight - viewportHeight - offsetTop, 0),
+  };
+}
+
+/**
+ * Publishes the visible viewport to the document root, so a stylesheet can size
+ * against what the reader can actually see rather than the whole screen.
+ *
+ * Held to while `enabled`, since the only thing that asks is a dialog with a
+ * search in it, and the properties are dropped on the way out so everything
+ * falls back to its `dvh` default.
+ */
+export default function useViewportInsets(enabled: boolean): void {
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    if (!enabled || viewport == null) return;
+
+    const root = document.documentElement;
+    let frame = 0;
+
+    const measure = () => {
+      frame = 0;
+      const { height, offset, keyboardInset } = viewportInsets({
+        layoutHeight: window.innerHeight,
+        viewportHeight: viewport.height,
+        offsetTop: viewport.offsetTop,
+        scale: viewport.scale,
+      });
+      root.style.setProperty(VIEWPORT_HEIGHT_VAR, `${height}px`);
+      root.style.setProperty(VIEWPORT_OFFSET_VAR, `${offset}px`);
+      root.style.setProperty(KEYBOARD_INSET_VAR, `${keyboardInset}px`);
+    };
+
+    // A keyboard opening fires both events several times as it slides in, and
+    // each one would otherwise write to the root mid-frame.
+    const schedule = () => {
+      if (frame === 0) frame = requestAnimationFrame(measure);
+    };
+
+    measure();
+    viewport.addEventListener("resize", schedule);
+    viewport.addEventListener("scroll", schedule);
+    return () => {
+      if (frame !== 0) cancelAnimationFrame(frame);
+      viewport.removeEventListener("resize", schedule);
+      viewport.removeEventListener("scroll", schedule);
+      root.style.removeProperty(VIEWPORT_HEIGHT_VAR);
+      root.style.removeProperty(VIEWPORT_OFFSET_VAR);
+      root.style.removeProperty(KEYBOARD_INSET_VAR);
+    };
+  }, [enabled]);
+}


### PR DESCRIPTION
## What

Sizes the player analysis dialog against the viewport on screen, so a phone's
keyboard no longer covers the search. Centers the toast stack.

## Why

A keyboard shrinks the visual viewport and leaves the layout viewport alone, so
`dvh` goes on measuring the whole screen and the sheet kept its full height.

## Changes

- `useViewportInsets` publishes the visible viewport to the document root. Mounted
  only while the dialog is open, since nothing else in the app has an input.
- A zoomed page reports the layout viewport back unchanged, so pinching is not read
  as a keyboard. Every property falls back to the `dvh` it replaced.
- No `interactive-widget=resizes-content`. It would leave a small phone in portrait
  wider than it is tall, which raises the rotate overlay over the whole app.
- The toaster's gutters are in its width, so the margin that also inset it is gone.

## Verification

- Stood in for a keyboard at 390x844 and 375x667. The sheet's bottom edge lands on
  the keyboard, and the navbar and table stay up.
- Base UI positions the list from the real `visualViewport`, so that part is
  unverified until it is on a phone.

🕵️ Handled by [Agent Kim Possible](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
