### PR TITLE
fix(app): steady the analysis dialog, and hide a season nobody has played

### DIFF
--- a/src/App.picks.test.tsx
+++ b/src/App.picks.test.tsx
@@ -123,6 +123,40 @@ describe("the app, first load", () => {
     ]);
   });
 
+  it("leaves out the season running now until its opener has been played", async () => {
+    // ESPN moves on to the next season as soon as the last one ends, months
+    // before anything is played. Asked for no season it answers with that one,
+    // which has no week behind it and so nothing anybody could score.
+    getLeagueInfoMock.mockImplementation(async (_league, season) =>
+      season == null
+        ? { ...leagueInfo, season: SEASON + 1, activeWeek: undefined }
+        : { ...leagueInfo, season },
+    );
+    global.fetch = routedFetch(notFoundResponse, [SEASON, SEASON - 1]);
+    const user = await mountLoadedApp();
+
+    await user.click(screen.getByRole("combobox", { name: "Season" }));
+    const options = (await screen.findAllByRole("option")).map(
+      (option) => option.textContent,
+    );
+    expect(options).toEqual([`${SEASON} Season`, `${SEASON - 1} Season`]);
+  });
+
+  it("offers no weeks of a season whose opener is still ahead", async () => {
+    getLeagueInfoMock.mockResolvedValue({
+      ...leagueInfo,
+      activeWeek: undefined,
+    });
+    await mountLoadedApp();
+
+    // Nothing selected, and nothing to select: the trigger is left asking for a
+    // week it has none of.
+    expect(screen.getByRole("combobox", { name: "Week" })).toHaveTextContent(
+      "Select a week...",
+    );
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+  });
+
   it("offers the current season alone when the list cannot be had", async () => {
     const user = await mountLoadedApp();
 

--- a/src/App.routes.test.tsx
+++ b/src/App.routes.test.tsx
@@ -261,6 +261,28 @@ describe("the app, week routes", () => {
     expect(await screen.findByText("Select a week...")).toBeInTheDocument();
   });
 
+  it("sends /scoreboard home when the season has no week behind it", async () => {
+    getLeagueInfoMock.mockResolvedValue({
+      ...leagueInfo,
+      activeWeek: undefined,
+    });
+    global.fetch = routedFetch(spreadsheetResponse, [SEASON]);
+    mountApp("/scoreboard");
+
+    expect(await screen.findByText("Select a week...")).toBeInTheDocument();
+  });
+
+  it("sends a week of a season with no week behind it home", async () => {
+    getLeagueInfoMock.mockResolvedValue({
+      ...leagueInfo,
+      activeWeek: undefined,
+    });
+    await mountLoadedApp(`/${SEASON}/1/scoreboard`);
+
+    expect(await screen.findByText("Unknown Week")).toBeInTheDocument();
+    expect(getPlayerScoresMock).not.toHaveBeenCalled();
+  });
+
   it("sends a season that is not a year home", async () => {
     await mountLoadedApp(`/nope/${CURRENT_WEEK}/scoreboard`);
 

--- a/src/components/home/HomePage.scss
+++ b/src/components/home/HomePage.scss
@@ -31,8 +31,6 @@
 
 .select__popup {
   @include listbox-popup;
-
-  max-height: var(--available-height);
 }
 
 .select__item {

--- a/src/components/home/HomePage.scss
+++ b/src/components/home/HomePage.scss
@@ -16,6 +16,8 @@
 }
 
 .select__popup {
+  @include listbox-popup;
+
   color: var(--rak-text-secondary);
 }
 
@@ -25,12 +27,6 @@
 
 .select__positioner {
   z-index: var(--rak-z-overlay);
-  // Keeps a long week list from running past the viewport.
-  max-height: var(--available-height);
-}
-
-.select__popup {
-  @include listbox-popup;
 }
 
 .select__item {

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -98,6 +98,9 @@ export default function HomePage() {
                 <Select.Positioner
                   className="select__positioner"
                   sideOffset={4}
+                  // Base UI otherwise lays the popup over the trigger and sizes it
+                  // to the viewport to do so, past the rows the stylesheet allows.
+                  alignItemWithTrigger={false}
                 >
                   <Select.Popup className="select__popup">
                     {selectableSeasons.map((season) => (
@@ -139,6 +142,7 @@ export default function HomePage() {
                 <Select.Positioner
                   className="select__positioner"
                   sideOffset={4}
+                  alignItemWithTrigger={false}
                 >
                   <Select.Popup className="select__popup">
                     {selectableWeeks.map((week) => (
@@ -173,9 +177,8 @@ export default function HomePage() {
               Use Local Spreadsheet
             </Button>
             <Button
-              className={`home__button --scores ${getClasses({
-                "--loading-btn": isBusy,
-              })}`}
+              className="home__button --scores"
+              busy={isBusy}
               disabled={hasNoScoresYet}
               color="success"
               onClick={() =>
@@ -185,9 +188,8 @@ export default function HomePage() {
               View Results
             </Button>
             <Button
-              className={`home__button --export ${getClasses({
-                "--loading-btn": isBusy || isExportLoading,
-              })}`}
+              className="home__button --export"
+              busy={isBusy || isExportLoading}
               disabled={hasNoScoresYet || isExportLoading}
               color="danger"
               onClick={exportResults}

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -177,7 +177,7 @@ export default function HomePage() {
               Use Local Spreadsheet
             </Button>
             <Button
-              className="home__button --scores"
+              className="home__button"
               busy={isBusy}
               disabled={hasNoScoresYet}
               color="success"
@@ -188,7 +188,7 @@ export default function HomePage() {
               View Results
             </Button>
             <Button
-              className="home__button --export"
+              className="home__button"
               busy={isBusy || isExportLoading}
               disabled={hasNoScoresYet || isExportLoading}
               color="danger"

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -11,11 +11,19 @@
 
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  // The standing above reads as a title over the body, so it sits the same distance
+  // from it as a section title sits from its own contents.
+  gap: 8px;
 
   @media (prefers-reduced-motion: no-preference) {
     animation: analysis-in 220ms ease both;
   }
+}
+
+.analysis__body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 // The fade alone. A transform counts against the scrollable overflow of the body

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -1,4 +1,4 @@
-// Whatever the answer turns out to be, it plays in under a dialog already growing
+// Whatever the answer turns out to be, it fades in under a dialog already growing
 // to hold it.
 .analysis {
   // What a pick chip sets its text in by, which a line under one indents by to
@@ -18,10 +18,11 @@
   }
 }
 
+// The fade alone. A transform counts against the scrollable overflow of the body
+// this sits in, so any travel draws a scrollbar over the answer while it runs.
 @keyframes analysis-in {
   from {
     opacity: 0;
-    transform: translateY(6px);
   }
 }
 

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -38,8 +38,8 @@
   gap: 8px;
 }
 
-// The two colors the tables and the search already draw a player's standing in,
-// at the step of each taken far enough down to read on a white surface.
+// A win and a knockout, in the hues the tables and the search already mark those
+// players with.
 .analysis__headline {
   &.--won {
     color: var(--rak-in-contention-on-light);

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -1,5 +1,3 @@
-// Whatever the answer turns out to be, it fades in under a dialog already growing
-// to hold it.
 .analysis {
   // What a pick chip sets its text in by, which a line under one indents by to
   // stand under that text rather than under the chip.
@@ -14,24 +12,12 @@
   // The standing above reads as a title over the body, so it sits the same distance
   // from it as a section title sits from its own contents.
   gap: 8px;
-
-  @media (prefers-reduced-motion: no-preference) {
-    animation: analysis-in 220ms ease both;
-  }
 }
 
 .analysis__body {
   display: flex;
   flex-direction: column;
   gap: 16px;
-}
-
-// The fade alone. A transform counts against the scrollable overflow of the body
-// this sits in, so any travel draws a scrollbar over the answer while it runs.
-@keyframes analysis-in {
-  from {
-    opacity: 0;
-  }
 }
 
 .analysis__note {
@@ -50,6 +36,18 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+// The two colors the tables and the search already draw a player's standing in,
+// at the step of each taken far enough down to read on a white surface.
+.analysis__headline {
+  &.--won {
+    color: var(--rak-in-contention-on-light);
+  }
+
+  &.--knocked-out {
+    color: var(--rak-knocked-out-on-light);
+  }
 }
 
 .analysis__standing,

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -36,6 +36,11 @@ const base = {
 };
 
 describe("Standing", () => {
+  /** Whole standing, whose headline is drawn apart from the tail it sits before. */
+  function standingText(): string {
+    return document.querySelector(".analysis__standing")?.textContent ?? "";
+  }
+
   /** One game already settled and one still open, which is a week under way. */
   function player(name: string, total: number, pick: string): PlayerScore {
     const result = (status: PlayerScore["pro"][number]["status"]) => ({
@@ -71,17 +76,13 @@ describe("Standing", () => {
   it("counts the player picked back to the leader", () => {
     render(<Standing scores={scores} player="Alice" />);
 
-    expect(
-      screen.getByText("2 points behind Rak · 1 game still to play"),
-    ).toBeInTheDocument();
+    expect(standingText()).toBe("2 points behind Rak · 1 game still to play");
   });
 
   it("ties the player picked to the lead where they hold it", () => {
     render(<Standing scores={scores} player="Rak" />);
 
-    expect(
-      screen.getByText("Tied for the lead · 1 game still to play"),
-    ).toBeInTheDocument();
+    expect(standingText()).toBe("Tied for the lead · 1 game still to play");
   });
 
   /** The same week with nothing left open, which is a week that has a winner. */
@@ -97,7 +98,7 @@ describe("Standing", () => {
   it("calls the player picked the winner rather than tied for the lead", () => {
     render(<Standing scores={finished(scores)} player="Rak" />);
 
-    expect(screen.getByText("Winner · Week complete")).toBeInTheDocument();
+    expect(standingText()).toBe("Winner · Week complete");
   });
 
   it("ties the player picked for the win where the top is shared", () => {
@@ -106,9 +107,7 @@ describe("Standing", () => {
     };
     render(<Standing scores={finished(tied)} player="Rak" />);
 
-    expect(
-      screen.getByText("Tied for the win · Week complete"),
-    ).toBeInTheDocument();
+    expect(standingText()).toBe("Tied for the win · Week complete");
   });
 
   /** Level on points, told apart by the Monday night tiebreaker. */
@@ -131,15 +130,13 @@ describe("Standing", () => {
     render(<Standing scores={separatedWeek} player="Rak" />);
 
     // Level on points with Bill, so only the tiebreaker makes this one winner.
-    expect(screen.getByText("Winner · Week complete")).toBeInTheDocument();
+    expect(standingText()).toBe("Winner · Week complete");
   });
 
   it("says the player picked lost the tiebreaker rather than tied for the win", () => {
     render(<Standing scores={separatedWeek} player="Bill" />);
 
-    expect(
-      screen.getByText("Loses the tiebreaker to Rak · Week complete"),
-    ).toBeInTheDocument();
+    expect(standingText()).toBe("Loses the tiebreaker to Rak · Week complete");
   });
 
   it("calls a clinched player the winner even where games remain", () => {
@@ -151,9 +148,7 @@ describe("Standing", () => {
       />,
     );
 
-    expect(
-      screen.getByText("Winner · 1 game still to play"),
-    ).toBeInTheDocument();
+    expect(standingText()).toBe("Winner · 1 game still to play");
   });
 
   it("ties a clinched player for the win where the top is shared", () => {
@@ -168,9 +163,7 @@ describe("Standing", () => {
       />,
     );
 
-    expect(
-      screen.getByText("Tied for the win · 1 game still to play"),
-    ).toBeInTheDocument();
+    expect(standingText()).toBe("Tied for the win · 1 game still to play");
   });
 
   it("ignores a clinch that answers for a different player", () => {
@@ -182,24 +175,45 @@ describe("Standing", () => {
       />,
     );
 
-    expect(
-      screen.getByText("Tied for the lead · 1 game still to play"),
-    ).toBeInTheDocument();
+    expect(standingText()).toBe("Tied for the lead · 1 game still to play");
   });
 
-  it("says a knocked out player is knocked out, and leaves the points to the answer", () => {
-    const out: RakMadnessScores = {
-      scores: scores.scores.map((it) =>
-        it.name === "Alice"
+  /** The same week with one player out of it. */
+  function knockedOut(week: RakMadnessScores, name: string): RakMadnessScores {
+    return {
+      scores: week.scores.map((it) =>
+        it.name === name
           ? { ...it, status: { ...it.status, isKnockedOut: true } }
           : it,
       ),
     };
-    render(<Standing scores={out} player="Alice" />);
+  }
 
-    expect(
-      screen.getByText("Knocked out · 1 game still to play"),
-    ).toBeInTheDocument();
+  it("says a knocked out player is knocked out, and leaves the points to the answer", () => {
+    render(<Standing scores={knockedOut(scores, "Alice")} player="Alice" />);
+
+    expect(standingText()).toBe("Knocked out · 1 game still to play");
+  });
+
+  it("colors a win and a knockout, and leaves an open standing plain", () => {
+    const headlineClasses = () =>
+      document.querySelector(".analysis__standing")?.firstElementChild
+        ?.className ?? "";
+
+    const { unmount: unmountWinner } = render(
+      <Standing scores={finished(scores)} player="Rak" />,
+    );
+    expect(headlineClasses()).toContain("--won");
+    unmountWinner();
+
+    const { unmount: unmountKnockedOut } = render(
+      <Standing scores={knockedOut(scores, "Alice")} player="Alice" />,
+    );
+    expect(headlineClasses()).toContain("--knocked-out");
+    unmountKnockedOut();
+
+    render(<Standing scores={scores} player="Alice" />);
+    expect(headlineClasses()).toBe("");
   });
 
   /** One game nobody could be scored on, which is a hole in a week otherwise done. */
@@ -225,9 +239,9 @@ describe("Standing", () => {
     );
 
     // Not the winner: a week with a hole in it has no result to state yet.
-    expect(
-      screen.getByText("Tied for the lead · 1 game could not be scored"),
-    ).toBeInTheDocument();
+    expect(standingText()).toBe(
+      "Tied for the lead · 1 game could not be scored",
+    );
   });
 
   it("counts a blank cell as the player's own, not a hole in the week", () => {
@@ -249,7 +263,7 @@ describe("Standing", () => {
     };
     render(<Standing scores={blank} player="Rak" />);
 
-    expect(screen.getByText("Winner · Week complete")).toBeInTheDocument();
+    expect(standingText()).toBe("Winner · Week complete");
   });
 
   it("says no game has been played rather than ranking anyone", () => {
@@ -262,9 +276,7 @@ describe("Standing", () => {
     };
     render(<Standing scores={fresh} player="Rak" />);
 
-    expect(
-      screen.getByText("No finished games · 2 games still to play"),
-    ).toBeInTheDocument();
+    expect(standingText()).toBe("No finished games · 2 games still to play");
   });
 });
 

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -345,7 +345,9 @@ describe("AnalysisSummary", () => {
     const why = screen.getByText(
       "Detailed paths are worked out once ten games are left.",
     );
-    expect(why).toBe(document.querySelector(".analysis")?.lastElementChild);
+    expect(why).toBe(
+      document.querySelector(".analysis__body")?.lastElementChild,
+    );
   });
 
   it("lists the must-win games and the pool behind them", () => {

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -196,24 +196,19 @@ describe("Standing", () => {
   });
 
   it("colors a win and a knockout, and leaves an open standing plain", () => {
-    const headlineClasses = () =>
-      document.querySelector(".analysis__standing")?.firstElementChild
-        ?.className ?? "";
-
-    const { unmount: unmountWinner } = render(
+    const { rerender } = render(
       <Standing scores={finished(scores)} player="Rak" />,
     );
-    expect(headlineClasses()).toContain("--won");
-    unmountWinner();
+    expect(screen.getByText("Winner")).toHaveClass("--won");
 
-    const { unmount: unmountKnockedOut } = render(
-      <Standing scores={knockedOut(scores, "Alice")} player="Alice" />,
+    rerender(<Standing scores={knockedOut(scores, "Alice")} player="Alice" />);
+    expect(screen.getByText("Knocked out")).toHaveClass("--knocked-out");
+
+    rerender(<Standing scores={scores} player="Rak" />);
+    expect(screen.getByText("Tied for the lead")).not.toHaveClass(
+      "--won",
+      "--knocked-out",
     );
-    expect(headlineClasses()).toContain("--knocked-out");
-    unmountKnockedOut();
-
-    render(<Standing scores={scores} player="Alice" />);
-    expect(headlineClasses()).toBe("");
   });
 
   /** One game nobody could be scored on, which is a hole in a week otherwise done. */

--- a/src/components/playerAnalysis/AnalysisSummary.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.tsx
@@ -330,24 +330,18 @@ function Message({ lines }: { lines: Array<string | undefined> }) {
 }
 
 /** What the player has to do, or why there is nothing left to do about it. */
-export default function AnalysisSummary({
+function Body({
   result,
   isOver,
   week,
 }: {
-  result?: PlayerAnalysis;
-  /** Whether the week itself is done, which is what the "clinched" case needs. */
+  result: PlayerAnalysis;
   isOver?: boolean;
-  /** Which week this is, named by the one line that congratulates a winner. */
   week?: number;
 }) {
-  // Nothing under the search until a name is picked, which the placeholder in it
-  // already asks for.
-  if (result == null) return null;
-
   if (result.kind === "eliminated") {
     return (
-      <Answer>
+      <>
         {/* The explanation names who knocked them out and by how much, so it says
             they cannot win on its own. Only a player without one needs telling. */}
         <Message
@@ -355,14 +349,14 @@ export default function AnalysisSummary({
             result.explanation ?? `${result.player} cannot win this week.`,
           ]}
         />
-      </Answer>
+      </>
     );
   }
 
   if (result.kind === "clinched") {
     return (
-      <Answer>
-        {/* The header calls a clinched player the winner without saying of what,
+      <>
+        {/* The standing calls a clinched player the winner without saying of what,
             so this names the week. Only a week still running needs the line
             under it, since a week with nothing left to play cannot be undone. */}
         <Message
@@ -371,13 +365,13 @@ export default function AnalysisSummary({
             isOver ? undefined : "Nothing still to be played can take it away.",
           ]}
         />
-      </Answer>
+      </>
     );
   }
 
   if (result.kind === "headline") {
     return (
-      <Answer>
+      <>
         <Message
           lines={[
             `${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`,
@@ -390,12 +384,12 @@ export default function AnalysisSummary({
         <p className="analysis__note">
           Detailed paths are worked out once ten games are left.
         </p>
-      </Answer>
+      </>
     );
   }
 
   return (
-    <Answer>
+    <>
       <Lead result={result} />
 
       {result.mustWin.length > 0 && (
@@ -431,6 +425,45 @@ export default function AnalysisSummary({
 
       <NeedsHelp games={result.needsHelp} />
       <MondayNight outlook={result.mondayNight} />
+    </>
+  );
+}
+
+/**
+ * The whole answer to a player: where they stand, then what that leaves them.
+ *
+ * The standing is drawn here rather than beside this, because there is one headline
+ * slot and one component has to own it. Held in the same wrapper as the body, so
+ * both play in on the same beat rather than the headline arriving cold.
+ */
+export default function AnalysisSummary({
+  scores,
+  player,
+  result,
+  isOver,
+  week,
+}: {
+  scores?: RakMadnessScores;
+  /** The player picked, whose standing heads the answer. */
+  player?: string;
+  result?: PlayerAnalysis;
+  /** Whether the week itself is done, which is what the "clinched" case needs. */
+  isOver?: boolean;
+  /** Which week this is, named by the one line that congratulates a winner. */
+  week?: number;
+}) {
+  // Nothing under the search until a name is picked, which the placeholder in it
+  // already asks for.
+  if (player == null && result == null) return null;
+
+  return (
+    <Answer>
+      <Standing scores={scores} player={player} result={result} />
+      {result != null && (
+        <div className="analysis__body">
+          <Body result={result} isOver={isOver} week={week} />
+        </div>
+      )}
     </Answer>
   );
 }

--- a/src/components/playerAnalysis/AnalysisSummary.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.tsx
@@ -63,17 +63,23 @@ function headline(
   isOver: boolean,
   chosen: PlayerScore,
   isClinched: boolean,
-): string {
-  if (!hasKickedOff(players)) return "No finished games";
+): { text: string; tone?: "won" | "knocked-out" } {
+  if (!hasKickedOff(players)) return { text: "No finished games" };
   const [leader] = players;
-  if (chosen.status.isKnockedOut) return "Knocked out";
+  if (chosen.status.isKnockedOut)
+    return { text: "Knocked out", tone: "knocked-out" };
   const behind = leader.score.total - chosen.score.total;
-  if (behind > 0) return `${plural(behind, "point")} behind ${leader.name}`;
-  if (!isOver && !isClinched) return "Tied for the lead";
+  if (behind > 0)
+    return { text: `${plural(behind, "point")} behind ${leader.name}` };
+  if (!isOver && !isClinched) return { text: "Tied for the lead" };
   const won = winners(players);
   // Level on points and still beaten, which only the tiebreakers can do.
-  if (!won.includes(chosen)) return `Loses the tiebreaker to ${leader.name}`;
-  return won.length > 1 ? "Tied for the win" : "Winner";
+  if (!won.includes(chosen))
+    return { text: `Loses the tiebreaker to ${leader.name}` };
+  return {
+    text: won.length > 1 ? "Tied for the win" : "Winner",
+    tone: "won",
+  };
 }
 
 /**
@@ -106,9 +112,15 @@ export function Standing({
   const unscoreable = unscoreableGames(players).length;
   const isClinched = result?.kind === "clinched" && result.player === player;
   const isOver = isWeekOver(players);
+  const { text, tone } = headline(players, isOver, chosen, isClinched);
   return (
     <p className="analysis__standing">
-      {headline(players, isOver, chosen, isClinched)}
+      {/* Held apart from the tail, which says how much of the week is behind the
+          standing rather than what the standing is, so only the standing is
+          colored by it. */}
+      <span className={tone != null ? `analysis__headline --${tone}` : ""}>
+        {text}
+      </span>
       {" · "}
       {remaining > 0
         ? `${plural(remaining, "game")} still to play`
@@ -119,7 +131,6 @@ export function Standing({
   );
 }
 
-/** Whatever the answer turns out to be, it plays in under the same wrapper. */
 function Answer({ children }: { children: ReactNode }) {
   return <div className="analysis">{children}</div>;
 }
@@ -433,8 +444,7 @@ function Body({
  * The whole answer to a player: where they stand, then what that leaves them.
  *
  * The standing is drawn here rather than beside this, because there is one headline
- * slot and one component has to own it. Held in the same wrapper as the body, so
- * both play in on the same beat rather than the headline arriving cold.
+ * slot and one component has to own it.
  */
 export default function AnalysisSummary({
   scores,

--- a/src/components/playerAnalysis/AnalysisSummary.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.tsx
@@ -63,11 +63,11 @@ function headline(
   isOver: boolean,
   chosen: PlayerScore,
   isClinched: boolean,
-): { text: string; tone?: "won" | "knocked-out" } {
+): { text: string; tone?: "--won" | "--knocked-out" } {
   if (!hasKickedOff(players)) return { text: "No finished games" };
   const [leader] = players;
   if (chosen.status.isKnockedOut)
-    return { text: "Knocked out", tone: "knocked-out" };
+    return { text: "Knocked out", tone: "--knocked-out" };
   const behind = leader.score.total - chosen.score.total;
   if (behind > 0)
     return { text: `${plural(behind, "point")} behind ${leader.name}` };
@@ -78,7 +78,7 @@ function headline(
     return { text: `Loses the tiebreaker to ${leader.name}` };
   return {
     text: won.length > 1 ? "Tied for the win" : "Winner",
-    tone: "won",
+    tone: "--won",
   };
 }
 
@@ -86,9 +86,9 @@ function headline(
  * Where the player picked stands, which the scores already say. Read straight off
  * them, so it is on screen while their routes are still being worked out.
  *
- * `result` is the analysis once it lands, read only for the "clinched" word: the
- * header and the answer below it are worked out from the same fact this way, so
- * neither has to guess what the other already said. Trusted only where it answers
+ * `result` is the analysis once it lands, read only for the "clinched" word: this
+ * standing and the answer below it are worked out from the same fact, so neither
+ * has to guess what the other already said. Trusted only where it answers
  * for the same player named here, since the dialog keeps the last answer on
  * screen while the next one is worked out.
  */
@@ -118,9 +118,7 @@ export function Standing({
       {/* Held apart from the tail, which says how much of the week is behind the
           standing rather than what the standing is, so only the standing is
           colored by it. */}
-      <span className={tone != null ? `analysis__headline --${tone}` : ""}>
-        {text}
-      </span>
+      <span className={`analysis__headline ${tone ?? ""}`}>{text}</span>
       {" · "}
       {remaining > 0
         ? `${plural(remaining, "game")} still to play`
@@ -129,10 +127,6 @@ export function Standing({
           : "Week complete"}
     </p>
   );
-}
-
-function Answer({ children }: { children: ReactNode }) {
-  return <div className="analysis">{children}</div>;
 }
 
 function Section({ title, children }: { title: string; children: ReactNode }) {
@@ -351,32 +345,26 @@ function Body({
   week?: number;
 }) {
   if (result.kind === "eliminated") {
+    // The explanation names who knocked them out and by how much, so it says they
+    // cannot win on its own. Only a player without one needs telling.
     return (
-      <>
-        {/* The explanation names who knocked them out and by how much, so it says
-            they cannot win on its own. Only a player without one needs telling. */}
-        <Message
-          lines={[
-            result.explanation ?? `${result.player} cannot win this week.`,
-          ]}
-        />
-      </>
+      <Message
+        lines={[result.explanation ?? `${result.player} cannot win this week.`]}
+      />
     );
   }
 
   if (result.kind === "clinched") {
+    // The standing calls a clinched player the winner without saying of what, so
+    // this names the week. Only a week still running needs the line under it,
+    // since a week with nothing left to play cannot be undone.
     return (
-      <>
-        {/* The standing calls a clinched player the winner without saying of what,
-            so this names the week. Only a week still running needs the line
-            under it, since a week with nothing left to play cannot be undone. */}
-        <Message
-          lines={[
-            `${result.player} has won ${week != null ? `week ${week}` : "the week"}.`,
-            isOver ? undefined : "Nothing still to be played can take it away.",
-          ]}
-        />
-      </>
+      <Message
+        lines={[
+          `${result.player} has won ${week != null ? `week ${week}` : "the week"}.`,
+          isOver ? undefined : "Nothing still to be played can take it away.",
+        ]}
+      />
     );
   }
 
@@ -443,8 +431,9 @@ function Body({
 /**
  * The whole answer to a player: where they stand, then what that leaves them.
  *
- * The standing is drawn here rather than beside this, because there is one headline
- * slot and one component has to own it.
+ * The standing belongs to this component rather than to the dialog around it,
+ * because there is one headline slot and two components rendering it can put two
+ * headlines on screen at once.
  */
 export default function AnalysisSummary({
   scores,
@@ -467,13 +456,13 @@ export default function AnalysisSummary({
   if (player == null && result == null) return null;
 
   return (
-    <Answer>
+    <div className="analysis">
       <Standing scores={scores} player={player} result={result} />
       {result != null && (
         <div className="analysis__body">
           <Body result={result} isOver={isOver} week={week} />
         </div>
       )}
-    </Answer>
+    </div>
   );
 }

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.scss
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.scss
@@ -141,7 +141,6 @@
   // Held to the width of the search above it, so a long name is cut short rather
   // than widening the popup past the input it hangs off.
   max-width: var(--anchor-width);
-  max-height: min(240px, var(--available-height));
 }
 
 // An entry carries the status icon the tables give the same player, in the hue
@@ -274,10 +273,12 @@ $bar-height: 2px;
     border-radius: var(--rak-radius-lg);
     transform: translate(-50%, -50%);
 
+    // The fade alone, at the transform it rests at, so the window opens where it
+    // will stand rather than travelling into place.
     &[data-starting-style],
     &[data-ending-style] {
       opacity: 0;
-      transform: translate(-50%, -46%);
+      transform: translate(-50%, -50%);
     }
   }
 }

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.scss
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.scss
@@ -132,7 +132,6 @@
 .player-analysis__positioner {
   // Above the dialog it opens inside of, which the backdrop already sits under.
   z-index: calc(var(--rak-z-modal) + 2);
-  max-height: var(--available-height);
 }
 
 .player-analysis__list {
@@ -197,14 +196,6 @@
   // The room a scrollbar needs, held whether or not there is one, so an answer
   // long enough to scroll does not narrow the one that was on screen before it.
   scrollbar-gutter: stable;
-}
-
-// The standing reads as a title over what follows, so it sits the same distance
-// from it as a section title sits from its own contents.
-.player-analysis__content {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
 }
 
 // A bar on the rule above it while the next answer is worked out, in place of

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
@@ -115,10 +115,9 @@ describe("PlayerAnalysisDialog", () => {
     expect(
       screen.getByRole("progressbar", { name: "Working out the paths" }),
     ).toHaveAttribute("aria-busy", "true");
-    expect(document.querySelector(".player-analysis__content")).toHaveAttribute(
-      "aria-live",
-      "polite",
-    );
+    expect(
+      document.querySelector(".player-analysis__body [aria-live]"),
+    ).toHaveAttribute("aria-live", "polite");
 
     // The search runs a frame after the bar that says it is under way.
     const mustWin = await screen.findByRole("heading", { name: "Must win" });
@@ -143,6 +142,40 @@ describe("PlayerAnalysisDialog", () => {
     expect(
       await screen.findByText("Knocked out on Total Score by Alice."),
     ).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Player" })).toHaveValue(
+      "Bobby",
+    );
+
+    // Closing takes that name away again. Nothing here goes with it, since the
+    // answer and the search are still on screen for as long as the fade runs.
+    rerender(
+      <PlayerAnalysisDialog
+        open
+        onOpenChange={() => undefined}
+        scores={scores}
+      />,
+    );
+
+    expect(screen.getByRole("combobox", { name: "Player" })).toHaveValue(
+      "Bobby",
+    );
+    expect(
+      screen.getByText("Knocked out on Total Score by Alice."),
+    ).toBeInTheDocument();
+
+    // Opened on that same player twice running, with something half typed into the
+    // search in between. The name arriving is still a change, so it wins.
+    await user.clear(screen.getByRole("combobox", { name: "Player" }));
+    await user.type(screen.getByRole("combobox", { name: "Player" }), "Ali");
+    rerender(
+      <PlayerAnalysisDialog
+        open
+        onOpenChange={() => undefined}
+        player="Bobby"
+        scores={scores}
+      />,
+    );
+
     expect(screen.getByRole("combobox", { name: "Player" })).toHaveValue(
       "Bobby",
     );

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -10,7 +10,7 @@ import isWeekOver from "../../utils/scoring/isWeekOver";
 import Button from "../button/Button";
 import { CloseRoundedIcon, UnfoldMoreIcon } from "../icon/Icon";
 import PlayerStatusIcon from "../table/playerName/PlayerStatusIcon";
-import AnalysisSummary, { Standing } from "./AnalysisSummary";
+import AnalysisSummary from "./AnalysisSummary";
 import "./PlayerAnalysisDialog.scss";
 
 export type PlayerOption = { name: string; isKnockedOut: boolean };
@@ -76,10 +76,20 @@ export default function PlayerAnalysisDialog({
   // A name arriving from outside stands in for a choice made in the search. Taken
   // during the render that brings it, so the answer is worked out in the same pass
   // rather than a beat behind it.
-  const [lastNamed, setLastNamed] = useState(named);
-  if (named !== lastNamed) {
-    setLastNamed(named);
-    setPlayer(options.find((option) => option.name === named));
+  //
+  // Only an arrival is acted on. The name is cleared as the dialog closes, and
+  // taking that would empty the dialog while it is still fading out. `arrivals`
+  // counts them rather than naming the latest, so opening on the same player twice
+  // running is still a change the combobox below can see.
+  const [arrival, setArrival] = useState({ named, arrivals: 0 });
+  if (named !== arrival.named) {
+    setArrival({
+      named,
+      arrivals: named != null ? arrival.arrivals + 1 : arrival.arrivals,
+    });
+    if (named != null) {
+      setPlayer(options.find((option) => option.name === named));
+    }
   }
 
   // The search is thousands of scenarios and holds the thread while it runs, so
@@ -135,7 +145,7 @@ export default function PlayerAnalysisDialog({
             // name in the input. The combobox keeps the choice itself, and handing
             // it a value it started without reads as a controlled input arriving
             // late, so a fresh one starts on the right player instead.
-            key={named ?? ""}
+            key={arrival.arrivals}
             defaultValue={player}
             items={options}
             filteredItems={playersMatching(options, query)}
@@ -217,17 +227,14 @@ export default function PlayerAnalysisDialog({
             {/* Polite, so a new answer replacing the last one is read once the
                 screen reader is free rather than cutting off what it is saying. */}
             <div className="player-analysis__content" aria-live="polite">
-              {/* Read off the scores, so it answers for the player picked before
-                  their routes have been worked out. */}
-              <Standing
-                scores={scores}
-                player={player?.name}
-                result={shown?.paths}
-              />
-              {/* Keyed on the player, so the answer to a new one plays in rather
-                  than replacing the last one in place. */}
+              {/* The standing heads the answer and is read off the scores, so it
+                  says where the player picked stands before their routes have been
+                  worked out. Keyed on the player, so the answer to a new one plays
+                  in rather than replacing the last one in place. */}
               <AnalysisSummary
                 key={shown?.name}
+                scores={scores}
+                player={player?.name}
                 result={shown?.paths}
                 isOver={isOver}
                 week={week}

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -229,10 +229,8 @@ export default function PlayerAnalysisDialog({
             <div className="player-analysis__content" aria-live="polite">
               {/* The standing heads the answer and is read off the scores, so it
                   says where the player picked stands before their routes have been
-                  worked out. Keyed on the player, so the answer to a new one plays
-                  in rather than replacing the last one in place. */}
+                  worked out. */}
               <AnalysisSummary
-                key={shown?.name}
                 scores={scores}
                 player={player?.name}
                 result={shown?.paths}

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -117,8 +117,8 @@ export default function PlayerAnalysisDialog({
   // dialog emptying and filling again. Only a rescore takes it away.
   const shown = found?.scores === scores ? found : undefined;
   const isSearching = player != null && shown?.name !== player.name;
-  // The same question `Standing` asks, off the same scores and the same predicate,
-  // so the header and the answer under it can never disagree about the week.
+  // Asked off the same scores and the same predicate the standing uses, so the two
+  // can never disagree about whether the week is done.
   const isOver = isWeekOver(scores?.scores ?? []);
 
   return (
@@ -226,10 +226,7 @@ export default function PlayerAnalysisDialog({
             )}
             {/* Polite, so a new answer replacing the last one is read once the
                 screen reader is free rather than cutting off what it is saying. */}
-            <div className="player-analysis__content" aria-live="polite">
-              {/* The standing heads the answer and is read off the scores, so it
-                  says where the player picked stands before their routes have been
-                  worked out. */}
+            <div aria-live="polite">
               <AnalysisSummary
                 scores={scores}
                 player={player?.name}

--- a/src/components/results/CurrentWeekRedirect.tsx
+++ b/src/components/results/CurrentWeekRedirect.tsx
@@ -23,17 +23,17 @@ export default function CurrentWeekRedirect({ view }: { view: ScoresView }) {
   if (!isWeekInfoLoading) {
     // The schedule lookup failed and already said so in its own toast, or the
     // season has no week to show. Home, as the week route guard does for both.
+    // `seasonYear` is set alongside the weeks, so it names the season those weeks
+    // describe by the time there are any.
     if (weeks == null || currentWeek == null) {
       return <Navigate to="/" replace />;
     }
-    if (seasonYear != null) {
-      return (
-        <Navigate
-          to={`/${seasonYear}/${currentWeek}/${view.toLowerCase()}`}
-          replace
-        />
-      );
-    }
+    return (
+      <Navigate
+        to={`/${seasonYear}/${currentWeek}/${view.toLowerCase()}`}
+        replace
+      />
+    );
   }
 
   return <ResultsFrame view={view} />;

--- a/src/components/results/CurrentWeekRedirect.tsx
+++ b/src/components/results/CurrentWeekRedirect.tsx
@@ -11,7 +11,8 @@ import ResultsFrame from "./ResultsFrame";
  * about to start, which has no picks and would land on a week with nothing in it.
  * `AppDataContext` already asks for the right season, so this only has to wait
  * for its schedule. A season that has finished has all of its weeks behind it, so
- * its current week is its last.
+ * its current week is its last. A season whose opener is still ahead has no such
+ * week, and goes home instead.
  *
  * Shows the wireframe while it waits, because it cannot know where it is going
  * until that schedule has arrived.
@@ -20,12 +21,12 @@ export default function CurrentWeekRedirect({ view }: { view: ScoresView }) {
   const { seasonYear, currentWeek, weeks, isWeekInfoLoading } = useAppData();
 
   if (!isWeekInfoLoading) {
-    // The schedule lookup failed, and already said so in its own toast. Home is
-    // where the week route guard sends people for the same reason.
-    if (weeks == null) {
+    // The schedule lookup failed and already said so in its own toast, or the
+    // season has no week to show. Home, as the week route guard does for both.
+    if (weeks == null || currentWeek == null) {
       return <Navigate to="/" replace />;
     }
-    if (seasonYear != null && currentWeek != null) {
+    if (seasonYear != null) {
       return (
         <Navigate
           to={`/${seasonYear}/${currentWeek}/${view.toLowerCase()}`}

--- a/src/context/AppDataContext.tsx
+++ b/src/context/AppDataContext.tsx
@@ -121,18 +121,19 @@ export function AppDataContextProvider({
   // That season's weeks are scored from a spreadsheet the user uploads until its
   // picks reach the database, and leaving it out puts the week they are holding
   // out of reach. Falling back to the season the week list describes keeps the
-  // picker usable where neither could be fetched, which is every `make run`.
-  const { seasonYear } = leagueWeeks;
+  // picker usable where neither could be fetched, which is every `make run`, so
+  // long as that season has a week behind it to score.
+  const { seasonYear, currentWeek } = leagueWeeks;
   const selectableSeasons = useMemo(() => {
     const offered = new Set(picksSeasons.seasons ?? []);
     if (currentSeason != null) {
       offered.add(currentSeason);
     }
-    if (offered.size === 0 && seasonYear != null) {
+    if (offered.size === 0 && seasonYear != null && currentWeek != null) {
       offered.add(seasonYear);
     }
     return [...offered].sort((a, b) => b - a);
-  }, [picksSeasons.seasons, currentSeason, seasonYear]);
+  }, [picksSeasons.seasons, currentSeason, seasonYear, currentWeek]);
 
   const value = useMemo(
     () => ({

--- a/src/context/AppDataContext.tsx
+++ b/src/context/AppDataContext.tsx
@@ -91,9 +91,9 @@ export function AppDataContextProvider({
 
   const picksSeasons = usePicksSeasons();
   const currentSeason = useCurrentSeason();
-  // The newest season with picks, unless the URL or the picker named one. ESPN
-  // moves on to the season about to start as soon as the last one ends, and that
-  // season has nothing to show, so it is offered below rather than opened on.
+  // The newest season with picks, unless the URL or the picker named one. Never
+  // the season ESPN calls current between the Super Bowl and the opener: nothing
+  // of it has been played, so `useCurrentSeason` withholds it too.
   const requestedSeason = selectedSeason ?? picksSeasons.seasons?.[0];
   const leagueWeeks = useLeagueWeeks(
     route.week,

--- a/src/hooks/CLAUDE.md
+++ b/src/hooks/CLAUDE.md
@@ -4,7 +4,7 @@ The app's data layer, and the two hooks that measure the page. The first four mo
 once, in `AppDataContext`, above the routes.
 
 - `usePicksSeasons`: the seasons that have picks, from `/api/picks`, newest first
-- `useCurrentSeason`: the season running now, asked of ESPN
+- `useCurrentSeason`: the season running now, once it starts
 - `useLeagueWeeks`: the season's weeks from ESPN, and which one is selected
 - `usePlayerScores`: a week's scores from the API, cache, or an uploaded file.
   Owns the refresh throttle

--- a/src/hooks/useCurrentSeason.ts
+++ b/src/hooks/useCurrentSeason.ts
@@ -6,9 +6,9 @@ import getLeagueInfo from "../utils/getLeagueInfo";
  * The season running now, by the year it started in, once it has begun.
  *
  * Asked for on its own, because the season list holds only the seasons with picks
- * in the database, and the picker has to offer this one whether or not it has any.
- * A week of it with no picks behind it is scored from a spreadsheet the user
- * uploads, which is what that path is for.
+ * in the database, and the picker has to offer this one once it starts whether or
+ * not it has any. A week of it with no picks behind it is scored from a spreadsheet
+ * the user uploads, which is what that path is for.
  *
  * ESPN moves on to the next season as soon as the last one ends, months before
  * anything is played. That season has no week anybody could score, so it is left
@@ -24,12 +24,8 @@ export default function useCurrentSeason() {
       try {
         // No season named, so ESPN answers with the one running now.
         const proLeagueInfo = await getLeagueInfo(League.PRO);
-        if (isCurrent) {
-          setCurrentSeason(
-            proLeagueInfo?.activeWeek != null
-              ? proLeagueInfo.season
-              : undefined,
-          );
+        if (isCurrent && proLeagueInfo?.activeWeek != null) {
+          setCurrentSeason(proLeagueInfo.season);
         }
       } catch (error) {
         console.warn("Could not work out the season running now", error);

--- a/src/hooks/useCurrentSeason.ts
+++ b/src/hooks/useCurrentSeason.ts
@@ -3,16 +3,17 @@ import { League } from "../types/League";
 import getLeagueInfo from "../utils/getLeagueInfo";
 
 /**
- * The season running now, by the year it started in.
+ * The season running now, by the year it started in, once it has begun.
  *
  * Asked for on its own, because the season list holds only the seasons with picks
  * in the database, and the picker has to offer this one whether or not it has any.
  * A week of it with no picks behind it is scored from a spreadsheet the user
  * uploads, which is what that path is for.
  *
- * Left undefined where ESPN cannot be reached. The picker then falls back to the
- * seasons it does know about, so a failure here costs the current season its place
- * in the list and nothing else.
+ * ESPN moves on to the next season as soon as the last one ends, months before
+ * anything is played. That season has no week anybody could score, so it is left
+ * undefined until its opener, as is a season ESPN could not be asked about at all.
+ * The picker then offers the seasons it does know about and nothing else.
  */
 export default function useCurrentSeason() {
   const [currentSeason, setCurrentSeason] = useState<number>();
@@ -24,7 +25,11 @@ export default function useCurrentSeason() {
         // No season named, so ESPN answers with the one running now.
         const proLeagueInfo = await getLeagueInfo(League.PRO);
         if (isCurrent) {
-          setCurrentSeason(proLeagueInfo?.season);
+          setCurrentSeason(
+            proLeagueInfo?.activeWeek != null
+              ? proLeagueInfo.season
+              : undefined,
+          );
         }
       } catch (error) {
         console.warn("Could not work out the season running now", error);

--- a/src/hooks/useLeagueWeeks.ts
+++ b/src/hooks/useLeagueWeeks.ts
@@ -72,10 +72,11 @@ export default function useLeagueWeeks(
       }
       const calendarWeeks = proLeagueInfo.activeCalendar.weeks;
       setWeeks(calendarWeeks);
-      setCurrentWeek(proLeagueInfo.activeWeek.value);
+      setCurrentWeek(proLeagueInfo.activeWeek?.value);
       setSeasonYear(proLeagueInfo.season);
       // The week the URL named, or the one the season has reached. That is the
-      // last regular week once the season is over.
+      // last regular week once the season is over, and none at all until its
+      // opener has been played.
       setSelectedWeek(
         calendarWeeks.find((week) => week.value === initialWeekRef.current) ??
           proLeagueInfo.activeWeek,
@@ -95,9 +96,11 @@ export default function useLeagueWeeks(
   const isWeekInfoLoading =
     !enabled || isLookupPending || (season != null && season !== seasonYear);
 
-  // Newest first, and never a week the season has not reached.
+  // Newest first, and never a week the season has not reached. Held apart from
+  // the slice, which reads a missing end as the whole array.
   const selectableWeeks = useMemo(
-    () => (weeks ?? []).slice(0, currentWeek).reverse(),
+    () =>
+      currentWeek == null ? [] : (weeks ?? []).slice(0, currentWeek).reverse(),
     [weeks, currentWeek],
   );
 

--- a/src/hooks/useLeagueWeeks.ts
+++ b/src/hooks/useLeagueWeeks.ts
@@ -96,11 +96,11 @@ export default function useLeagueWeeks(
   const isWeekInfoLoading =
     !enabled || isLookupPending || (season != null && season !== seasonYear);
 
-  // Newest first, and never a week the season has not reached. Held apart from
-  // the slice, which reads a missing end as the whole array.
+  // Newest first, and never a week the season has not reached. A season with no
+  // week behind it offers none, which is what the 0 stands for: `slice` would read
+  // a missing end as the whole array.
   const selectableWeeks = useMemo(
-    () =>
-      currentWeek == null ? [] : (weeks ?? []).slice(0, currentWeek).reverse(),
+    () => (weeks ?? []).slice(0, currentWeek ?? 0).reverse(),
     [weeks, currentWeek],
   );
 

--- a/src/styles/_listbox.scss
+++ b/src/styles/_listbox.scss
@@ -3,9 +3,21 @@
 // dialog. Mixins only, so this emits no CSS of its own however many files pull it
 // in. Each caller adds what makes its own list different.
 
+// The most rows any of these lists shows before it scrolls.
+$-max-rows: 5;
+
 @mixin listbox-popup {
   box-sizing: border-box;
   min-width: var(--anchor-width);
+  // A count of rows is a height, because every row is a touch target. The rules
+  // between them and the padding either end of the popup make up the rest.
+  max-height: min(
+    calc(
+      #{$-max-rows} * var(--rak-touch-target) + #{$-max-rows - 1} *
+        var(--rak-border-width-hairline) + 2 * var(--rak-space-1)
+    ),
+    var(--available-height, 100dvh)
+  );
   overflow-y: auto;
   padding: var(--rak-space-1) 0;
   border: var(--rak-border-width-hairline) solid var(--rak-border);

--- a/src/types/League.ts
+++ b/src/types/League.ts
@@ -37,6 +37,10 @@ export type LeagueInfo = {
    */
   season: number;
   activeCalendar: LeagueCalendar;
-  activeWeek: WeekInfo;
+  /**
+   * The week being played now, or the last one that has begun. Absent where the
+   * season's opener is still ahead, which means no week of it can be scored yet.
+   */
+  activeWeek?: WeekInfo;
   calendars: LeagueCalendar[];
 };

--- a/src/utils/getLeagueInfo.test.ts
+++ b/src/utils/getLeagueInfo.test.ts
@@ -181,7 +181,7 @@ describe("getLeagueInfo, calendar mapping", () => {
     vi.setSystemTime(new Date("2025-05-01T00:00Z"));
     const info = await infoFor(League.COLLEGE);
     expect(info.activeCalendar.seasonType).toBe(SeasonType.REGULAR);
-    expect(info.activeWeek.value).toBe(18);
+    expect(info.activeWeek?.value).toBe(18);
   });
 
   it("falls back to the last college calendar outside every date range", async () => {
@@ -196,14 +196,28 @@ describe("getLeagueInfo, active week", () => {
   it("picks the week containing today", async () => {
     mockFetch(scoreboard(League.PRO));
     const info = await infoFor(League.PRO);
-    expect(info.activeWeek.value).toBe(5);
+    expect(info.activeWeek?.value).toBe(5);
   });
 
-  it("falls back to the last week when today is outside every week", async () => {
+  it("holds the last week that has begun between two weeks", async () => {
     vi.setSystemTime(new Date("2024-11-15T00:00Z"));
     mockFetch(scoreboard(League.PRO));
     const info = await infoFor(League.PRO);
-    expect(info.activeWeek.value).toBe(18);
+    expect(info.activeWeek?.value).toBe(5);
+  });
+
+  it("holds the last week of the season once it is over", async () => {
+    vi.setSystemTime(new Date("2025-06-01T00:00Z"));
+    mockFetch(scoreboard(League.PRO));
+    const info = await infoFor(League.PRO);
+    expect(info.activeWeek?.value).toBe(18);
+  });
+
+  it("has no active week before the season's opener", async () => {
+    vi.setSystemTime(new Date("2024-08-01T00:00Z"));
+    mockFetch(scoreboard(League.PRO));
+    const info = await infoFor(League.PRO);
+    expect(info.activeWeek).toBeUndefined();
   });
 });
 

--- a/src/utils/getLeagueInfo.ts
+++ b/src/utils/getLeagueInfo.ts
@@ -158,21 +158,19 @@ async function fetchLeagueInfo(
           );
         });
 
-  // The week being played now, or the last one begun once the season is over.
-  // `findLast` would say this in one call, but it is ES2023 and this builds to
-  // ES2022.
-  const activeWeek = activeCalendar?.weeks
-    .filter((week) => week.startDate <= now)
-    .at(-1);
-
-  // The calendar lookup falls back to the last entry, so it only comes back empty
-  // when the response carried no calendar with any weeks in it.
   if (activeCalendar == null) {
     console.error(
       `Scoreboard response has no dated calendar for league ${league}`,
     );
     return null;
   }
+
+  // The week being played now, or the last one begun once the season is over. A
+  // season whose opener is still ahead has none. `findLast` would say this in one
+  // call, but it is ES2023 and this builds to ES2022.
+  const activeWeek = activeCalendar.weeks
+    .filter((week) => week.startDate <= now)
+    .at(-1);
 
   return {
     league,

--- a/src/utils/getLeagueInfo.ts
+++ b/src/utils/getLeagueInfo.ts
@@ -158,20 +158,18 @@ async function fetchLeagueInfo(
           );
         });
 
-  // Find the active week for the current date/time, if applicable.
-  // Fall back to the last week in the active calendar.
-  const activeWeek = activeCalendar?.weeks.find((week, index) => {
-    return (
-      (week.startDate <= now && week.endDate >= now) ||
-      index === activeCalendar.weeks.length - 1
-    );
-  });
+  // The week being played now, or the last one begun once the season is over.
+  // `findLast` would say this in one call, but it is ES2023 and this builds to
+  // ES2022.
+  const activeWeek = activeCalendar?.weeks
+    .filter((week) => week.startDate <= now)
+    .at(-1);
 
-  // Both lookups fall back to the last entry, so they only come back empty when
-  // the response carried no calendars or no weeks at all.
-  if (activeCalendar == null || activeWeek == null) {
+  // The calendar lookup falls back to the last entry, so it only comes back empty
+  // when the response carried no calendar with any weeks in it.
+  if (activeCalendar == null) {
     console.error(
-      `Scoreboard response has no active week for league ${league}`,
+      `Scoreboard response has no dated calendar for league ${league}`,
     );
     return null;
   }


### PR DESCRIPTION
## What

The analysis dialog, every popup list's height, and the home page's pickers and
loading sheen.

## Why

Opening the dialog drew a scrollbar over the answer and moved it, and closing it
resized the window mid fade. Every week of the 2026 season was selectable.

## Changes

- A transform inside `.player-analysis__body` counts against that body's
  scrollable overflow, so the answer no longer travels. Its fade is gone too: it
  read as a flicker between players.
- The standing is drawn inside the answer's own wrapper. Two components owning one
  headline slot is how a stale "Winner" and a fresh "Knocked out" shared a popup.
- The dialog acts only on a player arriving, not on the clearing that closing
  does, so nothing unmounts mid fade.
- The headline takes the blue the tables mark a player in contention with, or
  their orange for a knockout.
- `getLeagueInfo` takes the last week that has begun, and `activeWeek` is now
  optional. `selectableWeeks` guards it: `slice(0, undefined)` copies everything.
- Five rows lives in the shared `listbox-popup` mixin. Base UI otherwise sizes a
  select's popup to cover its trigger, hence `alignItemWithTrigger={false}`.
- The home buttons take the shared `busy` prop.

🕵️ Intercepted by [Agent Carmen Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
