### PR TITLE
perf(espn): hold the games and calendars nothing can change

### DIFF
--- a/.claude/skills/build-run-test/SKILL.md
+++ b/.claude/skills/build-run-test/SKILL.md
@@ -40,7 +40,8 @@ Writing a test here:
 - Reading an exported workbook back flattens the fill onto `cell.s`, so assert `cell.s.fgColor.rgb`, not `cell.s.fill.fgColor.rgb`.
 - jsdom reports no layout: every rect is zero and `window.innerHeight` is 768. Anything that measures the page has its arithmetic tested apart from the hook that feeds it.
 - Mount `App` the way `index.tsx` does: inside `MemoryRouter`, `ToastContextProvider`, and `AppDataContextProvider`, with `Toaster` beside it. Toasts render in `Toaster`, so without it no toast assertion can pass.
-- Clear `localStorage` in `beforeEach` for anything that uploads. An upload caches its workbook per week, and jsdom keeps storage between cases, so a later case would find picks an earlier one left behind.
+- Clear `localStorage` in `beforeEach` for anything that uploads or scores. An upload caches its workbook per week, and `espnCache` holds the games of a week that is over plus a finished season's calendar, and jsdom keeps storage between cases. Without the clear a later case finds an answer an earlier one left behind, and asserting on `fetch` calls is what breaks.
+- `getLeagueInfo` also caches week counts in a module-level `Map` that no reset clears, so a case that counts calendar requests needs a season number no other case in the file uses. The existing ones use 3001 upward.
 - `mountLoadedApp` waits for the home controls, so it only works for URLs that land on `/`. Deep-link cases use `mountApp` and await something on the results route.
 - The week `Select` compares option values by reference, so a fixture's `activeWeek` must be the same object as its entry in `weeks`.
 - Don't name a helper `render*` unless it returns the render result — `testing-library/render-result-naming-convention` is an error, not a warning.
@@ -84,4 +85,4 @@ The scoring path logs through `src/utils/debugLog.ts`, which is silent when the 
 
 ## Offline
 
-`make setup` needs network (`npm ci`). `make build`, `make check`, `make test`, `make run` work offline once `node_modules` exists. `make run` fetches live ESPN endpoints at runtime (`src/utils/getLeagueInfo.ts`, `getLeagueResults.ts`), so scoring needs network even though the dev server does not.
+`make setup` needs network (`npm ci`). `make build`, `make check`, `make test`, `make run` work offline once `node_modules` exists. `make run` fetches live ESPN endpoints at runtime (`src/utils/getLeagueInfo.ts`, `getLeagueResults.ts`), so scoring needs network even though the dev server does not. A week `espnCache` has every answer for is the exception: it scores from `localStorage` and asks ESPN nothing.

--- a/src/components/gameStatus/GameStatusDialog.test.tsx
+++ b/src/components/gameStatus/GameStatusDialog.test.tsx
@@ -317,7 +317,7 @@ describe("GameStatusDialog", () => {
       "",
     ]);
 
-    await user.click(screen.getByRole("option", { name: /MICH @ OSU/ }));
+    await user.click(screen.getByRole("option", { name: /DAL @ PHI/ }));
 
     // Choosing ends the search, so a phone's keyboard comes down off the game that
     // was just asked for. The dialog holds the focus rather than nothing.
