### PR TITLE
fix(gameStatus): drop the keyboard on a choice, and hold the dash in the middle

### DIFF
--- a/src/components/dialog/CLAUDE.md
+++ b/src/components/dialog/CLAUDE.md
@@ -1,12 +1,13 @@
 # dialog
 
 The dialog the player analysis and the game status are shown in, and the search each
-is pointed with. Base UI ships both unstyled, so these stylesheets carry the look.
+is pointed with.
 
 - `DialogShell`: `Dialog.Root` down to the scrolling body. Takes a `search` holding
   still above the body's hairline rule, and `busy` for the bar drawn there.
-- `DialogShell.scss`: a bottom sheet, a centered modal at `wide-screen`. Sized and
-  padded against `useViewportInsets`, so a keyboard covers nothing and the sheet still
-  reaches the bottom edge. `--rak-dialog-inset` is what the bar sits on that rule by.
-- `DialogCombobox`: the controlled combobox, generic over its option. The caller holds
-  the choice and the query, so a subject from outside needs no rebuild.
+- `DialogShell.scss`: a bottom sheet, a centered modal at `wide-screen`, sized against
+  `useViewportInsets` so a keyboard covers nothing and the sheet still reaches the
+  bottom edge. `--rak-dialog-inset` stands the bar on the rule.
+- `DialogCombobox`: the controlled combobox, generic over its option, the caller holding
+  the choice and the query. Its list opens under the search, never over it. Choosing
+  hands the focus to the dialog, which drops a phone's keyboard.

--- a/src/components/dialog/DialogCombobox.tsx
+++ b/src/components/dialog/DialogCombobox.tsx
@@ -1,5 +1,5 @@
 import { Combobox } from "@base-ui-components/react/combobox";
-import { ReactNode } from "react";
+import { ReactNode, useRef } from "react";
 import { UnfoldMoreIcon } from "../icon/Icon";
 import "./DialogCombobox.scss";
 
