### PR TITLE
refactor: score a game against the line in one place

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -46,15 +46,19 @@ export default function Button({
   /** Set where the button opens and closes something below it. */
   ariaExpanded?: boolean;
 }) {
-  const modifiers = getClasses({
-    [`--${variant}`]: true,
-    [`--${color}`]: true,
-    "--sm": size === "sm",
-    "--icon": iconOnly,
-    "--compact": compact,
-    "--selected": !!selected,
-    "--busy": busy,
-  });
+  const classes = getClasses(
+    "button",
+    {
+      [`--${variant}`]: true,
+      [`--${color}`]: true,
+      "--sm": size === "sm",
+      "--icon": iconOnly,
+      "--compact": compact,
+      "--selected": !!selected,
+      "--busy": busy,
+    },
+    className,
+  );
   return (
     <BaseButton
       type="button"
@@ -63,7 +67,7 @@ export default function Button({
       aria-pressed={selected}
       aria-disabled={ariaDisabled || undefined}
       aria-busy={busy || undefined}
-      className={`button ${modifiers} ${className}`}
+      className={classes}
       disabled={disabled}
       onClick={ariaDisabled ? () => {} : onClick}
     >

--- a/src/components/gameStatus/GameStatusSummary.tsx
+++ b/src/components/gameStatus/GameStatusSummary.tsx
@@ -3,6 +3,7 @@ import { GameStatus, HomeAway } from "../../types/ESPN";
 import { GameSide, LeagueResult } from "../../types/LeagueResult";
 import { GameSpread, WeekGame } from "../../types/WeekGame";
 import getClasses from "../../utils/getClasses";
+import marginAgainstSpread from "../../utils/scoring/marginAgainstSpread";
 import "./GameStatusSummary.scss";
 
 /** Regulation is four quarters, and anything past them is overtime. */
@@ -155,29 +156,22 @@ type SideOutcome = "scored" | "missed";
  * on, and on the game itself where they did not. Nobody on a tie or a push, which the
  * pool scores for everybody either way.
  *
- * The same question `getPickResults` asks, from the favored side rather than from the
- * side a player picked.
+ * The same question `getPickResults` asks of a player's own pick, over the same
+ * `marginAgainstSpread`, read from the favored side rather than the picked one.
  */
 function scoringTeam(
   result: LeagueResult,
   spread?: GameSpread,
 ): string | undefined {
-  const winner = result.winner.team;
   if (spread == null) {
-    return winner?.abbreviation;
+    return result.winner.team?.abbreviation;
   }
-  // How far the favored side finished ahead, which is a negative number where it lost.
-  const margin =
-    winner == null
-      ? 0
-      : winner.abbreviation === spread.team
-        ? result.winner.by
-        : -result.winner.by;
-  const against = margin + spread.points;
-  if (against === 0) {
+  // Read from the favored side, which is the side `weekGames` writes the line from.
+  const margin = marginAgainstSpread(result, spread.team, spread.points);
+  if (margin === 0) {
     return undefined;
   }
-  return against > 0 ? spread.team : opponentOf(result, spread.team);
+  return margin > 0 ? spread.team : opponentOf(result, spread.team);
 }
 
 /**
@@ -281,10 +275,10 @@ function Score({
   const padded = isPadded(side.score, opponent.score);
   return (
     <p
-      className={`game-status__score --${homeAway}${getClasses({
+      className={getClasses("game-status__score", `--${homeAway}`, {
         "--scored": outcome === "scored",
         "--missed": outcome === "missed",
-      })}`}
+      })}
     >
       {/* Held apart from the marker beside it so the wireframe can draw a bar over
           the number alone, and so a number of one digit takes the room two do. */}
@@ -389,10 +383,10 @@ function Side({
           {homeAway === HomeAway.HOME ? "Home" : "Away"}
         </span>
         <span
-          className={`game-status__team-name${getClasses({
+          className={getClasses("game-status__team-name", {
             "--scored": outcome === "scored",
             "--missed": outcome === "missed",
-          })}`}
+          })}
         >
           {/* The abbreviation on a phone and the name once there is width for it.
               Both are in the page, so neither costs a measurement to choose

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -168,9 +168,9 @@ export default function HomePage() {
               onChange={handleFileUpload}
             />
             <Button
-              className={`home__button ${getClasses({
+              className={getClasses("home__button", {
                 "--hide": isBusy || !!scores,
-              })}`}
+              })}
               onClick={clickFileInput}
               disabled={!selectedWeek || isBusy}
             >

--- a/src/components/pageLayout/PageLayout.tsx
+++ b/src/components/pageLayout/PageLayout.tsx
@@ -79,7 +79,7 @@ export default function PageLayout({
 
   return (
     <div
-      className={`page ${getClasses({ "--tiles-loaded": areTilesLoaded })}`}
+      className={getClasses("page", { "--tiles-loaded": areTilesLoaded })}
       style={BACKGROUND_STYLE}
     >
       <a className="page__skip-link" href="#main">
@@ -88,10 +88,10 @@ export default function PageLayout({
       <Navbar left={navbarLeft} right={navbarRight} />
       <main
         id="main"
-        className={`page__content ${getClasses({
+        className={getClasses("page__content", {
           "--scores": showingScores,
           "--frozen": !scrollable,
-        })}`}
+        })}
       >
         <h1 className="page__title">{title}</h1>
         {children}

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -114,9 +114,9 @@ export default function PlayerAnalysisDialog({
           itemToStringLabel={(option) => option.name}
           itemKey={(option) => option.name}
           optionClassName={(option) =>
-            `player-analysis__option ${getClasses({
+            getClasses("player-analysis__option", {
               "--knocked-out": option.isKnockedOut,
-            })}`
+            })
           }
           // The player named in the input is marked the way the tables mark them,
           // so the search says where they stand before the answer below it has
@@ -124,9 +124,9 @@ export default function PlayerAnalysisDialog({
           adornment={
             player != null && (
               <span
-                className={`player-analysis__input-status ${getClasses({
+                className={getClasses("player-analysis__input-status", {
                   "--knocked-out": player.isKnockedOut,
-                })}`}
+                })}
               >
                 <PlayerStatusIcon isKnockedOut={player.isKnockedOut} />
               </span>

--- a/src/components/table/playerName/PlayerName.tsx
+++ b/src/components/table/playerName/PlayerName.tsx
@@ -10,9 +10,9 @@ function PlayerName({ player }: { player: PlayerScore }) {
 
   return (
     <td
-      className={`table__player-col ${getClasses({
+      className={getClasses("table__player-col", {
         "--knocked-out": player.status.isKnockedOut,
-      })}`}
+      })}
     >
       <button
         type="button"

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -1,15 +1,15 @@
 # src/utils
 
-- `getLeagueInfo` / `getLeagueResults`: ESPN API fetch, calendar and week mapping,
+- `getLeagueInfo` / `getLeagueResults`: ESPN fetch, calendar and week mapping,
   plus `getGameResult`, one game by event id
-- `getRegularSeasonWeekCount`: a season's week count, cached per league and season
+- `getRegularSeasonWeekCount`: a season's week count, cached per league
 - `buildSpreadsheetBuffer`: the xlsx-js-style workbook export and its content type
 - `pickStatusFill`: pick colors for the export
 - `picksCache`: localStorage cache of an uploaded workbook, per season and week
 - `loadStoredPicks`: a week's workbook from the API, falling back to that cache
 - `debugLog`: scoring traces, silent outside a dev server
 - `latestOnly`: drops an async result its effect has outlived
-- `getClasses`: conditional className join
+- `getClasses`: className join, fixed and conditional names together
 - `plural`: a count and its noun, pluralized
 - `rangeWithPrefix`: labeled index arrays (C1, C2…)
 - `readFileToBuffer`: an uploaded spreadsheet's bytes

--- a/src/utils/getClasses.ts
+++ b/src/utils/getClasses.ts
@@ -1,11 +1,22 @@
-export default function getClasses(classes: {
-  [className: string]: boolean;
-}): string {
-  return Object.entries(classes)
-    .map(([className, isActive]) => (isActive ? className : ""))
-    .filter(Boolean)
-    .reduce(
-      (combined: string, className: string) => `${combined} ${className}`,
-      "",
-    );
+/** A fixed name, a name to keep only when its condition holds, or nothing at all. */
+type ClassPart = string | false | null | undefined | Record<string, boolean>;
+
+/**
+ * Joins class names into one attribute, dropping every conditional whose condition is
+ * false and every part that is not there.
+ *
+ * The fixed names go in alongside the conditional ones rather than being written
+ * around the call, so no caller has to know whether the result starts with a space or
+ * what an empty one leaves behind.
+ */
+export default function getClasses(...parts: Array<ClassPart>): string {
+  return parts
+    .flatMap((part) => {
+      if (part == null || part === false || part === "") return [];
+      if (typeof part === "string") return [part];
+      return Object.entries(part)
+        .filter(([, isActive]) => isActive)
+        .map(([className]) => className);
+    })
+    .join(" ");
 }

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -1,11 +1,12 @@
 # scoring
 
-The picks-to-scoreboard pipeline, a file per concern, sequenced by `getPlayerScores`.
+The picks-to-scoreboard pipeline, sequenced by `getPlayerScores`.
 
 - `parsePicksWorkbook`: xlsx buffer to rows, keys, matchups
 - `parsePick`: one cell to a team and a spread
 - `validateSpreads`: rows disagreeing on a spread
-- `getPickResults`: picks scored, and `getStatus`
+- `marginAgainstSpread`: a side's margin, line applied
+- `getPickResults`: picks scored, plus `getStatus`
 - `gameColumns`: `LEAGUES`, `LEAGUE_PREFIX`, `gameLabels`
 - `weekGames`: each column, its game, its line
 - `getTiebreakerScore`: the Monday night total
@@ -14,7 +15,7 @@ The picks-to-scoreboard pipeline, a file per concern, sequenced by `getPlayerSco
 - `isWeekDecided`: whether knockouts settled it
 - `remainingGames`: the open games
 - `unscoreableGames`: games nobody scores on
-- `isWeekOver`: whether the week has a result
+- `isWeekOver`: whether the week has finished
 - `applyKnockouts`: who can still win, why not
 - `getPlayerAnalysis`: what a player must do
-- `leagueResultFixtures`: game builders for the tests
+- `leagueResultFixtures`: test game builders

--- a/src/utils/scoring/getPickResults.ts
+++ b/src/utils/scoring/getPickResults.ts
@@ -3,6 +3,7 @@ import { GameScore } from "../../types/GameScore";
 import { LeagueResult } from "../../types/LeagueResult";
 import { Status } from "../../types/RakMadnessScores";
 import debugLog from "../debugLog";
+import marginAgainstSpread from "./marginAgainstSpread";
 import parsePick from "./parsePick";
 
 export function getStatus(score: GameScore): Status {
@@ -108,25 +109,17 @@ export function getPickResults(
       );
     }
 
-    // A tie counts as picking the winner, and so does an unfinished game, which
-    // has no winner either. The unfinished case is harmless because nothing reads
-    // `pointValue` until `isCompleted`.
-    const pickedWinner =
-      gameResult.winner.team === null ||
-      gameResult.winner.team.abbreviation === selectedTeam;
-
-    // How far ahead the picked team finished once the spread is applied. A push
-    // counts as a win, which is why this is >= rather than >.
-    // `winner.by` is only signed from the picked team's side once the game is
-    // final, so this value means nothing until `isCompleted`.
-    const marginAgainstSpread =
-      (pickedWinner ? gameResult.winner.by : -gameResult.winner.by) + spread;
-    const pointValue = marginAgainstSpread >= 0 ? 1 : 0;
+    // From the picked team's side, since that is the side the cell's spread is
+    // written from. A push counts as a win, which is why this is >= rather than >.
+    // Nothing reads `pointValue` until `isCompleted`, which is when the margin
+    // means anything.
+    const margin = marginAgainstSpread(gameResult, selectedTeam, spread);
+    const pointValue = margin >= 0 ? 1 : 0;
     debugLog("scored pick", {
       selectedTeam,
       spread,
       winnerBy: gameResult.winner.by,
-      marginAgainstSpread,
+      marginAgainstSpread: margin,
       pointValue,
     });
 

--- a/src/utils/scoring/marginAgainstSpread.test.ts
+++ b/src/utils/scoring/marginAgainstSpread.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { finalGame } from "./leagueResultFixtures";
+import marginAgainstSpread from "./marginAgainstSpread";
+
+// Buffalo beat Kansas City by ten.
+const game = finalGame({
+  home: "BUF",
+  away: "KC",
+  homeScore: 30,
+  awayScore: 20,
+});
+
+describe("marginAgainstSpread", () => {
+  it("gives the winner its margin where no line was written", () => {
+    expect(marginAgainstSpread(game, "BUF", 0)).toBe(10);
+    expect(marginAgainstSpread(game, "KC", 0)).toBe(-10);
+  });
+
+  it("takes what the favored side gave off its margin", () => {
+    expect(marginAgainstSpread(game, "BUF", -3)).toBe(7);
+    expect(marginAgainstSpread(game, "BUF", -14)).toBe(-4);
+  });
+
+  it("adds what the underdog was given to its margin", () => {
+    expect(marginAgainstSpread(game, "KC", 14)).toBe(4);
+    expect(marginAgainstSpread(game, "KC", 3)).toBe(-7);
+  });
+
+  it("reads zero either side of a game that landed on the number", () => {
+    expect(marginAgainstSpread(game, "BUF", -10)).toBe(0);
+    expect(marginAgainstSpread(game, "KC", 10)).toBe(0);
+  });
+
+  it("reads a tie as a push for both sides, which scores for everybody", () => {
+    const drawn = finalGame({
+      home: "BUF",
+      away: "KC",
+      homeScore: 20,
+      awayScore: 20,
+    });
+    expect(marginAgainstSpread(drawn, "BUF", 0)).toBe(0);
+    expect(marginAgainstSpread(drawn, "KC", 0)).toBe(0);
+  });
+});

--- a/src/utils/scoring/marginAgainstSpread.ts
+++ b/src/utils/scoring/marginAgainstSpread.ts
@@ -1,0 +1,26 @@
+import { LeagueResult } from "../../types/LeagueResult";
+
+/**
+ * How far a side finished ahead once the pool's line is applied, from that side's own
+ * point of view. Zero is a push, and anything above it is a point.
+ *
+ * `points` is the line written from `team`'s side, which is the sign the picks carry
+ * and the sign `weekGames` normalizes a spread to. Read from the other side, the same
+ * game gives the same number negated.
+ *
+ * A game with no winner is level, and `winner.by` is zero either way, so a tie reads as
+ * a push and scores for everybody. The number means nothing until the game is final,
+ * because that is when `winner.by` is settled.
+ */
+export default function marginAgainstSpread(
+  result: LeagueResult,
+  team: string,
+  points: number,
+): number {
+  const winner = result.winner.team;
+  const ahead =
+    winner == null || winner.abbreviation === team
+      ? result.winner.by
+      : -result.winner.by;
+  return ahead + points;
+}


### PR DESCRIPTION
## What

The two small follow-ups noted in the review of #31. No behavior change.

## Changes

- `marginAgainstSpread` holds the against-the-spread arithmetic. `getPickResults` reads it from the picked side and the game status dialog from the favored one, which is the same sum written from two directions.
- `getClasses` takes the fixed class names alongside the conditional ones. It used to return only the conditional half, prefixed with a space that callers had to know about, and six of the seven wrote a space of their own on top of it.

## Verification

`make check` and `make build`. The existing scoring and dialog suites cover both, since neither is meant to change what renders or what scores.

🕵️ Handled by [Agent Juni Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