@@ -325,30 +325,38 @@ describe("GameStatusDialog", () => {
     expect(document.activeElement).toHaveClass("dialog__popup");
 
     expect(getGameResultMock).toHaveBeenLastCalledWith(
-      League.COLLEGE,
+      League.PRO,
       WEEK,
-      "402",
+      "403",
       SEASON,
     );
     expect(
       screen.getByRole("progressbar", { name: "Fetching the game" }),
     ).toBeInTheDocument();
     expect(screen.queryByText("BUF Team")).toBeNull();
-    // The game being switched to, which is over, rather than the live one whose
-    // result is still the last one fetched.
-    expect(screen.getByRole("img", { name: "Final" })).toBeInTheDocument();
+    // The game being switched to, which has yet to kick off, rather than the live one
+    // whose result is still the last one fetched.
+    expect(
+      screen.getByRole("img", { name: "Yet to kick off" }),
+    ).toBeInTheDocument();
 
-    pending.settle(collegeGame);
+    pending.settle(upcomingGame);
     await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"));
-    expect(screen.getByText("OSU Team")).toBeInTheDocument();
-    // Over, so the search says so rather than that there is something to watch.
+    expect(screen.getByText("PHI Team")).toBeInTheDocument();
+    // Not started, so the search says so rather than that there is something to watch.
     expect(screen.queryByRole("img", { name: /Live/ })).toBeNull();
-    expect(screen.getByRole("img", { name: "Final" })).toBeInTheDocument();
 
-    // Final, so there is nothing left to ask about.
-    const askedByFinal = getGameResultMock.mock.calls.length;
+    // A game the week was already scored on after it finished is shown as it was
+    // scored, without being asked for at all. Nothing about it can have changed, and
+    // there is nothing left to poll for either.
+    const askedBeforeFinal = getGameResultMock.mock.calls.length;
+    await user.click(screen.getByRole("combobox", { name: "Game" }));
+    await user.click(await screen.findByRole("option", { name: /MICH @ OSU/ }));
+    expect(screen.getByText("OSU Team")).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+    expect(screen.getByRole("img", { name: "Final" })).toBeInTheDocument();
     await vi.advanceTimersByTimeAsync(POLL_MS * 3);
-    expect(getGameResultMock).toHaveBeenCalledTimes(askedByFinal);
+    expect(getGameResultMock).toHaveBeenCalledTimes(askedBeforeFinal);
 
     // Back on the live game, which is asked about again on the way in.
     getGameResultMock.mockResolvedValue(proGame);

--- a/src/components/gameStatus/GameStatusDialog.test.tsx
+++ b/src/components/gameStatus/GameStatusDialog.test.tsx
@@ -358,6 +358,26 @@ describe("GameStatusDialog", () => {
     await vi.advanceTimersByTimeAsync(POLL_MS * 3);
     expect(getGameResultMock).toHaveBeenCalledTimes(askedBeforeFinal);
 
+    // The same switch made with the last game's fetch still outstanding. The answer
+    // lands after the switch, and the finished game stays where it is.
+    const stray = deferred();
+    getGameResultMock.mockReturnValue(stray.promise);
+    await user.click(screen.getByRole("combobox", { name: "Game" }));
+    await user.click(await screen.findByRole("option", { name: /KC @ BUF/ }));
+    expect(
+      screen.getByRole("progressbar", { name: "Fetching the game" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox", { name: "Game" }));
+    await user.click(await screen.findByRole("option", { name: /MICH @ OSU/ }));
+    expect(screen.getByText("OSU Team")).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+
+    stray.settle(proGame);
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    expect(screen.getByText("OSU Team")).toBeInTheDocument();
+    expect(screen.queryByText("BUF Team")).toBeNull();
+
     // Back on the live game, which is asked about again on the way in.
     getGameResultMock.mockResolvedValue(proGame);
     await user.click(screen.getByRole("combobox", { name: "Game" }));

--- a/src/components/gameStatus/GameStatusDialog.tsx
+++ b/src/components/gameStatus/GameStatusDialog.tsx
@@ -96,9 +96,9 @@ function GameMark({
  * How a game in the week on screen is going, opened from a pick cell in the picks
  * table.
  *
- * The game is fetched again on the way in and every twenty seconds after that until it
- * is final, so a live game on screen is the game as it stands rather than as the
- * week was last scored.
+ * A game that has not finished is fetched again on the way in and every twenty seconds
+ * after that, so a live game on screen is the game as it stands rather than as the
+ * week was last scored. One already final is shown as the week scored it.
  */
 export default function GameStatusDialog({
   open,

--- a/src/hooks/useLiveGame.ts
+++ b/src/hooks/useLiveGame.ts
@@ -14,8 +14,8 @@ export const POLL_MS = 20_000;
  *
  * The week's scores carry the game as it stood when they were worked out, which is
  * stale the moment a live game moves, so a game is fetched again before it is
- * shown and then on `POLL_MS` until it is final. A final game is fetched once and
- * left alone.
+ * shown and then on `POLL_MS` until it is final. A game already final when it is
+ * opened is shown as the scoring pass left it, because nothing about it can differ.
  *
  * The game already on screen stays there while the next one is fetched, the way the
  * player analysis holds the last answer up behind its progress bar. `games` is the
@@ -47,10 +47,15 @@ export default function useLiveGame({
   const label = game?.label;
   const league = game?.league;
   const eventId = game?.result?.id;
+  // A game the week was scored on after it finished cannot come back any other way,
+  // so it is shown as the scoring pass left it rather than asked about again.
+  const settled =
+    game?.result?.status === GameStatus.FINAL ? game.result : undefined;
 
   useEffect(() => {
     if (!open || games == null || week == null) return;
     if (label == null || league == null || eventId == null) return;
+    if (settled != null) return;
     let timer = 0;
     const stop = latestOnly(async (isCurrent) => {
       const poll = async () => {
@@ -83,13 +88,15 @@ export default function useLiveGame({
       // outstanding whatever it comes back with.
       setFetching(false);
     };
-  }, [open, games, label, league, eventId, week, season]);
+  }, [open, games, label, league, eventId, settled, week, season]);
 
   const shown =
-    found != null && found.games === games ? found.result : undefined;
+    settled ??
+    (found != null && found.games === games ? found.result : undefined);
   const isLoading =
     game != null &&
     eventId != null &&
+    settled == null &&
     (shown == null || found?.label !== label);
   // `isLoading` is the wait with nothing to show behind it, and `isFetching` every
   // wait, a poll of a game already on screen included.

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -2,10 +2,11 @@
 
 - `getLeagueInfo` / `getLeagueResults`: ESPN fetch, calendar and week mapping,
   plus `getGameResult`, one game by event id
-- `getRegularSeasonWeekCount`: a season's week count, cached per league
+- `getRegularSeasonWeekCount`: a season's week count, cached
 - `buildSpreadsheetBuffer`: the xlsx-js-style workbook export and its content type
 - `pickStatusFill`: pick colors for the export
-- `picksCache`: localStorage cache of an uploaded workbook, per season and week
+- `picksCache` / `espnCache`: localStorage, an uploaded workbook and the ESPN
+  answers nothing can change
 - `loadStoredPicks`: a week's workbook from the API, falling back to that cache
 - `debugLog`: scoring traces, silent outside a dev server
 - `latestOnly`: drops an async result its effect has outlived

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -1,19 +1,19 @@
 # src/utils
 
 - `getLeagueInfo` / `getLeagueResults`: ESPN fetch, calendar and week mapping,
-  plus `getGameResult`, one game by event id
+  plus `getGameResult` by event id
 - `getRegularSeasonWeekCount`: a season's week count, cached
-- `buildSpreadsheetBuffer`: the xlsx-js-style workbook export and its content type
+- `buildSpreadsheetBuffer`: the xlsx export and its content type
 - `pickStatusFill`: pick colors for the export
-- `picksCache` / `espnCache`: localStorage, an uploaded workbook and the ESPN
-  answers nothing can change
-- `loadStoredPicks`: a week's workbook from the API, falling back to that cache
+- `picksCache` / `espnCache`: an uploaded workbook, and the ESPN answers nothing
+  can change, both on `localStorageCache`, a capped store under one prefix
+- `loadStoredPicks`: a week's workbook from the API, else that cache
 - `debugLog`: scoring traces, silent outside a dev server
-- `latestOnly`: drops an async result its effect has outlived
-- `getClasses`: className join, fixed and conditional names together
+- `latestOnly`: drops an async result its effect outlived
+- `getClasses`: className join, fixed and conditional names
 - `plural`: a count and its noun, pluralized
 - `rangeWithPrefix`: labeled index arrays (C1, C2…)
-- `readFileToBuffer`: an uploaded spreadsheet's bytes
+- `readFileToBuffer`: an upload's bytes
 
 ## Subdirectories
 

--- a/src/utils/espnCache.test.ts
+++ b/src/utils/espnCache.test.ts
@@ -37,9 +37,8 @@ describe("matchupKey", () => {
     expect(matchupKey(new Set(["buf", "Kc"]))).toBe(BUF_KC);
   });
 
-  it("names a column with one team, and one with none", () => {
+  it("names a column every player picked the same side of", () => {
     expect(matchupKey(new Set(["BUF"]))).toBe("BUF");
-    expect(matchupKey(new Set())).toBe("");
   });
 });
 
@@ -98,10 +97,27 @@ describe("espnCache, results", () => {
   it("treats an entry an older version wrote as a miss", () => {
     localStorage.setItem(
       `rak-madness:espn:results:${SEASON}:3:nfl`,
-      JSON.stringify({ version: 0, games: { [BUF_KC]: game() } }),
+      JSON.stringify({ version: 0, value: { [BUF_KC]: game() } }),
     );
 
     expect(readCachedResults(SEASON, 3, League.PRO)).toEqual({});
+  });
+
+  it("treats an entry of this version with no games in it as a miss", () => {
+    // Anything at all can be written to storage this shares with the rest of the
+    // origin, so a version match is not on its own a promise about the shape.
+    [
+      { version: 1 },
+      { version: 1, value: null },
+      { version: 1, value: 3 },
+    ].forEach((entry) => {
+      localStorage.setItem(
+        `rak-madness:espn:results:${SEASON}:3:nfl`,
+        JSON.stringify(entry),
+      );
+
+      expect(readCachedResults(SEASON, 3, League.PRO)).toEqual({});
+    });
   });
 
   it("caps how many weeks it holds, keeping the one just written", () => {
@@ -132,6 +148,15 @@ describe("espnCache, calendars", () => {
 
     expect(readCachedCalendar(League.COLLEGE, 2022)).toBeUndefined();
     expect(readCachedCalendar(League.PRO, 2023)).toBeUndefined();
+  });
+
+  it("treats a calendar an older version wrote as a miss", () => {
+    localStorage.setItem(
+      "rak-madness:espn:calendar:nfl:2022",
+      JSON.stringify({ version: 0, value: { leagues: [{ slug: "nfl" }] } }),
+    );
+
+    expect(readCachedCalendar(League.PRO, 2022)).toBeUndefined();
   });
 });
 

--- a/src/utils/espnCache.test.ts
+++ b/src/utils/espnCache.test.ts
@@ -1,0 +1,168 @@
+import { GameStatus } from "../types/ESPN";
+import { League } from "../types/League";
+import { LeagueResult } from "../types/LeagueResult";
+import { finalGame } from "./scoring/leagueResultFixtures";
+import {
+  isSettled,
+  matchupKey,
+  readCachedCalendar,
+  readCachedResults,
+  writeCachedCalendar,
+  writeCachedResults,
+} from "./espnCache";
+
+const SEASON = 2025;
+const BUF_KC = "BUF|KC";
+
+function game(): LeagueResult {
+  return finalGame({ home: "BUF", away: "KC", homeScore: 30, awayScore: 20 });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("matchupKey", () => {
+  it("names the same two teams the same way around either way", () => {
+    expect(matchupKey(new Set(["KC", "BUF"]))).toBe(BUF_KC);
+    expect(matchupKey(new Set(["BUF", "KC"]))).toBe(BUF_KC);
+  });
+
+  it("folds the case the workbook happened to use", () => {
+    expect(matchupKey(new Set(["buf", "Kc"]))).toBe(BUF_KC);
+  });
+
+  it("names a column with one team, and one with none", () => {
+    expect(matchupKey(new Set(["BUF"]))).toBe("BUF");
+    expect(matchupKey(new Set())).toBe("");
+  });
+});
+
+describe("isSettled", () => {
+  it("holds a game that has been played, and a matchup with no game", () => {
+    expect(isSettled(game())).toBe(true);
+    expect(isSettled(null)).toBe(true);
+  });
+
+  it("holds nothing about a game still being played", () => {
+    expect(isSettled({ ...game(), status: GameStatus.LIVE })).toBe(false);
+  });
+});
+
+describe("espnCache, results", () => {
+  it("reads back a game and a hole, the date a date again", () => {
+    writeCachedResults(SEASON, 3, League.PRO, {
+      [BUF_KC]: game(),
+      "PHI|DAL": null,
+    });
+
+    const held = readCachedResults(SEASON, 3, League.PRO);
+
+    expect(held[BUF_KC]?.date).toEqual(game().date);
+    expect(held[BUF_KC]?.date).toBeInstanceOf(Date);
+    expect(held["PHI|DAL"]).toBeNull();
+    // A hole is an answer, so telling one from a matchup never asked about is what
+    // says whether the week still has anything to fetch.
+    expect("PHI|DAL" in held).toBe(true);
+    expect("OSU|MICH" in held).toBe(false);
+  });
+
+  it("keeps each league, week, and season apart", () => {
+    writeCachedResults(SEASON, 3, League.PRO, { [BUF_KC]: game() });
+
+    expect(readCachedResults(SEASON, 3, League.COLLEGE)).toEqual({});
+    expect(readCachedResults(SEASON, 4, League.PRO)).toEqual({});
+    expect(readCachedResults(2024, 3, League.PRO)).toEqual({});
+  });
+
+  it("drops whatever it held for a week it is asked to hold again", () => {
+    writeCachedResults(SEASON, 3, League.PRO, { [BUF_KC]: game() });
+    writeCachedResults(SEASON, 3, League.PRO, { "PHI|DAL": null });
+
+    expect(readCachedResults(SEASON, 3, League.PRO)).toEqual({
+      "PHI|DAL": null,
+    });
+  });
+
+  it("treats an entry it cannot read as a miss", () => {
+    localStorage.setItem(`rak-madness:espn:results:${SEASON}:3:nfl`, "!!!");
+
+    expect(readCachedResults(SEASON, 3, League.PRO)).toEqual({});
+  });
+
+  it("treats an entry an older version wrote as a miss", () => {
+    localStorage.setItem(
+      `rak-madness:espn:results:${SEASON}:3:nfl`,
+      JSON.stringify({ version: 0, games: { [BUF_KC]: game() } }),
+    );
+
+    expect(readCachedResults(SEASON, 3, League.PRO)).toEqual({});
+  });
+
+  it("caps how many weeks it holds, keeping the one just written", () => {
+    [1, 2, 3, 4, 5, 6, 7].forEach((week) =>
+      writeCachedResults(SEASON, week, League.PRO, { [BUF_KC]: game() }),
+    );
+
+    expect(readCachedResults(SEASON, 7, League.PRO)[BUF_KC]).not.toBeNull();
+    const held = [1, 2, 3, 4, 5, 6, 7].filter(
+      (week) =>
+        Object.keys(readCachedResults(SEASON, week, League.PRO)).length > 0,
+    );
+    expect(held).toHaveLength(6);
+  });
+});
+
+describe("espnCache, calendars", () => {
+  it("reads back the answer it was given", () => {
+    writeCachedCalendar(League.PRO, 2022, { leagues: [{ slug: "nfl" }] });
+
+    expect(readCachedCalendar(League.PRO, 2022)).toEqual({
+      leagues: [{ slug: "nfl" }],
+    });
+  });
+
+  it("keeps each league and season apart", () => {
+    writeCachedCalendar(League.PRO, 2022, { leagues: [] });
+
+    expect(readCachedCalendar(League.COLLEGE, 2022)).toBeUndefined();
+    expect(readCachedCalendar(League.PRO, 2023)).toBeUndefined();
+  });
+});
+
+describe("espnCache, storage that will not have it", () => {
+  it("leaves nothing behind when a write is rejected", () => {
+    writeCachedResults(SEASON, 3, League.PRO, { [BUF_KC]: game() });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    writeCachedResults(SEASON, 4, League.PRO, { [BUF_KC]: game() });
+
+    expect(readCachedResults(SEASON, 3, League.PRO)).toEqual({});
+    expect(readCachedResults(SEASON, 4, League.PRO)).toEqual({});
+  });
+
+  it("misses rather than throws when every localStorage method throws", () => {
+    const blocked = () => {
+      throw new Error("storage blocked");
+    };
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(blocked);
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(blocked);
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(blocked);
+    vi.spyOn(Storage.prototype, "key").mockImplementation(blocked);
+    vi.spyOn(Storage.prototype, "length", "get").mockImplementation(blocked);
+
+    expect(readCachedResults(SEASON, 3, League.PRO)).toEqual({});
+    expect(() =>
+      writeCachedResults(SEASON, 3, League.PRO, { [BUF_KC]: game() }),
+    ).not.toThrow();
+    expect(readCachedCalendar(League.PRO, 2022)).toBeUndefined();
+    expect(() => writeCachedCalendar(League.PRO, 2022, {})).not.toThrow();
+  });
+});

--- a/src/utils/espnCache.ts
+++ b/src/utils/espnCache.ts
@@ -12,8 +12,8 @@
 import { GameStatus } from "../types/ESPN";
 import { League } from "../types/League";
 import { LeagueResult } from "../types/LeagueResult";
+import localStorageCache from "./localStorageCache";
 
-const KEY_PREFIX = "rak-madness:espn:";
 /** A size guard, not a history. A week of both leagues is tens of KB. */
 const MAX_CACHED_WEEKS = 6;
 /** Bumped where a stored shape changes, which makes every older entry a miss. */
@@ -22,85 +22,41 @@ const VERSION = 1;
 /** A game as it was stored, whose date has been through JSON and is text again. */
 type StoredGame = (Omit<LeagueResult, "date"> & { date: string }) | null;
 
-type StoredWeek = {
-  version: number;
-  /** Keyed by matchup. Null is a matchup ESPN listed no game for. */
-  games: Record<string, StoredGame>;
-};
+/** Keyed by matchup. Null is a matchup ESPN listed no game for. */
+type StoredGames = Record<string, StoredGame>;
+
+type Versioned<T> = { version: number; value: T };
 
 /** A game ESPN has finished with, or null for a matchup it never listed. */
 export type CachedGame = LeagueResult | null;
 
-function resultsKey(season: number, week: number, league: League): string {
-  return `${KEY_PREFIX}results:${season}:${week}:${league}`;
-}
+const results = localStorageCache<Versioned<StoredGames>>({
+  prefix: "rak-madness:espn:results:",
+  cap: MAX_CACHED_WEEKS,
+  label: "ESPN results",
+  encode: (value) => JSON.stringify(value),
+  decode: (text) => JSON.parse(text),
+});
 
-function calendarKey(league: League, season: number): string {
-  return `${KEY_PREFIX}calendar:${league}:${season}`;
-}
-
-function cachedKeys(prefix: string): Array<string> {
-  const keys: Array<string> = [];
-  for (let index = 0; index < localStorage.length; index++) {
-    const key = localStorage.key(index);
-    if (key?.startsWith(prefix)) {
-      keys.push(key);
-    }
-  }
-  return keys;
-}
-
-function clearCache(): void {
-  try {
-    cachedKeys(KEY_PREFIX).forEach((key) => localStorage.removeItem(key));
-  } catch (error) {
-    // Called from catch blocks that turn a storage failure into a cache miss. If
-    // storage is blocked outright, this must not throw past them.
-    console.warn("Could not clear the ESPN cache", error);
-  }
-}
-
-/** Writes a value, having made room for it, and never throws. */
-function store(key: string, prefix: string, cap: number, value: unknown): void {
-  try {
-    // Pruned before writing, so the entry being written is never the one dropped.
-    // localStorage does not report insertion order, so which others go is arbitrary.
-    // The cap is only here to bound how much space this takes.
-    const keys = cachedKeys(prefix).filter((it) => it !== key);
-    keys
-      .slice(0, Math.max(keys.length - (cap - 1), 0))
-      .forEach((it) => localStorage.removeItem(it));
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch (error) {
-    console.warn("Could not cache an ESPN answer", error);
-    clearCache();
-  }
-}
-
-/** Reads a value back, and counts a corrupt or unreadable one as a miss. */
-function read<T>(key: string): T | undefined {
-  try {
-    const text = localStorage.getItem(key);
-    return text != null ? (JSON.parse(text) as T) : undefined;
-  } catch (error) {
-    // A cache is never allowed to break scoring.
-    console.warn("Could not read a cached ESPN answer", error);
-    clearCache();
-    return undefined;
-  }
-}
+const calendars = localStorageCache<Versioned<unknown>>({
+  prefix: "rak-madness:espn:calendar:",
+  cap: MAX_CACHED_WEEKS,
+  label: "ESPN calendar",
+  encode: (value) => JSON.stringify(value),
+  decode: (text) => JSON.parse(text),
+});
 
 /**
  * What a matchup is filed under.
  *
  * Folded and sorted, because the workbook could name the same two teams either way
  * around and in any case at all, while a result carries them already uppercased. A
- * column names one team where every player picked the same side, and none at all
- * where nobody filled it in, both of which are matchups in their own right.
+ * column names one team where every player picked the same side, which is a matchup in
+ * its own right.
  */
 export function matchupKey(teams: Set<string>): string {
   return [...teams]
-    .map((team) => team?.toUpperCase())
+    .map((team) => team.toUpperCase())
     .sort()
     .join("|");
 }
@@ -111,12 +67,14 @@ export function readCachedResults(
   week: number,
   league: League,
 ): Record<string, CachedGame> {
-  const stored = read<StoredWeek>(resultsKey(season, week, league));
-  if (stored?.version !== VERSION) {
+  const stored = results.read(`${season}:${week}:${league}`);
+  // An entry of the version in hand can still be nonsense, since anything at all can
+  // be written to storage this shares with the rest of the origin.
+  if (stored?.version !== VERSION || typeof stored.value !== "object") {
     return {};
   }
   const games: Record<string, CachedGame> = {};
-  Object.entries(stored.games).forEach(([key, game]) => {
+  Object.entries(stored.value ?? {}).forEach(([key, game]) => {
     games[key] = game == null ? null : { ...game, date: new Date(game.date) };
   });
   return games;
@@ -134,16 +92,15 @@ export function writeCachedResults(
   league: League,
   games: Record<string, CachedGame>,
 ): void {
-  const entry: StoredWeek = {
+  const stored: StoredGames = {};
+  Object.entries(games).forEach(([key, game]) => {
+    stored[key] =
+      game == null ? null : { ...game, date: game.date.toISOString() };
+  });
+  results.write(`${season}:${week}:${league}`, {
     version: VERSION,
-    games: games as StoredWeek["games"],
-  };
-  store(
-    resultsKey(season, week, league),
-    `${KEY_PREFIX}results:`,
-    MAX_CACHED_WEEKS,
-    entry,
-  );
+    value: stored,
+  });
 }
 
 /** Whether an answer is one this browser can hold on to for good. */
@@ -161,7 +118,8 @@ export function readCachedCalendar<T>(
   league: League,
   season: number,
 ): T | undefined {
-  return read<T>(calendarKey(league, season));
+  const stored = calendars.read(`${league}:${season}`);
+  return stored?.version === VERSION ? (stored.value as T) : undefined;
 }
 
 export function writeCachedCalendar(
@@ -169,10 +127,8 @@ export function writeCachedCalendar(
   season: number,
   scoreboard: unknown,
 ): void {
-  store(
-    calendarKey(league, season),
-    `${KEY_PREFIX}calendar:`,
-    MAX_CACHED_WEEKS,
-    scoreboard,
-  );
+  calendars.write(`${league}:${season}`, {
+    version: VERSION,
+    value: scoreboard,
+  });
 }

--- a/src/utils/espnCache.ts
+++ b/src/utils/espnCache.ts
@@ -1,0 +1,178 @@
+// What ESPN has said that it cannot say differently later, kept in this browser so it
+// is not asked again. A game that has been played keeps its score, a matchup ESPN
+// never listed keeps being a hole, and a season that is over keeps its schedule.
+//
+// Nothing about the pool is cached, only ESPN's side of it: a spread the workbook
+// contradicts itself on, and a cell nobody filled in, are worked out from the picks
+// every time, and they cost no request.
+//
+// Games are filed under the matchup the picks name, so a week whose matchups change
+// finds nothing for the ones that moved and asks about those again.
+
+import { GameStatus } from "../types/ESPN";
+import { League } from "../types/League";
+import { LeagueResult } from "../types/LeagueResult";
+
+const KEY_PREFIX = "rak-madness:espn:";
+/** A size guard, not a history. A week of both leagues is tens of KB. */
+const MAX_CACHED_WEEKS = 6;
+/** Bumped where a stored shape changes, which makes every older entry a miss. */
+const VERSION = 1;
+
+/** A game as it was stored, whose date has been through JSON and is text again. */
+type StoredGame = (Omit<LeagueResult, "date"> & { date: string }) | null;
+
+type StoredWeek = {
+  version: number;
+  /** Keyed by matchup. Null is a matchup ESPN listed no game for. */
+  games: Record<string, StoredGame>;
+};
+
+/** A game ESPN has finished with, or null for a matchup it never listed. */
+export type CachedGame = LeagueResult | null;
+
+function resultsKey(season: number, week: number, league: League): string {
+  return `${KEY_PREFIX}results:${season}:${week}:${league}`;
+}
+
+function calendarKey(league: League, season: number): string {
+  return `${KEY_PREFIX}calendar:${league}:${season}`;
+}
+
+function cachedKeys(prefix: string): Array<string> {
+  const keys: Array<string> = [];
+  for (let index = 0; index < localStorage.length; index++) {
+    const key = localStorage.key(index);
+    if (key?.startsWith(prefix)) {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+function clearCache(): void {
+  try {
+    cachedKeys(KEY_PREFIX).forEach((key) => localStorage.removeItem(key));
+  } catch (error) {
+    // Called from catch blocks that turn a storage failure into a cache miss. If
+    // storage is blocked outright, this must not throw past them.
+    console.warn("Could not clear the ESPN cache", error);
+  }
+}
+
+/** Writes a value, having made room for it, and never throws. */
+function store(key: string, prefix: string, cap: number, value: unknown): void {
+  try {
+    // Pruned before writing, so the entry being written is never the one dropped.
+    // localStorage does not report insertion order, so which others go is arbitrary.
+    // The cap is only here to bound how much space this takes.
+    const keys = cachedKeys(prefix).filter((it) => it !== key);
+    keys
+      .slice(0, Math.max(keys.length - (cap - 1), 0))
+      .forEach((it) => localStorage.removeItem(it));
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn("Could not cache an ESPN answer", error);
+    clearCache();
+  }
+}
+
+/** Reads a value back, and counts a corrupt or unreadable one as a miss. */
+function read<T>(key: string): T | undefined {
+  try {
+    const text = localStorage.getItem(key);
+    return text != null ? (JSON.parse(text) as T) : undefined;
+  } catch (error) {
+    // A cache is never allowed to break scoring.
+    console.warn("Could not read a cached ESPN answer", error);
+    clearCache();
+    return undefined;
+  }
+}
+
+/**
+ * What a matchup is filed under.
+ *
+ * Folded and sorted, because the workbook could name the same two teams either way
+ * around and in any case at all, while a result carries them already uppercased. A
+ * column names one team where every player picked the same side, and none at all
+ * where nobody filled it in, both of which are matchups in their own right.
+ */
+export function matchupKey(teams: Set<string>): string {
+  return [...teams]
+    .map((team) => team?.toUpperCase())
+    .sort()
+    .join("|");
+}
+
+/** The games this browser has stored for a week, keyed by matchup. */
+export function readCachedResults(
+  season: number,
+  week: number,
+  league: League,
+): Record<string, CachedGame> {
+  const stored = read<StoredWeek>(resultsKey(season, week, league));
+  if (stored?.version !== VERSION) {
+    return {};
+  }
+  const games: Record<string, CachedGame> = {};
+  Object.entries(stored.games).forEach(([key, game]) => {
+    games[key] = game == null ? null : { ...game, date: new Date(game.date) };
+  });
+  return games;
+}
+
+/**
+ * Keeps a week's finished games and its holes, dropping whatever it held before.
+ *
+ * The whole week goes in at once, so a matchup the picks no longer name is not left
+ * behind to be answered with.
+ */
+export function writeCachedResults(
+  season: number,
+  week: number,
+  league: League,
+  games: Record<string, CachedGame>,
+): void {
+  const entry: StoredWeek = {
+    version: VERSION,
+    games: games as StoredWeek["games"],
+  };
+  store(
+    resultsKey(season, week, league),
+    `${KEY_PREFIX}results:`,
+    MAX_CACHED_WEEKS,
+    entry,
+  );
+}
+
+/** Whether an answer is one this browser can hold on to for good. */
+export function isSettled(game: CachedGame): boolean {
+  return game == null || game.status === GameStatus.FINAL;
+}
+
+/**
+ * A season's calendar as ESPN sent it, or undefined where this browser has none.
+ *
+ * Held as the response rather than as what the response was read as, so the reading
+ * of it stays in one place and a stored date needs no bringing back to life.
+ */
+export function readCachedCalendar<T>(
+  league: League,
+  season: number,
+): T | undefined {
+  return read<T>(calendarKey(league, season));
+}
+
+export function writeCachedCalendar(
+  league: League,
+  season: number,
+  scoreboard: unknown,
+): void {
+  store(
+    calendarKey(league, season),
+    `${KEY_PREFIX}calendar:`,
+    MAX_CACHED_WEEKS,
+    scoreboard,
+  );
+}

--- a/src/utils/getLeagueInfo.test.ts
+++ b/src/utils/getLeagueInfo.test.ts
@@ -56,13 +56,28 @@ function scoreboard(
   return { leagues: [{ slug, season: { year: SEASON }, calendar }] };
 }
 
-function scoreboardForSeason(slug: string, seasonYear: number) {
-  return {
-    leagues: [
-      { slug, season: { year: seasonYear }, calendar: [REGULAR_SEASON] },
-    ],
-  };
+function scoreboardForSeason(
+  slug: string,
+  seasonYear: number,
+  calendar: Array<CalendarFixture> = [REGULAR_SEASON],
+) {
+  return { leagues: [{ slug, season: { year: seasonYear }, calendar }] };
 }
+
+/** A season every week of which is behind `NOW`. */
+const FINISHED_SEASON = {
+  value: String(SeasonType.REGULAR),
+  startDate: "2022-09-01T00:00Z",
+  endDate: "2023-01-01T00:00Z",
+  entries: [week("1", "2022-09-01T00:00Z", "2022-09-08T00:00Z")],
+};
+
+// ESPN's Off Season calendar runs to the following August, and has no weeks.
+const FINISHED_OFF_SEASON = {
+  value: String(SeasonType.OFF),
+  startDate: "2023-01-02T00:00Z",
+  endDate: "2025-08-01T00:00Z",
+};
 
 function mockFetch(body: unknown, ok = true, status = 200) {
   const fetchMock = vi.fn().mockResolvedValue({
@@ -88,6 +103,8 @@ async function infoFor(league: League) {
 }
 
 beforeEach(() => {
+  // jsdom keeps storage between cases, and a finished season's calendar is held there.
+  localStorage.clear();
   vi.useFakeTimers().setSystemTime(NOW);
 });
 
@@ -241,5 +258,49 @@ describe("getRegularSeasonWeekCount, caching", () => {
     await getRegularSeasonWeekCount(League.COLLEGE);
     await getRegularSeasonWeekCount(League.COLLEGE, 3003);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getLeagueInfo, what it holds on to", () => {
+  it("reads a finished season's calendar back rather than asking again", async () => {
+    const fetchMock = mockFetch(
+      scoreboardForSeason(League.PRO, 3101, [
+        FINISHED_SEASON,
+        FINISHED_OFF_SEASON,
+      ]),
+    );
+    const first = await getLeagueInfo(League.PRO, 3101);
+
+    const again = await getLeagueInfo(League.PRO, 3101);
+
+    // The Off Season calendar has yet to end, and is not what says whether a season is
+    // over: it has no weeks, and every week there is has been played.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(again?.season).toBe(3101);
+    expect(again?.activeCalendar.weeks).toEqual(first?.activeCalendar.weeks);
+    expect(again?.activeWeek?.startDate).toBeInstanceOf(Date);
+  });
+
+  it("asks again for a season that is not over", async () => {
+    const fetchMock = mockFetch(scoreboardForSeason(League.PRO, 3102));
+
+    await getLeagueInfo(League.PRO, 3102);
+    await getLeagueInfo(League.PRO, 3102);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("holds nothing where no season was named, that being whichever runs now", async () => {
+    const fetchMock = mockFetch(
+      scoreboardForSeason(League.PRO, 3103, [
+        FINISHED_SEASON,
+        FINISHED_OFF_SEASON,
+      ]),
+    );
+
+    await getLeagueInfo(League.PRO);
+    await getLeagueInfo(League.PRO);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/getLeagueInfo.ts
+++ b/src/utils/getLeagueInfo.ts
@@ -1,4 +1,5 @@
 import { League, LeagueInfo, SeasonType } from "../types/League";
+import { readCachedCalendar, writeCachedCalendar } from "./espnCache";
 
 type WeekEntry = {
   label: string;
@@ -96,6 +97,16 @@ async function fetchLeagueInfo(
   league: League,
   season?: number,
 ): Promise<LeagueInfo | null> {
+  // A season this browser has already seen the end of. Its schedule cannot gain
+  // another week, so it is read rather than asked for.
+  if (season != null) {
+    const held = readCachedCalendar<Scoreboard>(league, season);
+    const info = held != null ? toLeagueInfo(league, held) : null;
+    if (info != null) {
+      return info;
+    }
+  }
+
   // Get the ESPN league data.
   const response = await fetch(
     `https://site.api.espn.com/apis/site/v2/sports/football/${league}/scoreboard${
@@ -110,7 +121,38 @@ async function fetchLeagueInfo(
     return null;
   }
   const scoreboard: Scoreboard = await response.json();
+  const info = toLeagueInfo(league, scoreboard);
+  if (info != null && season != null && isSeasonOver(info)) {
+    // Only the calendar, not the whole answer, which carries a week of games with it.
+    writeCachedCalendar(league, season, {
+      leagues: scoreboard.leagues.filter(
+        (it) => it.slug === (league as string),
+      ),
+    });
+  }
+  return info;
+}
 
+/**
+ * Whether every week a season has is behind us.
+ *
+ * Read from the calendars that have weeks, because ESPN's Off Season calendar runs to
+ * the following August and would have a season looking unfinished for half a year
+ * after its last game.
+ */
+function isSeasonOver(info: LeagueInfo): boolean {
+  const now = new Date();
+  const dated = info.calendars.filter((calendar) => calendar.weeks.length > 0);
+  return (
+    dated.length > 0 &&
+    dated.every((calendar) => calendar.endDate.valueOf() < now.valueOf())
+  );
+}
+
+function toLeagueInfo(
+  league: League,
+  scoreboard: Scoreboard,
+): LeagueInfo | null {
   // Find the requested league. Should always be index 0, but we are being safe.
   const leagueMetadata = scoreboard.leagues.find(
     (it) => it.slug === (league as string),

--- a/src/utils/getLeagueResults.test.ts
+++ b/src/utils/getLeagueResults.test.ts
@@ -107,6 +107,9 @@ const bufVsKc = espnEvent({ home: "BUF", away: "KC" });
 const BUF_KC = new Set(["BUF", "KC"]);
 
 beforeEach(() => {
+  // jsdom keeps storage between cases, and a week whose games are over is held there,
+  // so a later case would find an answer an earlier one left behind.
+  localStorage.clear();
   vi.spyOn(console, "log").mockImplementation(() => undefined);
   // The counts the calendars carried in 2024.
   weekCountMock.mockImplementation(async (league) =>
@@ -410,5 +413,127 @@ describe("getLeagueResults, matchup filtering", () => {
       new Set<string>(),
     ]);
     expect(results).toHaveLength(0);
+  });
+});
+
+describe("getLeagueResults, what it does not ask twice", () => {
+  const SEASON = 2024;
+  const PHI_DAL = new Set(["PHI", "DAL"]);
+
+  it("asks nothing more once every game of the week is over", async () => {
+    const fetchMock = mockFetch([bufVsKc]);
+    const first = await getLeagueResults(League.PRO, WEEK, [BUF_KC], SEASON);
+
+    const again = await getLeagueResults(League.PRO, WEEK, [BUF_KC], SEASON);
+
+    expect(urlsOf(fetchMock)).toHaveLength(1);
+    expect(again).toEqual(first);
+    // Through storage and back, so a date is a date rather than the text it was kept as.
+    expect(again[0].date).toBeInstanceOf(Date);
+  });
+
+  it("asks again while a game is still being played", async () => {
+    const fetchMock = mockFetch([
+      espnEvent({ home: "BUF", away: "KC", status: GameStatus.LIVE }),
+    ]);
+
+    await getLeagueResults(League.PRO, WEEK, [BUF_KC], SEASON);
+    await getLeagueResults(League.PRO, WEEK, [BUF_KC], SEASON);
+
+    expect(urlsOf(fetchMock)).toHaveLength(2);
+  });
+
+  it("asks again when the picks name a matchup it has no answer for", async () => {
+    const fetchMock = mockFetch([bufVsKc]);
+
+    await getLeagueResults(League.PRO, WEEK, [BUF_KC], SEASON);
+    // Every player picked the same side, so the column names one team, not two.
+    await getLeagueResults(League.PRO, WEEK, [new Set(["BUF"])], SEASON);
+
+    expect(urlsOf(fetchMock)).toHaveLength(2);
+  });
+
+  it("remembers a matchup ESPN listed no game for", async () => {
+    const fetchMock = mockFetch([bufVsKc]);
+    const matchups = [BUF_KC, PHI_DAL];
+
+    const first = await getLeagueResults(League.PRO, WEEK, matchups, SEASON);
+    const again = await getLeagueResults(League.PRO, WEEK, matchups, SEASON);
+
+    expect(urlsOf(fetchMock)).toHaveLength(1);
+    expect(first).toHaveLength(1);
+    expect(again).toEqual(first);
+  });
+
+  it("keeps a finished game the next answer has stopped listing", async () => {
+    const live = espnEvent({
+      home: "PHI",
+      away: "DAL",
+      id: "2",
+      status: GameStatus.LIVE,
+    });
+    const fetchMock = mockFetch([bufVsKc, live]);
+    const matchups = [BUF_KC, PHI_DAL];
+    await getLeagueResults(League.PRO, WEEK, matchups, SEASON);
+
+    // ESPN moves a game out of a week's answer from time to time. Without the game it
+    // held, the column would go from scored to missing.
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ events: [live] }),
+    });
+    const again = await getLeagueResults(League.PRO, WEEK, matchups, SEASON);
+
+    expect(urlsOf(fetchMock)).toHaveLength(2);
+    expect(again.map((it) => it.shortName).sort()).toEqual([
+      "DAL @ PHI",
+      "KC @ BUF",
+    ]);
+  });
+
+  it("holds nothing from a week ESPN has not published", async () => {
+    const fetchMock = mockFetch([]);
+
+    await getLeagueResults(League.PRO, WEEK, [BUF_KC], SEASON);
+    await getLeagueResults(League.PRO, WEEK, [BUF_KC], SEASON);
+
+    expect(urlsOf(fetchMock)).toHaveLength(2);
+  });
+
+  it("asks again where no season was named, which names no week to hold", async () => {
+    const fetchMock = mockFetch([bufVsKc]);
+
+    await getLeagueResults(League.PRO, WEEK, [BUF_KC]);
+    await getLeagueResults(League.PRO, WEEK, [BUF_KC]);
+
+    expect(urlsOf(fetchMock)).toHaveLength(2);
+  });
+
+  it("gives a bowl week's later game first from what it held", async () => {
+    const fetchMock = mockFetch([
+      espnEvent({ home: "OSU", away: "MICH", date: "2024-10-02T17:00Z" }),
+      espnEvent({
+        home: "PSU",
+        away: "IOWA",
+        date: "2024-10-05T17:00Z",
+        id: "2",
+      }),
+    ]);
+    const matchups = [new Set(["OSU", "MICH"]), new Set(["PSU", "IOWA"])];
+    await getLeagueResults(League.COLLEGE, WEEK, matchups, SEASON);
+
+    const again = await getLeagueResults(
+      League.COLLEGE,
+      WEEK,
+      matchups,
+      SEASON,
+    );
+
+    // Both college groups answered with both games, and one game is held per matchup.
+    expect(urlsOf(fetchMock)).toHaveLength(2);
+    expect(again.map((it) => it.shortName)).toEqual([
+      "IOWA @ PSU",
+      "MICH @ OSU",
+    ]);
   });
 });

--- a/src/utils/getLeagueResults.ts
+++ b/src/utils/getLeagueResults.ts
@@ -13,6 +13,13 @@ import {
   Possession,
 } from "../types/LeagueResult";
 import debugLog from "./debugLog";
+import {
+  CachedGame,
+  isSettled,
+  matchupKey,
+  readCachedResults,
+  writeCachedResults,
+} from "./espnCache";
 import { getRegularSeasonWeekCount } from "./getLeagueInfo";
 
 /**
@@ -266,8 +273,31 @@ export function toLeagueResult(event: EspnEvent): LeagueResult | null {
 }
 
 /**
- * Get the results for a given league in a given week.
- * Output is sorted by date (earliest date first).
+ * The order the fetch puts a league's games in.
+ *
+ * College is latest first, because its postseason arrives as one bowl week spanning a
+ * month and a team can appear twice, the later game being the one the week is about.
+ * Whichever game of the two comes first is the one every lookup by team answers with.
+ */
+function inFetchOrder(
+  league: League,
+  results: Array<LeagueResult>,
+): Array<LeagueResult> {
+  if (league !== League.COLLEGE) {
+    return results;
+  }
+  return [...results].sort((a, b) => b.date.valueOf() - a.date.valueOf());
+}
+
+/**
+ * Get the results for a given league in a given week, in `inFetchOrder`.
+ *
+ * Nothing is fetched where this browser already has an answer for every matchup that
+ * ESPN cannot answer differently later: a game that has been played, or a matchup it
+ * listed no game for. That covers a whole week once its last game is over, which is
+ * every week but the one being played, and the calendar reads behind the fetch go with
+ * it. Changing the picks changes which matchups are asked about, and a matchup that
+ * moved has nothing stored under its new name, so the week is fetched again.
  *
  * @param league league for which to get results
  * @param week week in the season (week 1 is the first NFL week)
@@ -281,15 +311,61 @@ export async function getLeagueResults(
   matchups: Array<Set<string>>,
   season?: number,
 ): Promise<Array<LeagueResult>> {
+  const keys = matchups.map(matchupKey);
+  // "Whichever season is running" is not something an answer can be filed under, so a
+  // week with no season named is always fetched.
+  const held =
+    season != null ? readCachedResults(season, week.value, league) : {};
+  if (keys.every((key) => key in held)) {
+    const settled = [...new Set(keys)]
+      .map((key) => held[key])
+      .filter((game) => game != null);
+    debugLog(`${league} games, every one of them already held`, settled);
+    return inFetchOrder(league, settled);
+  }
+
   const events = await getLeagueEvents(league, week, season);
   debugLog(`${league} events`, events);
 
-  return events
+  const results = events
     .map(toLeagueResult)
     .filter((it) => it != null)
     .filter((result) =>
       matchups.some((teams) => matchesMatchup(result, teams)),
     );
+
+  // Each matchup and the one game the fetch found for it. `find` over results already
+  // in fetch order picks the same game every lookup by team will.
+  const found = new Map<string, CachedGame>();
+  matchups.forEach((teams, index) => {
+    if (found.has(keys[index])) return;
+    found.set(
+      keys[index],
+      results.find((result) => matchesMatchup(result, teams)) ?? null,
+    );
+  });
+
+  const games: Record<string, CachedGame> = {};
+  const kept: Array<LeagueResult> = [];
+  found.forEach((result, key) => {
+    // A game the fetch no longer lists keeps the outcome this browser already had.
+    // ESPN moves a game out of a week's answer now and then, and without this the
+    // column would go from scored to missing.
+    const game = result ?? held[key] ?? null;
+    if (result == null && game != null) {
+      kept.push(game);
+    }
+    if (isSettled(game)) {
+      games[key] = game;
+    }
+  });
+  // An answer with no games in it is ESPN not having published the week yet, and
+  // holding every matchup of it as a hole would leave the week empty for good.
+  if (season != null && events.length > 0) {
+    writeCachedResults(season, week.value, league, games);
+  }
+
+  return inFetchOrder(league, [...results, ...kept]);
 }
 
 /**

--- a/src/utils/getLeagueResults.ts
+++ b/src/utils/getLeagueResults.ts
@@ -273,24 +273,28 @@ export function toLeagueResult(event: EspnEvent): LeagueResult | null {
 }
 
 /**
- * The order the fetch puts a league's games in.
+ * A league's games in date order, college latest first and pro earliest first.
  *
- * College is latest first, because its postseason arrives as one bowl week spanning a
+ * College runs backwards because its postseason arrives as one bowl week spanning a
  * month and a team can appear twice, the later game being the one the week is about.
  * Whichever game of the two comes first is the one every lookup by team answers with.
+ *
+ * Sorted here rather than left in the order ESPN sent, because a game this browser
+ * remembered and the ones just fetched are answered with together.
  */
-function inFetchOrder(
+function inDateOrder(
   league: League,
   results: Array<LeagueResult>,
 ): Array<LeagueResult> {
-  if (league !== League.COLLEGE) {
-    return results;
-  }
-  return [...results].sort((a, b) => b.date.valueOf() - a.date.valueOf());
+  const earliestFirst = league !== League.COLLEGE;
+  return [...results].sort((a, b) => {
+    const gap = a.date.valueOf() - b.date.valueOf();
+    return earliestFirst ? gap : -gap;
+  });
 }
 
 /**
- * Get the results for a given league in a given week, in `inFetchOrder`.
+ * Get the results for a given league in a given week, in `inDateOrder`.
  *
  * Nothing is fetched where this browser already has an answer for every matchup that
  * ESPN cannot answer differently later: a game that has been played, or a matchup it
@@ -321,7 +325,7 @@ export async function getLeagueResults(
       .map((key) => held[key])
       .filter((game) => game != null);
     debugLog(`${league} games, every one of them already held`, settled);
-    return inFetchOrder(league, settled);
+    return inDateOrder(league, settled);
   }
 
   const events = await getLeagueEvents(league, week, season);
@@ -365,7 +369,7 @@ export async function getLeagueResults(
     writeCachedResults(season, week.value, league, games);
   }
 
-  return inFetchOrder(league, [...results, ...kept]);
+  return inDateOrder(league, [...results, ...kept]);
 }
 
 /**

--- a/src/utils/localStorageCache.ts
+++ b/src/utils/localStorageCache.ts
@@ -1,0 +1,76 @@
+// A capped, prefixed corner of localStorage, shared by the caches built on one.
+//
+// Everything kept this way is something a page load can do without, so a read or a
+// write that fails counts as a miss and never as an error. A failure of either clears
+// the cache, on the grounds that storage this browser cannot be trusted with is better
+// left empty than left half full.
+
+export type LocalStorageCache<T> = {
+  /** The value stored under a name, or undefined for one this browser does not have. */
+  read: (name: string) => T | undefined;
+  write: (name: string, value: T) => void;
+};
+
+export default function localStorageCache<T>(options: {
+  /** What every key of this cache starts with, which a prune and a clear go by. */
+  prefix: string;
+  /** How many entries to keep. A size guard, not a history. */
+  cap: number;
+  /** Names this cache in a warning. */
+  label: string;
+  encode: (value: T) => string;
+  decode: (text: string) => T;
+}): LocalStorageCache<T> {
+  const { prefix, cap, label, encode, decode } = options;
+
+  function ownKeys(): Array<string> {
+    const keys: Array<string> = [];
+    for (let index = 0; index < localStorage.length; index++) {
+      const key = localStorage.key(index);
+      if (key?.startsWith(prefix)) {
+        keys.push(key);
+      }
+    }
+    return keys;
+  }
+
+  function clear(): void {
+    try {
+      ownKeys().forEach((key) => localStorage.removeItem(key));
+    } catch (error) {
+      // Called from the catch blocks below, which turn a storage failure into a miss.
+      // If storage is blocked outright, this must not throw past them.
+      console.warn(`Could not clear the ${label} cache`, error);
+    }
+  }
+
+  return {
+    read(name) {
+      try {
+        const text = localStorage.getItem(prefix + name);
+        return text != null ? decode(text) : undefined;
+      } catch (error) {
+        console.warn(`Could not read the ${label} cache`, error);
+        clear();
+        return undefined;
+      }
+    },
+
+    write(name, value) {
+      const key = prefix + name;
+      try {
+        // Pruned before writing, so the entry being written is never the one dropped.
+        // localStorage does not report insertion order, so which others go is arbitrary.
+        // The cap is only here to bound how much space this takes.
+        const keys = ownKeys().filter((it) => it !== key);
+        keys
+          .slice(0, Math.max(keys.length - (cap - 1), 0))
+          .forEach((it) => localStorage.removeItem(it));
+        localStorage.setItem(key, encode(value));
+      } catch (error) {
+        console.warn(`Could not write the ${label} cache`, error);
+        clear();
+      }
+    },
+  };
+}

--- a/src/utils/picksCache.ts
+++ b/src/utils/picksCache.ts
@@ -3,16 +3,13 @@
 // scores: recomputing those is fast, and a cached score could go stale against a
 // change to the scoring rules.
 
-const KEY_PREFIX = "rak-madness:picks:";
+import localStorageCache from "./localStorageCache";
+
 /** A size guard, not a history. Picks files are tens of KB. */
 const MAX_CACHED_WEEKS = 3;
 // Encoding the whole buffer in one call overflows the argument list, so it goes
 // through in slices.
 const BASE64_CHUNK_BYTES = 8192;
-
-function keyFor(season: number, week: number): string {
-  return `${KEY_PREFIX}${season}:${week}`;
-}
 
 function toBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
@@ -34,42 +31,20 @@ function fromBase64(text: string): ArrayBuffer {
   return bytes.buffer;
 }
 
-function cachedKeys(): Array<string> {
-  const keys: Array<string> = [];
-  for (let index = 0; index < localStorage.length; index++) {
-    const key = localStorage.key(index);
-    if (key?.startsWith(KEY_PREFIX)) {
-      keys.push(key);
-    }
-  }
-  return keys;
-}
-
-function clearCache(): void {
-  try {
-    cachedKeys().forEach((key) => localStorage.removeItem(key));
-  } catch (error) {
-    // Called from catch blocks that turn a storage failure into a cache miss.
-    // If storage is blocked outright, this must not throw past them.
-    console.warn("Could not clear picks cache", error);
-  }
-}
+const workbooks = localStorageCache<ArrayBuffer>({
+  prefix: "rak-madness:picks:",
+  cap: MAX_CACHED_WEEKS,
+  label: "picks",
+  encode: toBase64,
+  decode: fromBase64,
+});
 
 /** The cached workbook for a week, or undefined if there isn't a usable one. */
 export function readCachedPicks(
   season: number,
   week: number,
 ): ArrayBuffer | undefined {
-  try {
-    const text = localStorage.getItem(keyFor(season, week));
-    return text != null ? fromBase64(text) : undefined;
-  } catch (error) {
-    // A cache is never allowed to break scoring, so a corrupt or unreadable
-    // entry counts as a miss.
-    console.warn("Could not read cached picks", error);
-    clearCache();
-    return undefined;
-  }
+  return workbooks.read(`${season}:${week}`);
 }
 
 export function writeCachedPicks(
@@ -77,17 +52,5 @@ export function writeCachedPicks(
   week: number,
   buffer: ArrayBuffer,
 ): void {
-  try {
-    // Prune before writing, so the week being written is never the one dropped.
-    // localStorage does not report insertion order, so which other weeks go is
-    // arbitrary. The cap is only here to bound how much space this takes.
-    const keys = cachedKeys().filter((key) => key !== keyFor(season, week));
-    keys
-      .slice(0, Math.max(keys.length - (MAX_CACHED_WEEKS - 1), 0))
-      .forEach((key) => localStorage.removeItem(key));
-    localStorage.setItem(keyFor(season, week), toBase64(buffer));
-  } catch (error) {
-    console.warn("Could not cache picks", error);
-    clearCache();
-  }
+  workbooks.write(`${season}:${week}`, buffer);
 }


### PR DESCRIPTION
## What

`espnCache` holds in `localStorage` what ESPN cannot answer differently later: a game already played, a matchup it listed no game for, a finished season's calendar. A settled week costs no requests instead of five.

## Changes

- Keyed by the matchup the picks name, so a picks change invalidates an entry itself.
- The check sits before `getLeagueEvents`, so the two calendar reads go too.
- An unpublished week stores nothing, else an empty answer freezes until the picks change.
- A game the next answer drops is kept, and `inDateOrder` sorts it back in.
- A season is over per the calendars with weeks. Off Season runs to next August.
- `localStorageCache` is the plumbing both caches had a copy of, hence `picksCache` here.

## Verification

- The tests mock `fetch`. A throwaway suite on live ESPN put a finished 2024 week and its calendar at zero requests on a reload.
- The browser path is unexercised, needing `pages:dev` and R2.

## Notes / Follow-ups

- A settled entry is held until the picks change. Clearing site data is the escape hatch.
- No server-side cache: ESPN 403s a Pages Function unless it sends a client `User-Agent`.

🕵️ Neutralized by [Agent Spy Fox](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
