### PR TITLE
fix(api): revalidate a week's picks instead of caching them forever

### DIFF
--- a/functions/api/picks/[year]/[week].ts
+++ b/functions/api/picks/[year]/[week].ts
@@ -3,6 +3,14 @@ type Env = {
 };
 
 /**
+ * An hour of reuse, then the browser asks whether its copy still stands. A week's
+ * picks are rewritten when the sheet turns out to carry an error, and the URL for
+ * them never changes, so a copy that can outlive a correction has to be able to
+ * find out about one.
+ */
+const CACHE_CONTROL = "public, max-age=3600, must-revalidate";
+
+/**
  * One week's picks workbook, from the season that started in `year`. A season
  * runs into the following January, so the 2025 season's week 18 was played in
  * January 2026 and is still filed under 2025.
@@ -14,18 +22,41 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     return new Response("Not Found", { status: 404 });
   }
 
+  // Only this one header, rather than the request's own: R2 reads every
+  // conditional in whatever it is handed, and the rest belong to requests this
+  // route has no answer for.
+  const conditional = new Headers();
+  const ifNoneMatch = context.request.headers.get("If-None-Match");
+  if (ifNoneMatch != null) {
+    conditional.set("If-None-Match", ifNoneMatch);
+  }
+
   // Get the spreadsheet from R2.
   const filePath = `picks/${year}/${week}.xlsx`;
   console.log(`Fetching picks for ${year} week ${week} from ${filePath}`);
   let spreadsheet;
   try {
-    spreadsheet = await context.env.RAK_MADNESS_BUCKET.get(filePath);
+    spreadsheet = await context.env.RAK_MADNESS_BUCKET.get(filePath, {
+      onlyIf: conditional,
+    });
   } catch (error) {
     console.error("Failed to fetch picks", error);
     return new Response("Service Unavailable", { status: 503 });
   }
   if (!spreadsheet) {
     return new Response("Not Found", { status: 404 });
+  }
+
+  // R2 answers a condition it did not meet with the object and no body, which is
+  // what says the caller's copy is the current one.
+  if (!("body" in spreadsheet)) {
+    return new Response(null, {
+      status: 304,
+      headers: {
+        ETag: spreadsheet.httpEtag,
+        "Cache-Control": CACHE_CONTROL,
+      },
+    });
   }
 
   return new Response(spreadsheet.body, {
@@ -36,8 +67,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       "Content-Type":
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
       "Content-Disposition": `attachment; filename=${year}-week-${week}-picks.xlsx`,
-      // A given year and week's picks never change once uploaded.
-      "Cache-Control": "public, max-age=31536000, immutable",
+      ETag: spreadsheet.httpEtag,
+      "Cache-Control": CACHE_CONTROL,
     },
   });
 };


### PR DESCRIPTION
## What

`/api/picks/<year>/<week>` now serves an ETag and revalidates, instead of telling every client the workbook can never change.

## Why

A week's picks get rewritten in the bucket when the sheet turns out to carry an error. Nine weeks across 2023 and 2024 were corrected this way today. The URL stays the same, so an `immutable` copy keeps scoring the broken sheet for a year.

## Changes

- One hour of free reuse, then `must-revalidate`. A correction reaches everyone within the hour.
- `If-None-Match` is copied into a fresh `Headers` and passed to R2 as `onlyIf`, so no other conditional on the request reaches the bucket.
- R2 returns the object with no body when the condition fails, which is what the 304 branch reads.

## Verification

Exercised against `wrangler pages dev` with a seeded local bucket: matching, weak, listed, and stale `If-None-Match` values, plus a rewritten object breaking the caller's old ETag.

## Notes / Follow-ups

Clients that already hold an `immutable` copy of the nine corrected weeks never revalidate. Those still need a cache purge.
