### PR TITLE
fix(playerAnalysis): clear the search on a tap, and stand it off the keyboard

### DIFF
--- a/src/components/playerAnalysis/PlayerAnalysisDialog.scss
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.scss
@@ -27,6 +27,12 @@
 // without shrinking `dvh`, so the sheet stands on top of the keyboard rather than
 // running on behind it, and is capped by what is left rather than by the screen.
 // Every one falls back to the whole screen, which is where they started.
+
+// How far the lowest thing in the sheet stands off the keyboard. The answer gives
+// up its room before the search does, so with a long answer squeezed out this is
+// what keeps the rule under the search off the keyboard's top edge.
+$keyboard-gap: 12px;
+
 .player-analysis__popup {
   position: fixed;
   z-index: calc(var(--rak-z-modal) + 1);
@@ -40,10 +46,12 @@
   max-height: min(85dvh, var(--rak-viewport-height, 85dvh));
   padding: 20px;
   // Room for the home indicator, given back once the sheet is standing on a
-  // keyboard rather than on the bottom edge the indicator is drawn over.
+  // keyboard rather than on the bottom edge the indicator is drawn over, which
+  // takes the gap above the keyboard in its place.
   padding-bottom: calc(
     20px +
-      max(0px, env(safe-area-inset-bottom) - var(--rak-keyboard-inset, 0px))
+      max(0px, env(safe-area-inset-bottom) - var(--rak-keyboard-inset, 0px)) +
+      min(var(--rak-keyboard-inset, 0px), #{$keyboard-gap})
   );
   border-radius: var(--rak-radius-lg) var(--rak-radius-lg) 0 0;
   background-color: var(--rak-surface);

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
@@ -197,5 +197,21 @@ describe("PlayerAnalysisDialog", () => {
     expect(
       screen.getByText("Knocked out on Total Score by Alice."),
     ).toBeInTheDocument();
+
+    // Dismissing puts the chosen name back, since the answer below is still that
+    // player's.
+    await user.keyboard("{Escape}");
+    expect(screen.getByRole("combobox", { name: "Player" })).toHaveValue(
+      "Bobby",
+    );
+
+    // Only a press empties the search. A letter typed into it opens the list too,
+    // and wiping on that would take the letter that opened it. Typed straight at
+    // the focused input, since `user.type` clicks first and would open by press.
+    await user.keyboard("x");
+
+    expect(screen.getByRole("combobox", { name: "Player" })).toHaveValue(
+      "Bobbyx",
+    );
   });
 });

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
@@ -179,5 +179,23 @@ describe("PlayerAnalysisDialog", () => {
     expect(screen.getByRole("combobox", { name: "Player" })).toHaveValue(
       "Bobby",
     );
+
+    // Typing above left the list open, which in the app it never is when a name
+    // arrives: the dialog is modal, so the table that names one is out of reach
+    // until it closes and takes the search with it.
+    await user.keyboard("{Escape}");
+
+    // Tapping the search is the start of looking someone else up, so the name in
+    // it goes and everyone is offered again. The answer stays on the player it was
+    // opened on until another one is picked.
+    await user.click(screen.getByRole("combobox", { name: "Player" }));
+
+    expect(screen.getByRole("combobox", { name: "Player" })).toHaveValue("");
+    expect(
+      (await screen.findAllByRole("option")).map((it) => it.textContent),
+    ).toEqual(["Alice", "Bob", "Bobby"]);
+    expect(
+      screen.getByText("Knocked out on Total Score by Alice."),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -77,17 +77,13 @@ export default function PlayerAnalysisDialog({
   // rather than a beat behind it.
   //
   // Only an arrival is acted on. The name is cleared as the dialog closes, and
-  // taking that would empty the dialog while it is still fading out. `arrivals`
-  // counts them rather than naming the latest, so opening on the same player twice
-  // running is still a change the combobox below can see.
-  const [arrival, setArrival] = useState({ named, arrivals: 0 });
-  if (named !== arrival.named) {
-    setArrival({
-      named,
-      arrivals: named != null ? arrival.arrivals + 1 : arrival.arrivals,
-    });
+  // taking that would empty the dialog while it is still fading out.
+  const [arrived, setArrived] = useState(named);
+  if (named !== arrived) {
+    setArrived(named);
     if (named != null) {
       setPlayer(options.find((option) => option.name === named));
+      setQuery(named);
     }
   }
 
@@ -136,23 +132,38 @@ export default function PlayerAnalysisDialog({
             </Button>
           </header>
 
-          <Combobox.Root
-            // Remounted on a name arriving from outside, which is what puts that
-            // name in the input. The combobox keeps the choice itself, and handing
-            // it a value it started without reads as a controlled input arriving
-            // late, so a fresh one starts on the right player instead.
-            key={arrival.arrivals}
-            defaultValue={player}
+          {/*
+            Typed on `PlayerOption | null` rather than on `PlayerOption`, because
+            nobody is chosen until a name arrives and a controlled combobox has to
+            be handed something other than `undefined` from its first render.
+          */}
+          <Combobox.Root<PlayerOption | null>
+            // The choice and the text in the input are both held here rather than
+            // by the combobox, so a name arriving from outside can be taken without
+            // the combobox being torn down and rebuilt around it.
+            value={player ?? null}
             items={options}
             filteredItems={playersMatching(options, query)}
-            itemToStringLabel={(option: PlayerOption) => option.name}
+            itemToStringLabel={(option: PlayerOption | null) =>
+              option?.name ?? ""
+            }
             // Null arrives when the input is cleared to type another name. The
             // dialog is opened on a player and answers for one from then on, so
             // that clears the search rather than the answer under it.
             onValueChange={(chosen: PlayerOption | null) => {
               if (chosen != null) setPlayer(chosen);
             }}
+            // Base UI writes the chosen name back through this on the way out, so
+            // dismissing without picking anyone restores it.
+            inputValue={query}
             onInputValueChange={setQuery}
+            // Tapping the search is the start of looking someone else up, so the
+            // name already in it goes rather than being deleted by hand. Only a
+            // press: opening by typing reports `input-change`, and wiping that
+            // would take the letters that opened the list.
+            onOpenChange={(open, details) => {
+              if (open && details.reason === "trigger-press") setQuery("");
+            }}
             // The list is short and already on screen, so the first match being
             // highlighted saves an arrow key before Enter.
             autoHighlight

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -161,8 +161,8 @@ export default function PlayerAnalysisDialog({
             // name already in it goes rather than being deleted by hand. Only a
             // press: opening by typing reports `input-change`, and wiping that
             // would take the letters that opened the list.
-            onOpenChange={(open, details) => {
-              if (open && details.reason === "trigger-press") setQuery("");
+            onOpenChange={(listOpen, details) => {
+              if (listOpen && details.reason === "trigger-press") setQuery("");
             }}
             // The list is short and already on screen, so the first match being
             // highlighted saves an arrow key before Enter.

--- a/src/hooks/useViewportInsets.test.ts
+++ b/src/hooks/useViewportInsets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { viewportInsets } from "./useViewportInsets";
+import { sameInsets, viewportInsets } from "./useViewportInsets";
 
 const SCREEN = 800;
 
@@ -57,5 +57,23 @@ describe("viewportInsets", () => {
       offset: 0,
       keyboardInset: 0,
     });
+  });
+});
+
+describe("sameInsets", () => {
+  const measured = insets({ viewportHeight: 460, offsetTop: 120 });
+
+  it("says a keyboard still on its way is not settled", () => {
+    expect(sameInsets(insets({ viewportHeight: 600 }), measured)).toBe(false);
+  });
+
+  it("says a keyboard that stopped where it was is settled", () => {
+    expect(
+      sameInsets(measured, insets({ viewportHeight: 460, offsetTop: 120 })),
+    ).toBe(true);
+  });
+
+  it("has nothing to compare the first measurement against", () => {
+    expect(sameInsets(undefined, measured)).toBe(false);
   });
 });

--- a/src/hooks/useViewportInsets.ts
+++ b/src/hooks/useViewportInsets.ts
@@ -47,7 +47,10 @@ export function viewportInsets({
   };
 }
 
-/** Whether two measurements are the same, which is how the loop below stops. */
+/**
+ * Whether two measurements are the same, which is how the loop below stops and
+ * what keeps it from writing the same numbers back every frame.
+ */
 export function sameInsets(
   a: ViewportInsets | undefined,
   b: ViewportInsets,
@@ -91,17 +94,24 @@ export default function useViewportInsets(enabled: boolean): void {
     let last: ViewportInsets | undefined;
     let frame = 0;
 
-    const measure = (): ViewportInsets => {
+    // Answers whether the viewport held still, which is what the loop counts. The
+    // root is written only when it moved, so the frames either side of a keyboard
+    // cost a read and nothing else.
+    const measure = (): boolean => {
       const insets = viewportInsets({
         layoutHeight: window.innerHeight,
         viewportHeight: viewport.height,
         offsetTop: viewport.offsetTop,
         scale: viewport.scale,
       });
-      root.style.setProperty(VIEWPORT_HEIGHT_VAR, `${insets.height}px`);
-      root.style.setProperty(VIEWPORT_OFFSET_VAR, `${insets.offset}px`);
-      root.style.setProperty(KEYBOARD_INSET_VAR, `${insets.keyboardInset}px`);
-      return insets;
+      const held = sameInsets(last, insets);
+      last = insets;
+      if (!held) {
+        root.style.setProperty(VIEWPORT_HEIGHT_VAR, `${insets.height}px`);
+        root.style.setProperty(VIEWPORT_OFFSET_VAR, `${insets.offset}px`);
+        root.style.setProperty(KEYBOARD_INSET_VAR, `${insets.keyboardInset}px`);
+      }
+      return held;
     };
 
     // Restarted rather than stacked, so a second event partway through a keyboard
@@ -111,9 +121,7 @@ export default function useViewportInsets(enabled: boolean): void {
       let held = 0;
       const until = performance.now() + TRACKING_MS;
       const step = () => {
-        const insets = measure();
-        held = sameInsets(last, insets) ? held + 1 : 0;
-        last = insets;
+        held = measure() ? held + 1 : 0;
         if (held < SETTLED_FRAMES && performance.now() < until) {
           frame = requestAnimationFrame(step);
         }

--- a/src/hooks/useViewportInsets.ts
+++ b/src/hooks/useViewportInsets.ts
@@ -9,6 +9,12 @@ export const VIEWPORT_OFFSET_VAR = "--rak-viewport-offset";
 /** How much of the bottom edge something like a keyboard covers. */
 export const KEYBOARD_INSET_VAR = "--rak-keyboard-inset";
 
+export type ViewportInsets = {
+  height: number;
+  offset: number;
+  keyboardInset: number;
+};
+
 /**
  * What is on screen, out of what the layout is sized against.
  *
@@ -30,7 +36,7 @@ export function viewportInsets({
   viewportHeight: number;
   offsetTop: number;
   scale: number;
-}): { height: number; offset: number; keyboardInset: number } {
+}): ViewportInsets {
   if (scale > 1) {
     return { height: layoutHeight, offset: 0, keyboardInset: 0 };
   }
@@ -41,6 +47,25 @@ export function viewportInsets({
   };
 }
 
+/** Whether two measurements are the same, which is how the loop below stops. */
+export function sameInsets(
+  a: ViewportInsets | undefined,
+  b: ViewportInsets,
+): boolean {
+  return (
+    a != null &&
+    a.height === b.height &&
+    a.offset === b.offset &&
+    a.keyboardInset === b.keyboardInset
+  );
+}
+
+/** How long the same measurement has to hold for the keyboard to be done moving. */
+const SETTLED_FRAMES = 5;
+
+/** The longest the loop runs, in case something keeps the viewport moving. */
+const TRACKING_MS = 1000;
+
 /**
  * Publishes the visible viewport to the document root, so a stylesheet can size
  * against what the reader can actually see rather than the whole screen.
@@ -48,6 +73,14 @@ export function viewportInsets({
  * Held to while `enabled`, since the only thing that asks is a dialog with a
  * search in it, and the properties are dropped on the way out so everything
  * falls back to its `dvh` default.
+ *
+ * A keyboard opens over a few hundred milliseconds, and Safari reports that with
+ * far fewer events than there are frames in it, so listening alone leaves the
+ * sheet sitting behind the keyboard and then jumping clear. Anything that could
+ * be the start of one instead kicks off a frame by frame read of the viewport,
+ * which stops once the numbers hold still. The properties are written straight
+ * to the root rather than through React, so a frame's measurement paints in that
+ * frame.
  */
 export default function useViewportInsets(enabled: boolean): void {
   useEffect(() => {
@@ -55,25 +88,49 @@ export default function useViewportInsets(enabled: boolean): void {
     if (!enabled || viewport == null) return;
 
     const root = document.documentElement;
+    let last: ViewportInsets | undefined;
+    let frame = 0;
 
-    const measure = () => {
-      const { height, offset, keyboardInset } = viewportInsets({
+    const measure = (): ViewportInsets => {
+      const insets = viewportInsets({
         layoutHeight: window.innerHeight,
         viewportHeight: viewport.height,
         offsetTop: viewport.offsetTop,
         scale: viewport.scale,
       });
-      root.style.setProperty(VIEWPORT_HEIGHT_VAR, `${height}px`);
-      root.style.setProperty(VIEWPORT_OFFSET_VAR, `${offset}px`);
-      root.style.setProperty(KEYBOARD_INSET_VAR, `${keyboardInset}px`);
+      root.style.setProperty(VIEWPORT_HEIGHT_VAR, `${insets.height}px`);
+      root.style.setProperty(VIEWPORT_OFFSET_VAR, `${insets.offset}px`);
+      root.style.setProperty(KEYBOARD_INSET_VAR, `${insets.keyboardInset}px`);
+      return insets;
     };
 
-    measure();
-    viewport.addEventListener("resize", measure);
-    viewport.addEventListener("scroll", measure);
+    // Restarted rather than stacked, so a second event partway through a keyboard
+    // opening extends the read instead of running a loop of its own.
+    const track = () => {
+      cancelAnimationFrame(frame);
+      let held = 0;
+      const until = performance.now() + TRACKING_MS;
+      const step = () => {
+        const insets = measure();
+        held = sameInsets(last, insets) ? held + 1 : 0;
+        last = insets;
+        if (held < SETTLED_FRAMES && performance.now() < until) {
+          frame = requestAnimationFrame(step);
+        }
+      };
+      step();
+    };
+
+    track();
+    viewport.addEventListener("resize", track);
+    viewport.addEventListener("scroll", track);
+    // The first sign a keyboard is on its way, and earlier than any of the above.
+    window.addEventListener("focusin", track);
     return () => {
-      viewport.removeEventListener("resize", measure);
-      viewport.removeEventListener("scroll", measure);
+      cancelAnimationFrame(frame);
+      viewport.removeEventListener("resize", track);
+      viewport.removeEventListener("scroll", track);
+      window.removeEventListener("focusin", track);
       root.style.removeProperty(VIEWPORT_HEIGHT_VAR);
       root.style.removeProperty(VIEWPORT_OFFSET_VAR);
       root.style.removeProperty(KEYBOARD_INSET_VAR);


### PR DESCRIPTION
## What

Three fixes to the player search in the player analysis dialog, all felt on a phone.

## Why

Looking up a second player meant deleting the first one's name by hand. When the keyboard opened, the sheet sat behind it for a moment, then jumped clear and settled flush against its top edge.

## Changes

- The dialog holds the combobox's chosen player and input text, instead of Base UI holding them. Half-controlled, it had to be rebuilt around a name arriving from a table, and warned in the console about a default value changing after initialization.
- Only a press on the input empties it. Opening the list by typing reports `input-change`, and wiping that would take the letters that opened it.
- `useViewportInsets` reads the viewport every frame after a focus or a resize, until the numbers hold still. Safari reports a keyboard's animation with far fewer events than it has frames.
- `$keyboard-gap` is folded into the sheet's padding, so the rule under the search stands off the keyboard once a long answer is squeezed out.

## Verification

Phone viewport, keyboard inset stubbed: the answer ends 32px above the keyboard, up from 20px.