@@ -43,6 +43,23 @@ export default function DialogCombobox<T>({
   adornment?: ReactNode;
   renderOption: (item: T) => ReactNode;
 }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  /**
+   * Choosing is the end of the search, so the input gives the focus up.
+   *
+   * A phone's keyboard covers the bottom of the screen while the input holds it,
+   * which is where the answer that was just chosen reads. The dialog itself takes
+   * the focus rather than nothing, so it is still what Escape and a screen reader
+   * are working in.
+   */
+  function releaseFocus() {
+    const input = inputRef.current;
+    const popup = input?.closest<HTMLElement>(".dialog__popup");
+    if (popup != null) popup.focus();
+    else input?.blur();
+  }
+
   return (
     /*
       Typed on `T | null` rather than on `T`, because nothing is chosen until a
@@ -60,7 +77,9 @@ export default function DialogCombobox<T>({
       // opened on a subject and answers for one from then on, so that clears the
       // search rather than the answer under it.
       onValueChange={(chosen: T | null) => {
-        if (chosen != null) onValueChange(chosen);
+        if (chosen == null) return;
+        onValueChange(chosen);
+        releaseFocus();
       }}
       // Base UI writes the chosen label back through this on the way out, so
       // dismissing without picking anything restores it.
@@ -79,6 +98,7 @@ export default function DialogCombobox<T>({
     >
       <div className="dialog__search">
         <Combobox.Input
+          ref={inputRef}
           placeholder={placeholder}
           aria-label={ariaLabel}
           className="dialog__input"
@@ -89,7 +109,20 @@ export default function DialogCombobox<T>({
         </Combobox.Icon>
       </div>
       <Combobox.Portal>
-        <Combobox.Positioner className="dialog__positioner" sideOffset={4}>
+        {/* Under the input and nowhere else. Flipped over it, the list would cover
+            the answer the dialog is open on, and on a phone it would come up under
+            the search only to be sat on by the keyboard. Squeezed for room it gives
+            up height instead, which the list scrolls. */}
+        <Combobox.Positioner
+          className="dialog__positioner"
+          side="bottom"
+          sideOffset={4}
+          collisionAvoidance={{
+            side: "none",
+            align: "shift",
+            fallbackAxisSide: "none",
+          }}
+        >
           <Combobox.Popup className="dialog__list">
             <Combobox.Empty className="dialog__empty">
               {emptyMessage}

--- a/src/components/gameStatus/CLAUDE.md
+++ b/src/components/gameStatus/CLAUDE.md
@@ -3,10 +3,11 @@
 How a game in the week is going, opened from a pick cell in the picks table.
 
 - `GameStatusDialog`: `DialogShell` over a `DialogCombobox` of `scores.games`, in picks
-  table column order. `gameSearchText` matches the column too, which is what a cell
-  said. `GameMark` says where a game stands; `useLiveGame` keeps the chosen one fresh.
-- `GameStatusSummary`: the pool's line, the game as ESPN's boxscore says it, and when
-  and where it is played. Both sides sit in one grid. The wireframe is that layout with
-  the week's own copy of the game in it, so it is the size the answer.
-- `GameStatusSummary.scss`: one block holds both scores, the status over them, the
-  down or the outcome under.
+  table column order, which the query matches too. `GameMark` says where a game stands;
+  `useLiveGame` keeps the chosen one fresh.
+- `GameStatusSummary`: the pool's line, the game as ESPN's boxscore says it, its kickoff
+  and its venue. The wireframe is that layout over the week's own copy of the game, so a
+  wait is the size of the answer.
+- `GameStatusSummary.scss`: both sides in one grid, the dash in a track between two
+  equal ones, so nothing either side moves it. `--rak-score-size` sizes that row; under
+  `$breakpoint-marks` the marks come off.

--- a/src/components/gameStatus/GameStatusDialog.test.tsx
+++ b/src/components/gameStatus/GameStatusDialog.test.tsx
@@ -283,6 +283,14 @@ describe("GameStatusDialog", () => {
     // over a tick, the one yet to start a calendar, and the column ESPN has no game
     // for a warning.
     await screen.findByRole("option", { name: /KC @ BUF/ });
+
+    // Under the search, whatever room is left below it, so the list never covers the
+    // game the dialog is already open on.
+    expect(screen.getByRole("listbox").closest("[data-side]")).toHaveAttribute(
+      "data-side",
+      "bottom",
+    );
+
     expect(
       screen.getAllByRole("option").map((option) =>
         within(option)
@@ -309,6 +317,11 @@ describe("GameStatusDialog", () => {
     ]);
 
     await user.click(screen.getByRole("option", { name: /MICH @ OSU/ }));
+
+    // Choosing ends the search, so a phone's keyboard comes down off the game that
+    // was just asked for. The dialog holds the focus rather than nothing.
+    expect(screen.getByRole("combobox", { name: "Game" })).not.toHaveFocus();
+    expect(document.activeElement).toHaveClass("dialog__popup");
 
     expect(getGameResultMock).toHaveBeenLastCalledWith(
       League.COLLEGE,

--- a/src/components/gameStatus/GameStatusSummary.scss
+++ b/src/components/gameStatus/GameStatusSummary.scss
@@ -27,10 +27,21 @@
   );
 }
 
+// How big the scores, the dash between them and the possession marks are set. Named
+// once here because the four have to grow and shrink together: they sit in one row,
+// and the room a phone has left over after them is what the two names get.
 .game-status {
+  --rak-score-size: 1.75rem;
+  --rak-marker-size: 1.75rem;
+
   display: flex;
   flex-direction: column;
   gap: var(--rak-space-4);
+
+  @include roomy-screen {
+    --rak-score-size: 2.5rem;
+    --rak-marker-size: 2.25rem;
+  }
 }
 
 // One sheen over the whole wireframe rather than one per bar, which is how the
@@ -65,7 +76,7 @@
 
   // Thicker, standing in for the one line here set big enough to carry its own weight.
   .game-status__points {
-    @include wireframe-bar(1.75rem);
+    @include wireframe-bar(1.5rem);
 
     @include roomy-screen {
       @include wireframe-bar(2.25rem);
@@ -148,11 +159,20 @@
 //
 // As big as the three lines of text beside it are tall, which is as much as either
 // can take without the name it stands over having to wrap sooner.
+// Left off the narrowest screens: what it takes out of the name and record beside it
+// breaks both across lines there, and a game reads better without it than with them
+// broken. The wireframe draws its circle by the same rule, so a wait is still the
+// size of the answer.
 .game-status__logo {
+  display: none;
   align-self: center;
   object-fit: contain;
   width: 32px;
   height: 32px;
+
+  @include marks-screen {
+    display: block;
+  }
 
   @include roomy-screen {
     width: 44px;
@@ -238,12 +258,8 @@
 // Held to the scores it joins, so it grows with them.
 .game-status__dash {
   color: var(--rak-primary-700);
-  font-size: 2rem;
+  font-size: var(--rak-score-size);
   line-height: 1.1;
-
-  @include roomy-screen {
-    font-size: 2.5rem;
-  }
 }
 
 .game-status__side-label {
@@ -299,14 +315,9 @@
   gap: var(--rak-space-1);
   margin: 0;
   color: var(--rak-primary-700);
-  font-size: 2rem;
+  font-size: var(--rak-score-size);
   font-weight: var(--rak-weight-bold);
   line-height: 1.1;
-
-  // The one thing a reader came for, so it takes the room a wider screen has.
-  @include roomy-screen {
-    font-size: 2.5rem;
-  }
 
   // Home only, since the marker is written after the score. Either way it lands on
   // the far side from the middle, so it never crowds the dash between the two.
@@ -327,16 +338,12 @@
 // triangle fills little of its em box, so it reads smaller than a letter set as big.
 .game-status__marker {
   color: var(--rak-brand-light);
-  font-size: 2rem;
+  font-size: var(--rak-marker-size);
   line-height: 1;
   // A triangle is drawn on the middle of the em box and a digit stands on the
   // baseline, so lining the two boxes up leaves the triangle low. Measured at a
-  // tenth of its own size, at both of the sizes below.
+  // tenth of its own size, at both of the sizes it is set at.
   transform: translateY(-0.1em);
-
-  @include roomy-screen {
-    font-size: 2.25rem;
-  }
 
   // Both sides carry a marker whatever the game is doing, and every side without the
   // ball wears an invisible one. It holds the room the visible one takes, so the
@@ -355,10 +362,15 @@
   display: contents;
 }
 
+// The dash is the middle of the dialog, so it is laid in a track of its own with a
+// track either side of it. Two equal shares rather than two boxes of whatever each
+// side happens to need: a marker one side is wearing, a record the other has none of,
+// or a score of two digits against one, would otherwise each move the dash.
 .game-status__scores {
   grid-row: 2;
   grid-column: 3;
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   justify-self: center;
   gap: var(--rak-space-2);

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -7,6 +7,14 @@
 // floor a finger needs would be the exception rather than the default.
 
 /**
+ * Above the narrowest screen a team's mark is worth the room it takes. Measured in
+ * the game status dialog, where the two marks stand beside the two names: at 330px
+ * and under, a record as short as `4-1` is broken across two lines by them, and at
+ * 340px it holds.
+ */
+$breakpoint-marks: 340px;
+
+/**
  * Above the widest phone held in portrait. Below it the tables and the navbar
  * tighten up and every target is a full `--rak-touch-target`. Measured against
  * the flagships, whose logical widths run to 440px.
@@ -27,6 +35,13 @@ $breakpoint-labelled-navbar: 561px;
  * rather than about what fits in one bar.
  */
 $breakpoint-wide: 601px;
+
+/** Room enough beside a team's mark for the name and record it stands by. */
+@mixin marks-screen {
+  @media (min-width: $breakpoint-marks) {
+    @content;
+  }
+}
 
 /** Room enough for the tables and the navbar to loosen up. */
 @mixin roomy-screen {


### PR DESCRIPTION
## What

Four fixes to the Game Status dialog and the search both dialogs share.

## Why

Choosing on a phone left the keyboard up over the answer. The dash between the two
scores was centered only where both sides came out the same width.

## Changes

- Choosing an option hands the focus to the dialog popup, not to nothing, so the
  keyboard drops and the dialog keeps Escape and a screen reader.
- The list is pinned under the search. It gives up height rather than flip over the
  input, which `--available-height` already caps and the popup already scrolls.
- The dash gets a track of its own between two equal ones, so nothing either side can
  move it.
- The scores, the dash and the marks are sized together, a quarter smaller on a phone,
  and under `$breakpoint-marks` the marks come off. At 330px they break a record as
  short as `4-1` across two lines.

## Verification

Measured in Chrome at 320, 390 and 1280. The dash is 0.00px off center in every game
state, where a three digit score used to move it 11.8px. Wireframe and answer still
stand the same height.

🕵️ Neutralized by [Agent Juni Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
