### PR TITLE
feat: stand the table on the page's blue, and link the game dialog out to ESPN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ worth showing. Deployed to Cloudflare Pages (`wrangler`);
 absolute path: `manifest.json`, the `favicon.ico` and `logo*.png` icons, and
 `robots.txt`. The HTML shell is `index.html` at the repo root.
 
+[`SCROLL-FLASH.md`](SCROLL-FLASH.md): an open bug, read before changing sticky.
+
 ## Subdirectories
 
 - [`src/`](src/CLAUDE.md) — application source

--- a/SCROLL-FLASH.md
+++ b/SCROLL-FLASH.md
@@ -1,0 +1,75 @@
+# The scroll flash on Android Firefox
+
+Flinging the results table on Android Firefox flashes a solid color over and
+around the pinned header and the pinned player column, for a frame or two. Not
+reproducible in desktop Firefox or Chrome, and not reproducible in a device
+emulator, because it needs the real async-scrolling path.
+
+Unresolved. This file records what is known so the next attempt does not repeat
+the four that failed.
+
+## Mechanism, confirmed
+
+Firefox scrolls asynchronously on the compositor. A fast fling outruns the
+rasterizer, and any region not yet rasterized is filled with a flat color.
+
+That color is read from **the scroll container's own background**, not from
+anything painted inside it. `.page__content` is the scroll container. Setting it
+to `--rak-primary-800` turned the flash from white to dark, which is how the
+mechanism was confirmed.
+
+Sticky elements are excluded from the layer the scrolled content rasterizes
+into, so each one leaves a hole. During a fling the hole is what gets the flat
+fill. The table has roughly forty sticky elements: every `<th>` in the header,
+and one `<td>` per row in the player column.
+
+## Bisected
+
+Two throwaway branches, both flick-tested on the reporter's phone:
+
+- `debug-no-sticky` — every `position: sticky` in `Table.scss` set to `static`.
+  **Flash gone.** Sticky is the cause.
+- `debug-header-sticky-only` — header still pins, player column does not. Result
+  not recorded; run this first if picking the work back up.
+
+Delete both branches when this is settled.
+
+## Ruled out
+
+Each of these was shipped, flick-tested, and did not fix it:
+
+1. Moving sticky off `<thead>` onto each `<th>`, on the theory that a sticky cell
+   inside a sticky section falls off the compositor path.
+2. `will-change: transform` on the player column, to force it onto its own layer.
+   Reverted, since it costs GPU memory on every row for nothing.
+3. Widening `.results-scores` to `max-content` so the frame's fill spans the
+   whole table. Correct on its own merits and kept, but it paints a descendant
+   of the scroll container, which is not where the flat fill comes from.
+4. Dropping `z-index` from the player column's cells, so they would not each
+   become a stacking context.
+
+## Options considered
+
+**A. Recolor the player column.** The flat fill on a phone is already the
+header's own dark, so a header hole is invisible. A dark player column would make
+its hole invisible too. One SCSS change, no architecture. Costs the blue and
+peach in-contention and knocked-out fills in that column, though
+`PlayerStatusIcon` already carries the same status.
+
+**B. Frozen panes.** Lift the rank and player columns out of the horizontal
+scroller so nothing in `<tbody>` is sticky. There is no CSS-only version of this:
+`overflow-x: auto` forces `overflow-y` to `auto`, so once the body columns have
+their own horizontal scroller the header's `top: 0` resolves against that box
+instead of the page and stops pinning. One scroll container needs sticky on both
+axes; two need a scroll listener syncing one axis, which lags on a fling. Trading
+a flash for a lag may not be a win.
+
+**C. CSS grid with ARIA grid roles.** The frozen column becomes one sticky
+element instead of thirty. Largest change, gives up native table semantics, and
+is still sticky, so it may still hole.
+
+## If picking this back up
+
+Run `debug-header-sticky-only` first. If the flash is gone there, only the player
+column matters and option A is enough. If it is still there, the header's sticky
+holes too, and no recoloring covers both.

--- a/src/components/dialog/DialogCombobox.tsx
+++ b/src/components/dialog/DialogCombobox.tsx
@@ -39,11 +39,24 @@ export default function DialogCombobox<T>({
   itemToStringLabel: (item: T) => string;
   itemKey: (item: T) => string;
   optionClassName?: (item: T) => string;
-  /** Held at the end of the input, saying something about what is chosen. */
+  /**
+   * Held at the end of the input, saying something about what is chosen. Drawn
+   * only while the input still names it, so a cleared search clears this too.
+   */
   adornment?: ReactNode;
   renderOption: (item: T) => ReactNode;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
+
+  /**
+   * Whether the input still reads as the choice the adornment speaks for.
+   *
+   * A press wipes the query below without touching the choice, so between that
+   * and the next selection the adornment would be marking a subject the input no
+   * longer names. Base UI writes the chosen label back on the way out of a list
+   * dismissed without a pick, so that restores this along with the text.
+   */
+  const showsChoice = value != null && query === itemToStringLabel(value);
 
   /**
    * Choosing is the end of the search, so the input gives the focus up.
@@ -103,7 +116,7 @@ export default function DialogCombobox<T>({
           aria-label={ariaLabel}
           className="dialog__input"
         />
-        {adornment}
+        {showsChoice && adornment}
         <Combobox.Icon className="dialog__input-icon">
           <UnfoldMoreIcon />
         </Combobox.Icon>

--- a/src/components/gameStatus/CLAUDE.md
+++ b/src/components/gameStatus/CLAUDE.md
@@ -6,7 +6,7 @@ How a game in the week is going, opened from a pick cell in the picks table.
   table column order, which the query matches too. `GameMark` says where a game stands;
   `useLiveGame` keeps the chosen one fresh.
 - `GameStatusSummary`: the pool's line, the game as ESPN's boxscore says it, its kickoff,
-  Gamecast link and venue. The wireframe is that layout over the week's own copy of it,
+  town and Gamecast link. The wireframe is that layout over the week's own copy of it,
   so a wait is the size of the answer.
 - `GameStatusSummary.scss`: both sides in one grid, the dash in a track between two
   equal ones, so nothing either side moves it. `--rak-score-size` sizes that row; under

--- a/src/components/gameStatus/CLAUDE.md
+++ b/src/components/gameStatus/CLAUDE.md
@@ -5,9 +5,9 @@ How a game in the week is going, opened from a pick cell in the picks table.
 - `GameStatusDialog`: `DialogShell` over a `DialogCombobox` of `scores.games`, in picks
   table column order, which the query matches too. `GameMark` says where a game stands;
   `useLiveGame` keeps the chosen one fresh.
-- `GameStatusSummary`: the pool's line, the game as ESPN's boxscore says it, its kickoff
-  and its venue. The wireframe is that layout over the week's own copy of the game, so a
-  wait is the size of the answer.
+- `GameStatusSummary`: the pool's line, the game as ESPN's boxscore says it, its kickoff,
+  Gamecast link and venue. The wireframe is that layout over the week's own copy of it,
+  so a wait is the size of the answer.
 - `GameStatusSummary.scss`: both sides in one grid, the dash in a track between two
   equal ones, so nothing either side moves it. `--rak-score-size` sizes that row; under
   `$breakpoint-marks` the marks come off.

--- a/src/components/gameStatus/GameStatusSummary.scss
+++ b/src/components/gameStatus/GameStatusSummary.scss
@@ -21,7 +21,9 @@
 // What separates one part of the strip under the scoreline from the next.
 @mixin meta-dot {
   content: "·";
-  margin-inline: var(--rak-space-2);
+  // Set where the dots are, so the strip can pull its parts together on a screen
+  // that has to hold three of them on one line.
+  margin-inline: var(--rak-meta-dot-gap);
 }
 
 // A bar over the words an element holds, one on each line of it, so a name that wraps
@@ -140,6 +142,11 @@
 // a long venue name needs it. Set apart by the space between them rather than by a
 // glyph, since each half already reads with a `·` inside it.
 .game-status__meta {
+  // Tight enough that the day, the kickoff and the link out hold one line on a
+  // phone. The room a wider screen has goes back at the foot of this block, where
+  // the two halves come onto one line and the dots between them read the same.
+  --rak-meta-dot-gap: var(--rak-space-1);
+
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -154,6 +161,10 @@
   }
 
   @include wide-screen {
+    // Room enough for the halves to share a line, so the dots can have their space
+    // back and the whole strip reads as one sentence rather than a crowded one.
+    --rak-meta-dot-gap: var(--rak-space-2);
+
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: center;
@@ -167,6 +178,14 @@
       @include meta-dot;
     }
   }
+}
+
+// The one part of the strip that goes anywhere. Underlined rather than colored, so
+// it reads as a link without pulling the eye off the scoreline the dialog was opened
+// for.
+.game-status__gamecast {
+  color: inherit;
+  text-decoration: underline;
 }
 
 // Held to a square whatever shape the mark is, so a wide logo and a tall one take

--- a/src/components/gameStatus/GameStatusSummary.scss
+++ b/src/components/gameStatus/GameStatusSummary.scss
@@ -21,9 +21,7 @@
 // What separates one part of the strip under the scoreline from the next.
 @mixin meta-dot {
   content: "·";
-  // Set where the dots are, so the strip can pull its parts together on a screen
-  // that has to hold three of them on one line.
-  margin-inline: var(--rak-meta-dot-gap);
+  margin-inline: var(--rak-space-2);
 }
 
 // A bar over the words an element holds, one on each line of it, so a name that wraps
@@ -138,15 +136,10 @@
 // What is the same about the game however it is going: when it starts and where it
 // is being played. Under the scoreline, as a footnote to it.
 //
-// One line where the dialog is wide enough to hold both, wrapping back to two where
-// a long venue name needs it. Set apart by the space between them rather than by a
-// glyph, since each half already reads with a `·` inside it.
+// One line where the dialog is wide enough to hold both halves, wrapping back to two
+// where it is not. Set apart by the space between them rather than by a glyph, since
+// each half already reads with a `·` inside it.
 .game-status__meta {
-  // Tight enough that the day, the kickoff and the link out hold one line on a
-  // phone. The room a wider screen has goes back at the foot of this block, where
-  // the two halves come onto one line and the dots between them read the same.
-  --rak-meta-dot-gap: var(--rak-space-1);
-
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -161,10 +154,6 @@
   }
 
   @include wide-screen {
-    // Room enough for the halves to share a line, so the dots can have their space
-    // back and the whole strip reads as one sentence rather than a crowded one.
-    --rak-meta-dot-gap: var(--rak-space-2);
-
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: center;

--- a/src/components/gameStatus/GameStatusSummary.test.tsx
+++ b/src/components/gameStatus/GameStatusSummary.test.tsx
@@ -342,22 +342,24 @@ describe("GameStatusSummary, which side took the point", () => {
     expect(missed).toEqual(["KC"]);
   });
 
-  it("marks neither side on a game that landed on the number", () => {
+  // A push and a tie with no line are a point for everybody, so every pick was on a
+  // side that scored and neither side is marked against.
+  it("marks both sides on a game that landed on the number", () => {
     expect(marked({ team: "BUF", points: -10 })).toEqual({
-      scored: [],
+      scored: ["KC", "BUF"],
       missed: [],
-      scores: [],
+      scores: ["20", "30"],
     });
   });
 
-  it("marks neither side on a game that finished level", () => {
+  it("marks both sides on a game that finished level", () => {
     const drawn = {
       away: { ...result().away, score: 30 },
       winner: { team: null, homeAway: null, by: 0 },
       loser: { team: null, homeAway: null, by: 0 },
     };
     const { scored, missed } = marked(undefined, drawn);
-    expect(scored).toEqual([]);
+    expect(scored).toEqual(["KC", "BUF"]);
     expect(missed).toEqual([]);
   });
 

--- a/src/components/gameStatus/GameStatusSummary.test.tsx
+++ b/src/components/gameStatus/GameStatusSummary.test.tsx
@@ -46,7 +46,7 @@ function result(over: Partial<LeagueResult> = {}): LeagueResult {
       record: "3-2",
       linescores: [7, 3, 10, 0],
     },
-    venue: { name: "Highmark Stadium", city: "Orchard Park", state: "NY" },
+    venue: "Orchard Park, NY",
     possession: {},
     winner: {
       team: { name: "Buffalo Bills", abbreviation: "BUF" },
@@ -211,11 +211,16 @@ describe("GameStatusSummary, a game that is over", () => {
     expect(screen.queryByText("Away")).toBeNull();
   });
 
-  it("heads the scoreline with the venue", () => {
+  it("ends the strip with where it was played and the link out, in that order", () => {
     renderFinal();
     // Each part on its own, since a dot between two of them is the stylesheet's.
-    expect(screen.getByText("Highmark Stadium")).toBeInTheDocument();
-    expect(screen.getByText("Orchard Park, NY")).toBeInTheDocument();
+    expect(
+      [
+        ...document.querySelectorAll(
+          ".game-status__meta-group:last-child span",
+        ),
+      ].map((part) => part.textContent),
+    ).toEqual(["Orchard Park, NY", "Gamecast"]);
   });
 
   it("says FT/OT, and nothing about how the quarters went", () => {
@@ -386,17 +391,9 @@ describe("GameStatusSummary, the kickoff", () => {
   function kickoff(timeZone: string): Array<string | null> {
     process.env.TZ = timeZone;
     render(<GameStatusSummary game={game(result())} result={result()} />);
-    return (
-      [
-        ...document.querySelectorAll(
-          ".game-status__meta-group:first-child span",
-        ),
-      ]
-        // The link out rides in this half after the time. It says the same thing
-        // whatever zone the reader is in, so it is not part of what these ask.
-        .filter((part) => part.querySelector("a") == null)
-        .map((part) => part.textContent)
-    );
+    return [
+      ...document.querySelectorAll(".game-status__meta-group:first-child span"),
+    ].map((part) => part.textContent);
   }
 
   it("says the day, the year and the time in the reader's own zone, and names it", () => {

--- a/src/components/gameStatus/GameStatusSummary.test.tsx
+++ b/src/components/gameStatus/GameStatusSummary.test.tsx
@@ -386,9 +386,17 @@ describe("GameStatusSummary, the kickoff", () => {
   function kickoff(timeZone: string): Array<string | null> {
     process.env.TZ = timeZone;
     render(<GameStatusSummary game={game(result())} result={result()} />);
-    return [
-      ...document.querySelectorAll(".game-status__meta-group:first-child span"),
-    ].map((part) => part.textContent);
+    return (
+      [
+        ...document.querySelectorAll(
+          ".game-status__meta-group:first-child span",
+        ),
+      ]
+        // The link out rides in this half after the time. It says the same thing
+        // whatever zone the reader is in, so it is not part of what these ask.
+        .filter((part) => part.querySelector("a") == null)
+        .map((part) => part.textContent)
+    );
   }
 
   it("says the day, the year and the time in the reader's own zone, and names it", () => {
@@ -475,9 +483,27 @@ describe("GameStatusSummary, a game still being played", () => {
     ]);
   });
 
-  it("sends a reader nowhere else: the dialog is the whole of it", () => {
+  it("sends a reader on to ESPN's own page for the game", () => {
     renderLive();
-    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByRole("link", { name: "Gamecast" })).toHaveAttribute(
+      "href",
+      "https://www.espn.com/nfl/game/_/gameId/401",
+    );
+  });
+
+  it("sends a college reader to the college section of the same site", () => {
+    // The league names itself in the path, so the two land on different sections
+    // rather than both on the one the pro games use.
+    render(
+      <GameStatusSummary
+        game={{ ...game(live), league: League.COLLEGE }}
+        result={live}
+      />,
+    );
+    expect(screen.getByRole("link", { name: "Gamecast" })).toHaveAttribute(
+      "href",
+      "https://www.espn.com/college-football/game/_/gameId/401",
+    );
   });
 
   it("holds the down's line with a word where there is no down to say", () => {

--- a/src/components/gameStatus/GameStatusSummary.test.tsx
+++ b/src/components/gameStatus/GameStatusSummary.test.tsx
@@ -168,9 +168,7 @@ describe("GameStatusSummary, what the pool made of a finished game", () => {
   });
 
   it("says a game that landed on the number scored for everybody", () => {
-    expect(covered({ team: "BUF", points: -10 })).toBe(
-      "Push, both sides scored",
-    );
+    expect(covered({ team: "BUF", points: -10 })).toBe("Push");
   });
 
   it("declares the winner where the picks carried no line", () => {
@@ -185,7 +183,7 @@ describe("GameStatusSummary, what the pool made of a finished game", () => {
     });
     render(<GameStatusSummary game={game(drawn)} result={drawn} />);
     expect(document.querySelector(".game-status__outcome")).toHaveTextContent(
-      "Tied, both sides scored",
+      "Tied",
     );
   });
 });

--- a/src/components/gameStatus/GameStatusSummary.tsx
+++ b/src/components/gameStatus/GameStatusSummary.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useState } from "react";
 import { GameStatus, HomeAway } from "../../types/ESPN";
+import { League } from "../../types/League";
 import { GameSide, LeagueResult } from "../../types/LeagueResult";
 import { GameSpread, WeekGame } from "../../types/WeekGame";
 import getClasses from "../../utils/getClasses";
@@ -20,6 +21,20 @@ const SCORE_DASH = "–";
  * is the same fact twice and in the wrong zone for anyone outside the east.
  */
 const PREGAME_DETAIL = "Pregame";
+
+/** What the link out to ESPN is called, which is what ESPN calls the page. */
+const GAMECAST_LABEL = "Gamecast";
+
+/**
+ * ESPN's own page for the game, where the drive chart and the box score this dialog
+ * leaves out are.
+ *
+ * The league names itself in the path, and the enum already holds the word ESPN uses
+ * for it, since the same value addresses the API the week is read from.
+ */
+function gamecastUrl(league: League, id: string): string {
+  return `https://www.espn.com/${league}/game/_/gameId/${id}`;
+}
 
 /** Points at the score of the side with the ball, from whichever side that is. */
 const MARKER: Record<HomeAway, string> = {
@@ -102,12 +117,17 @@ function venueParts(result: LeagueResult): Array<string> | undefined {
   return place !== "" ? [venue.name, place] : [venue.name];
 }
 
-/** One half of the strip under the scoreline, its parts dotted apart. */
-function MetaGroup({ parts }: { parts: Array<string> }) {
+/**
+ * One half of the strip under the scoreline, its parts dotted apart.
+ *
+ * Keyed by where a part sits rather than by what it says, because the parts are a
+ * fixed list in a fixed order and one of them is a link rather than a word.
+ */
+function MetaGroup({ parts }: { parts: Array<ReactNode> }) {
   return (
     <span className="game-status__meta-group">
-      {parts.map((part) => (
-        <span key={part}>{part}</span>
+      {parts.map((part, index) => (
+        <span key={index}>{part}</span>
       ))}
     </span>
   );
@@ -443,11 +463,17 @@ function Game({
   result,
   spread,
   logo,
+  gamecastHref,
 }: {
   result: LeagueResult;
   spread?: GameSpread;
   /** What a side wears beside its name, or nothing where the marks are dropped. */
   logo?: (side: GameSide) => ReactNode;
+  /**
+   * ESPN's page for the game. Left off the wireframe, which is hidden from a screen
+   * reader and would otherwise hold a link that can be tabbed to but not seen.
+   */
+  gamecastHref?: string;
 }) {
   const venue = venueParts(result);
   // Only once the game is over, which is when the sentence under the scores says the
@@ -488,7 +514,23 @@ function Game({
       {/* Under the scoreline rather than over it: the game is what the dialog was
           opened for, and when and where it is played is the footnote. */}
       <div className="game-status__meta">
-        <MetaGroup parts={kickoffParts(result.date)} />
+        {/* The link rides with the kickoff rather than the venue, so it sits after
+            the time at every width rather than moving when the two halves stack. */}
+        <MetaGroup
+          parts={[
+            ...kickoffParts(result.date),
+            gamecastHref != null && (
+              <a
+                className="game-status__gamecast"
+                href={gamecastHref}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {GAMECAST_LABEL}
+              </a>
+            ),
+          ].filter(Boolean)}
+        />
         {venue != null && <MetaGroup parts={venue} />}
       </div>
     </>
@@ -586,6 +628,7 @@ export default function GameStatusSummary({
       <Game
         result={result}
         spread={game.spread}
+        gamecastHref={gamecastUrl(game.league, result.id)}
         logo={
           logos
             ? (side) => (

--- a/src/components/gameStatus/GameStatusSummary.tsx
+++ b/src/components/gameStatus/GameStatusSummary.tsx
@@ -110,13 +110,6 @@ function kickoffParts(date: Date): Array<string> {
   ];
 }
 
-function venueParts(result: LeagueResult): Array<string> | undefined {
-  const { venue } = result;
-  if (venue == null) return undefined;
-  const place = [venue.city, venue.state].filter((it) => it != null).join(", ");
-  return place !== "" ? [venue.name, place] : [venue.name];
-}
-
 /**
  * One half of the strip under the scoreline, its parts dotted apart.
  *
@@ -475,7 +468,22 @@ function Game({
    */
   gamecastHref?: string;
 }) {
-  const venue = venueParts(result);
+  // The link rides with the place rather than the kickoff, so it ends the strip at
+  // every width rather than moving when the two halves stack. Both parts are their
+  // own, so a game ESPN sent no address for still carries the link.
+  const placeParts = [
+    result.venue,
+    gamecastHref != null && (
+      <a
+        className="game-status__gamecast"
+        href={gamecastHref}
+        target="_blank"
+        rel="noreferrer"
+      >
+        {GAMECAST_LABEL}
+      </a>
+    ),
+  ].filter(Boolean);
   // Only once the game is over, which is when the sentence under the scores says the
   // same thing. A side ahead at half time has won nothing yet.
   const isOver = result.status === GameStatus.FINAL;
@@ -514,24 +522,8 @@ function Game({
       {/* Under the scoreline rather than over it: the game is what the dialog was
           opened for, and when and where it is played is the footnote. */}
       <div className="game-status__meta">
-        {/* The link rides with the kickoff rather than the venue, so it sits after
-            the time at every width rather than moving when the two halves stack. */}
-        <MetaGroup
-          parts={[
-            ...kickoffParts(result.date),
-            gamecastHref != null && (
-              <a
-                className="game-status__gamecast"
-                href={gamecastHref}
-                target="_blank"
-                rel="noreferrer"
-              >
-                {GAMECAST_LABEL}
-              </a>
-            ),
-          ].filter(Boolean)}
-        />
-        {venue != null && <MetaGroup parts={venue} />}
+        <MetaGroup parts={kickoffParts(result.date)} />
+        {placeParts.length > 0 && <MetaGroup parts={placeParts} />}
       </div>
     </>
   );

--- a/src/components/gameStatus/GameStatusSummary.tsx
+++ b/src/components/gameStatus/GameStatusSummary.tsx
@@ -451,18 +451,16 @@ function Game({
   const venue = venueParts(result);
   // Only once the game is over, which is when the sentence under the scores says the
   // same thing. A side ahead at half time has won nothing yet.
-  const scored =
-    result.status === GameStatus.FINAL
-      ? scoringTeam(result, spread)
-      : undefined;
-  // Nothing on either side where nobody scored, since a tie and a push are a point
-  // for everybody and marking both sides green would say the same thing twice.
-  const outcomeOf = (side: GameSide): SideOutcome | undefined =>
-    scored == null
-      ? undefined
-      : side.team.abbreviation === scored
-        ? "scored"
-        : "missed";
+  const isOver = result.status === GameStatus.FINAL;
+  const scored = isOver ? scoringTeam(result, spread) : undefined;
+  // Both sides where the game is over and nobody scored, which is a push or a tie
+  // with no line to push against. The pool gives everybody the point there, so
+  // whichever side a pick was on, it was on a side that scored.
+  const outcomeOf = (side: GameSide): SideOutcome | undefined => {
+    if (!isOver) return undefined;
+    if (scored == null) return "scored";
+    return side.team.abbreviation === scored ? "scored" : "missed";
+  };
   return (
     <>
       <p className="game-status__spread">

--- a/src/components/gameStatus/GameStatusSummary.tsx
+++ b/src/components/gameStatus/GameStatusSummary.tsx
@@ -61,10 +61,11 @@ const NO_SPREAD = "None";
 /**
  * How a game that finished level, or on its number, was scored. Both are a point for
  * everybody: the pool counts a tie as picking the winner, and a margin that lands on
- * the spread as covering it.
+ * the spread as covering it. Said in the word alone, because the scoreline above
+ * marks both sides as having scored and would only be repeating itself here.
  */
-const TIED = "Tied, both sides scored";
-const PUSH = "Push, both sides scored";
+const TIED = "Tied";
+const PUSH = "Push";
 
 /**
  * When the game starts, as its own parts.

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -84,6 +84,12 @@
     @include roomy-screen {
       background-color: transparent;
       box-shadow: none;
+      // The room held for a scrollbar above goes with the fill. Held, it is a
+      // strip of the box the frame cannot reach, which used to be the same white
+      // as the box and is now the page showing through. It bought nothing here
+      // either: the table is `max-content` at this width, so a box narrower by a
+      // scrollbar moves where the table is centered rather than how wide it is.
+      scrollbar-gutter: auto;
     }
   }
 

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -47,8 +47,12 @@
   width: min(1024px, 100%);
   max-width: 100%;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  // Centered while what is inside fits, aligned to the start once it does not.
+  // Plain centering splits the overflow across both edges, and the half that
+  // goes off the near side cannot be scrolled back to: a table wider than the
+  // window would lose its first columns for good.
+  align-items: safe center;
+  justify-content: safe center;
   box-shadow: var(--rak-shadow-overlay);
   overflow: auto;
   // The room a scrollbar needs, held whether or not there is one, so a week long

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -100,6 +100,15 @@
   // its band out of the page. Refusing the pointer is what keeps this unscrollable.
   &.--frozen {
     pointer-events: none;
+
+    // Except across, where there is room to spare. A bar under a wireframe that
+    // refuses the pointer offers a scroll nothing can take, and at this width the
+    // wireframe is the only thing that would draw one. The band it held is given
+    // up with it, so a week wide enough to need a bar takes that height when it
+    // lands rather than before.
+    @include roomy-screen {
+      overflow-x: hidden;
+    }
   }
 }
 

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -70,9 +70,15 @@
     // The scrolling box's own fill, which is what Firefox paints into a region it
     // has not rasterized yet. It reads this element rather than whatever is drawn
     // inside it, so the frame's fill on `.results-scores` never reached it and a
-    // fast fling filled the gap with the white above. The table covers this
-    // whenever there is a frame to see, so it shows only in that gap.
+    // fast fling filled the gap with the white above. A phone's table is as wide as
+    // the box, so nothing but that gap ever shows this. A roomier screen leaves
+    // room beside the table, where it would show as a second dark band against the
+    // header, so the surface every other page carries goes back below.
     background-color: var(--rak-primary-800);
+
+    @include roomy-screen {
+      background-color: var(--rak-surface);
+    }
   }
 
   // The wireframe is the size of the table it stands in for, so the surest way to

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -67,6 +67,12 @@
   // inside this instead, and a wide one scrolls.
   &.--scores {
     width: 100%;
+    // The scrolling box's own fill, which is what Firefox paints into a region it
+    // has not rasterized yet. It reads this element rather than whatever is drawn
+    // inside it, so the frame's fill on `.results-scores` never reached it and a
+    // fast fling filled the gap with the white above. The table covers this
+    // whenever there is a frame to see, so it shows only in that gap.
+    background-color: var(--rak-primary-800);
   }
 
   // The wireframe is the size of the table it stands in for, so the surest way to

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -76,8 +76,14 @@
     // header, so the surface every other page carries goes back below.
     background-color: var(--rak-primary-800);
 
+    // Nothing of its own, so the tiled blue behind the page shows either side of
+    // the table, which is what every other page stands on. The shadow goes with
+    // it: it is what lifts a panel off that blue, and with the fill gone there is
+    // no panel here to lift. `ResultsFrame.scss` puts it on the table, which is
+    // what stands on the blue instead.
     @include roomy-screen {
-      background-color: var(--rak-surface);
+      background-color: transparent;
+      box-shadow: none;
     }
   }
 

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
@@ -208,6 +208,9 @@ describe("PlayerAnalysisDialog", () => {
     expect(
       screen.getByText("Knocked out on Total Score by Alice."),
     ).toBeInTheDocument();
+    // The mark beside the input speaks for the name that was in it, so it goes
+    // with the name rather than standing over an empty search.
+    expect(document.querySelector(".player-analysis__input-status")).toBeNull();
 
     // Dismissing puts the chosen name back, since the answer below is still that
     // player's.
@@ -215,6 +218,9 @@ describe("PlayerAnalysisDialog", () => {
     expect(screen.getByRole("combobox", { name: "Player" })).toHaveValue(
       "Bobby",
     );
+    expect(
+      document.querySelector(".player-analysis__input-status"),
+    ).toBeInTheDocument();
 
     // Only a press empties the search. A letter typed into it opens the list too,
     // and wiping on that would take the letter that opened it. Typed straight at
@@ -224,5 +230,8 @@ describe("PlayerAnalysisDialog", () => {
     expect(screen.getByRole("combobox", { name: "Player" })).toHaveValue(
       "Bobbyx",
     );
+    // Half a name reaches nobody yet, so there is nobody for the mark to speak
+    // for until the next one is picked.
+    expect(document.querySelector(".player-analysis__input-status")).toBeNull();
   });
 });

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
@@ -118,6 +118,12 @@ describe("PlayerAnalysisDialog", () => {
     await user.type(search, "Ali");
     await user.click(await screen.findByRole("option", { name: "Alice" }));
 
+    // Picking puts the mark back beside the input, in the same pass the name
+    // lands in it.
+    expect(
+      document.querySelector(".player-analysis__input-status"),
+    ).toBeInTheDocument();
+
     // Announced as busy while the search runs, on the region a screen reader
     // reads politely once the answer replaces it.
     expect(

--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -1,6 +1,11 @@
+@use "../../styles/breakpoints" as *;
+
 .results-scores {
   display: flex;
   flex-direction: column;
+  // The whole box on a phone, where a table narrower than the screen would leave
+  // a band of page beside a frame that stops short. A roomier screen hugs the
+  // table instead, at the foot of this file.
   width: 100%;
   // As wide as the table, not as wide as the window. Left at the window's width
   // this stopped at the first screenful, and every column past it had nothing
@@ -20,4 +25,17 @@
   // height; painted the same, it reads as that row being the taller for it rather
   // than as the page running out before the table does.
   background-color: var(--rak-primary-800);
+}
+
+// Room enough that the table does not fill the width, so the frame is cut to the
+// table and what is left either side is the page's own tiled blue, the same
+// background the home page stands on.
+@include roomy-screen {
+  .results-scores {
+    width: max-content;
+    // The panel the page carries on every other route, handed to the table now
+    // that it is the thing standing on the blue. `PageLayout.scss` gives this up
+    // at the same width.
+    box-shadow: var(--rak-shadow-overlay);
+  }
 }

--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -9,7 +9,11 @@
   // fill below reaches the whole table now, so what shows in the gap is the
   // frame's own color.
   min-width: max-content;
-  height: 100%;
+  // Tall enough to reach the bottom of the box on a short week, and as tall as the
+  // table on a long one. Fixed at the box's own height it stopped one screenful
+  // down, and every row past that had the page's surface behind it instead of the
+  // frame. Same reasoning as the width above, on the other axis.
+  min-height: 100%;
   margin: 0;
   // The trailing row's own fill, behind the column rather than only in that row.
   // Filler rows come whole, so what is left under the last of them is under a row

--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -2,6 +2,13 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  // As wide as the table, not as wide as the window. Left at the window's width
+  // this stopped at the first screenful, and every column past it had nothing
+  // behind it but the page's own white. That is what a frame Firefox has not
+  // drawn yet falls through to, so a fast sideways flick flashed white. The
+  // fill below reaches the whole table now, so what shows in the gap is the
+  // frame's own color.
+  min-width: max-content;
   height: 100%;
   margin: 0;
   // The trailing row's own fill, behind the column rather than only in that row.

--- a/src/components/table/CLAUDE.md
+++ b/src/components/table/CLAUDE.md
@@ -2,13 +2,14 @@
 
 - `TableShell`: the frame both results tables share, the filler rows carrying a
   table to the bottom of the viewport, and the trailing row keeping the last real
-  row clear of a phone's rounded corners. Takes `caption`, `ariaBusy`, `ariaHidden`.
+  row clear of a phone's rounded corners. Takes `caption`, `ariaBusy`, `ariaHidden`,
+  `standInRows`.
 - `Table.scss`: the shared `.table` styles, sticky header and player column, touch
   feedback, striped rows, the trailing row, the `.table__cell-button` a clickable
   cell holds, and the width a column of each kind is laid out at. Fixed, so a long
   value is cut short rather than widening it.
 - `SkeletonTable`: the wireframe shown while a week is worked out. Its columns are
-  the real ones' width and its rows are the frame's, so it guesses at no row count.
+  the real ones' width, and its sixty-odd rows scroll as the table will.
 
 ## Subdirectories
 

--- a/src/components/table/SkeletonTable.scss
+++ b/src/components/table/SkeletonTable.scss
@@ -22,8 +22,9 @@
 
 .table.--skeleton {
   // The sheen is held to the table's own box, so it crosses the wireframe and not
-  // the page around it. Nothing here sticks, because the page holds still until the
-  // week arrives, so there is no sticky header to lose to the mixin's clip.
+  // the page around it. The clip that holds it makes this box the one the header
+  // cells stick inside, which costs the wireframe nothing: it stands still until
+  // the week arrives, so they never come off their own row.
   @include skeleton-sheen;
 
   th {

--- a/src/components/table/SkeletonTable.scss
+++ b/src/components/table/SkeletonTable.scss
@@ -20,13 +20,22 @@
   @include visually-hidden;
 }
 
-.table.--skeleton {
-  // The sheen is held to the table's own box, so it crosses the wireframe and not
-  // the page around it. The clip that holds it makes this box the one the header
-  // cells stick inside, which costs the wireframe nothing: it stands still until
-  // the week arrives, so they never come off their own row.
+// What holds the sheen to the wireframe rather than letting it cross the page
+// around it. A box of its own, cut to the table, rather than the `<table>`: a
+// browser generates a wrapper box around a table and splits the properties
+// between the two, so `position` and `overflow` written on one element do not
+// always land on the same box, and a clip that does not hold the sheen's own
+// containing block does not hold the sheen. This is one box either way.
+.skeleton__sheen {
   @include skeleton-sheen;
 
+  width: max-content;
+  // Centered where the frame is wider than the table, which the table does for
+  // itself in `Table.scss`.
+  margin-inline: auto;
+}
+
+.table.--skeleton {
   th {
     @include skeleton-reserve;
   }

--- a/src/components/table/SkeletonTable.test.tsx
+++ b/src/components/table/SkeletonTable.test.tsx
@@ -41,23 +41,22 @@ describe("SkeletonTable", () => {
     ).toHaveLength(24);
   });
 
-  it("guesses at no row count of its own", () => {
+  it("stands in for a field the window cannot show at once", () => {
     render(<SkeletonTable view="Picks" />);
-    // How many players played is a thing the wireframe cannot know, and the rows
-    // below carry it to the bottom of the window whatever the answer is.
+    // Which players played is a thing the wireframe cannot know, so it holds no
+    // rows of its own and the filler carries the whole table.
     expect(
       document.querySelectorAll(
         ".table.--skeleton tbody tr:not(.table__last-row):not(.table__filler-row)",
       ),
     ).toHaveLength(0);
-  });
-
-  it("fills the wireframe with rows down to the bottom of the viewport", () => {
-    // jsdom reports no layout, so every measurement is zero and the whole
-    // viewport counts as spare. That still exercises the row count for real.
-    render(<SkeletonTable view="Scoreboard" />);
-    expect(document.querySelectorAll(".table__filler-row")).toHaveLength(
-      Math.floor(window.innerHeight / 32),
-    );
+    // More rows than the window has room for either way, so the wireframe scrolls
+    // the way the table it stands in for will and the scrollbar is already there
+    // when the week lands. jsdom reports no layout, so what the rows are measured
+    // to fill is the whole window and the floor is what shows above it here.
+    // `useFillerRows` covers the measuring on its own.
+    expect(
+      document.querySelectorAll(".table__filler-row").length,
+    ).toBeGreaterThan(Math.floor(window.innerHeight / 32));
   });
 });

--- a/src/components/table/SkeletonTable.test.tsx
+++ b/src/components/table/SkeletonTable.test.tsx
@@ -50,13 +50,9 @@ describe("SkeletonTable", () => {
         ".table.--skeleton tbody tr:not(.table__last-row):not(.table__filler-row)",
       ),
     ).toHaveLength(0);
-    // More rows than the window has room for either way, so the wireframe scrolls
-    // the way the table it stands in for will and the scrollbar is already there
-    // when the week lands. jsdom reports no layout, so what the rows are measured
-    // to fill is the whole window and the floor is what shows above it here.
-    // `useFillerRows` covers the measuring on its own.
-    expect(
-      document.querySelectorAll(".table__filler-row").length,
-    ).toBeGreaterThan(Math.floor(window.innerHeight / 32));
+    // `PLAYER_COUNT`, the usual field the wireframe stands in for, which is more
+    // than a screen shows at once up to 4K. jsdom measures nothing, so the floor is
+    // the whole count here and the measuring is `useFillerRows`'s own test.
+    expect(document.querySelectorAll(".table__filler-row")).toHaveLength(60);
   });
 });

--- a/src/components/table/SkeletonTable.tsx
+++ b/src/components/table/SkeletonTable.tsx
@@ -15,6 +15,15 @@ import "./SkeletonTable.scss";
 const COLLEGE_COUNT = 6;
 const PRO_COUNT = 13;
 
+/**
+ * The field a week is usually played by, which runs past sixty. More than most
+ * screens show, so the wireframe scrolls the way the table it stands in for will
+ * and the bar is already there when the week lands. `TableShell` carries it one row
+ * past the bottom of the box on top of this, for the screen tall enough to show
+ * sixty rows at once.
+ */
+const PLAYER_COUNT = 60;
+
 type Column = {
   header: string;
   /** A game's column, which the real table sizes and centers by its own class. */
@@ -89,6 +98,7 @@ function SkeletonTable({ view }: { view: ScoresView }) {
         <TableShell
           className="--skeleton"
           columnCount={columns.length}
+          standInRows={PLAYER_COUNT}
           ariaBusy
           ariaHidden
           header={columns.map((column, index) => (

--- a/src/components/table/SkeletonTable.tsx
+++ b/src/components/table/SkeletonTable.tsx
@@ -84,24 +84,27 @@ function SkeletonTable({ view }: { view: ScoresView }) {
       <span className="skeleton__status" role="status">
         Loading {view.toLowerCase()} results
       </span>
-      <TableShell
-        className="--skeleton"
-        columnCount={columns.length}
-        ariaBusy
-        ariaHidden
-        header={columns.map((column, index) => (
-          // The heading itself, hidden, so a header that wraps to two lines is two
-          // lines tall here as well.
-          <th
-            key={index}
-            className={headerClass(column)}
-            scope="col"
-            data-skeleton-text={column.header}
-          >
-            <span className="skeleton__bar" />
-          </th>
-        ))}
-      />
+      {/* The box the sheen sweeps inside, cut to the table by `SkeletonTable.scss`. */}
+      <div className="skeleton__sheen">
+        <TableShell
+          className="--skeleton"
+          columnCount={columns.length}
+          ariaBusy
+          ariaHidden
+          header={columns.map((column, index) => (
+            // The heading itself, hidden, so a header that wraps to two lines is two
+            // lines tall here as well.
+            <th
+              key={index}
+              className={headerClass(column)}
+              scope="col"
+              data-skeleton-text={column.header}
+            >
+              <span className="skeleton__bar" />
+            </th>
+          ))}
+        />
+      </div>
     </>
   );
 }

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -143,6 +143,13 @@
     z-index: var(--rak-z-sticky-cell);
     position: sticky;
     left: 0;
+    // Gecko repaints a sticky element's whole box on every scroll frame rather
+    // than moving what it already drew, so a fast sideways flick outruns it and
+    // the ordinary cells underneath show through. Promoted, the compositor
+    // shifts the column instead of the main thread redrawing it. A hint, not a
+    // promise: over Firefox's budget it is dropped, which is only today's
+    // behavior back.
+    will-change: transform;
   }
 
   tbody {

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -50,12 +50,17 @@
   }
 
   .table__header {
-    z-index: var(--rak-z-sticky-header);
-    position: sticky;
-    top: 0;
     background-color: var(--rak-primary-800);
 
     th {
+      // Each cell sticks on its own rather than the row's section doing it for
+      // them. The player column sticks left, and a cell sticking inside a
+      // sticky <thead> is a case Firefox on Android hands back to the main
+      // thread, which lands it a frame or two behind a fling. What shows in the
+      // gap is the white underneath.
+      z-index: var(--rak-z-sticky-header);
+      position: sticky;
+      top: 0;
       color: var(--rak-on-solid);
       background-color: var(--rak-primary-800);
       // The header row is what a fixed layout reads its columns off, so the widths
@@ -83,7 +88,11 @@
         border-left: var(--rak-table-header-border);
       }
 
+      // The corner, stuck to the top and the left at once. Above its neighbours
+      // rather than level with them: they come after it in the table, so at the
+      // same step they would draw over it on the way past.
       &.table__player-col {
+        z-index: var(--rak-z-sticky-corner);
         width: var(--rak-table-player-width);
       }
 
@@ -146,38 +155,47 @@
       // its hit area.
       padding: 0;
       cursor: pointer;
-      transition: filter 150ms;
+      transition: background-color 150ms;
+
+      // Mixed toward black rather than run through `filter: brightness()`, which
+      // is the same arithmetic but puts the cell on a rendering surface of its
+      // own. A finger landing on a cell is the moment before a fling, so on a
+      // phone that surface is built and torn down exactly as the scroll starts.
 
       // A step of its own, well past the one between an odd row and an even one,
       // so a hovered odd row is never mistaken for the striped row below it.
       @include can-hover {
         &:hover {
-          filter: brightness(0.75);
+          background-color: color-mix(in srgb, var(--rak-cell-fill) 75%, black);
         }
       }
 
       // As dark as a cell goes. Black text on a striped knocked-out cell still
       // clears 5:1 here.
       &:active {
-        filter: brightness(0.68);
+        background-color: color-mix(in srgb, var(--rak-cell-fill) 68%, black);
       }
     }
 
     .table__player-col {
       border-left: var(--rak-table-border);
-      --rak-cell-fill: var(--rak-in-contention-300);
+      --rak-cell-base: var(--rak-in-contention-300);
 
       &.--knocked-out {
-        --rak-cell-fill: var(--rak-knocked-out-300);
+        --rak-cell-base: var(--rak-knocked-out-300);
       }
     }
 
     td {
       color: black;
-      // Every cell names the fill it carries and reads it back here, so an even row
-      // is one rule rather than one per column. A column with a fill of its own
-      // says so by setting this, and its stripe follows.
-      --rak-cell-fill: var(--rak-surface);
+      // Every cell names the color its column carries and reads the fill back
+      // here, so an even row is one rule rather than one per column. A column
+      // with a color of its own says so by setting the base, and its stripe
+      // follows. Two properties rather than one because the fill is what a
+      // pressed cell mixes from, and it has to be the striped color on a striped
+      // row.
+      --rak-cell-base: var(--rak-surface);
+      --rak-cell-fill: var(--rak-cell-base);
       background-color: var(--rak-cell-fill);
       font-family: var(--rak-font-mono);
       // A column is the width it was declared, so the rare value too long for one is
@@ -197,9 +215,9 @@
     }
 
     tr:nth-child(even) td {
-      background-color: color-mix(
+      --rak-cell-fill: color-mix(
         in srgb,
-        var(--rak-cell-fill) var(--rak-stripe-strength),
+        var(--rak-cell-base) var(--rak-stripe-strength),
         var(--rak-stripe-with)
       );
     }

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -1,6 +1,15 @@
 @use "../../styles/breakpoints" as *;
 @use "../../styles/a11y" as *;
 
+// A cell taken the given distance toward black, from whatever fill it carries,
+// striped or not. Mixed rather than run through `filter: brightness()`, which is
+// the same arithmetic but puts the cell on a rendering surface of its own. A
+// finger landing on a cell is the moment before a fling, so on a phone that
+// surface is built and torn down exactly as the scroll starts.
+@mixin cell-darkened($strength) {
+  background-color: color-mix(in srgb, var(--rak-cell-fill) $strength, black);
+}
+
 .table {
   // Centered across, and flush to the top, which is where the wireframe stands. The
   // rows below carry the table to the bottom of the window, and what is left under
@@ -173,27 +182,15 @@
       cursor: pointer;
       transition: background-color 150ms;
 
-      // Mixed toward black rather than run through `filter: brightness()`, which
-      // is the same arithmetic but puts the cell on a rendering surface of its
-      // own. A finger landing on a cell is the moment before a fling, so on a
-      // phone that surface is built and torn down exactly as the scroll starts.
       // Both steps are named in `index.scss`, beside the stripe they clear.
       @include can-hover {
         &:hover {
-          background-color: color-mix(
-            in srgb,
-            var(--rak-cell-fill) var(--rak-hover-strength),
-            black
-          );
+          @include cell-darkened(var(--rak-hover-strength));
         }
       }
 
       &:active {
-        background-color: color-mix(
-          in srgb,
-          var(--rak-cell-fill) var(--rak-press-strength),
-          black
-        );
+        @include cell-darkened(var(--rak-press-strength));
       }
     }
 

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -102,10 +102,6 @@
     }
   }
 
-  .table__center {
-    text-align: center;
-  }
-
   // The clickable surface inside a tappable cell. The cell keeps the fill and the
   // padding it always had; this resets both away and fills the cell edge to edge,
   // so the whole cell, padding included, is inside the button's own hit area.
@@ -190,6 +186,10 @@
 
     .table__player-col {
       border-left: var(--rak-table-border);
+      // A name is read, not compared down the column, and it is the one cell cut
+      // short with an ellipsis. Centering would move where it starts from row to
+      // row and put the cut at both ends.
+      text-align: left;
       --rak-cell-base: var(--rak-in-contention-300);
 
       &.--knocked-out {
@@ -199,6 +199,10 @@
 
     td {
       color: black;
+      // Every cell holds a number or a short pick, which reads as a column when
+      // it is centered under a centered heading. The name is the exception, and
+      // sets itself back below.
+      text-align: center;
       // Every cell names the color its column carries and reads the fill back
       // here, so an even row is one rule rather than one per column. A column
       // with a color of its own says so by setting the base, and its stripe

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -150,9 +150,13 @@
     white-space: nowrap;
   }
 
-  // Stick the player column to the left side of the screen.
+  // Stick the player column to the left side of the screen. No `z-index`, which
+  // would make each of these cells a stacking context and take it out of the layer
+  // Firefox rasterizes the scrolled content into. What is left where it was taken
+  // from is filled with the scrolling box's own color, which is the flash. A
+  // positioned cell already draws over the static ones beside it, and the header
+  // sets a `z-index` of its own to stay over this on the way past.
   .table__player-col {
-    z-index: var(--rak-z-sticky-cell);
     position: sticky;
     left: 0;
   }

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -22,7 +22,9 @@
   // and a score are two digits, a pick is a team and its spread, and a name runs to
   // whatever a player calls themselves.
   --rak-table-rank-width: 3.5em;
-  --rak-table-player-width: 11em;
+  // Room for about seventeen characters of a name, plus the status icon and the
+  // gap before it.
+  --rak-table-player-width: 13.5em;
   --rak-table-pick-width: 6.5em;
   --rak-table-score-width: 8em;
   // Read back by useFillerRows, which needs a row height to work out how many
@@ -35,6 +37,20 @@
   --rak-table-cell-padding-x: 6px;
   --rak-table-cell-padding-y: 2px;
   --rak-table-header-padding-x: 8px;
+  // What is left of the player column for the name itself, once the status icon
+  // beside it, the gap between them, and the cell's own padding and edges have
+  // taken theirs. `PlayerName.scss` cuts the name off here rather than at a count
+  // of characters, because a name long enough to widen the column is a name the
+  // wireframe did not have when it drew that column at the width above. Derived
+  // from the same value, the two cannot disagree. The edges come out of it
+  // because `box-sizing` is `border-box`, so the width above is the whole cell
+  // rather than the room inside it.
+  --rak-table-player-name-width: calc(
+    var(--rak-table-player-width) - var(--rak-player-icon-size) - var(
+        --rak-player-icon-gap
+      ) -
+      2 * var(--rak-table-cell-padding-x) - 2 * var(--rak-border-width)
+  );
   --rak-table-border: var(--rak-border-width) solid var(--rak-primary-800);
   --rak-table-header-border: var(--rak-border-width) solid
     var(--rak-primary-600);
@@ -139,13 +155,6 @@
     z-index: var(--rak-z-sticky-cell);
     position: sticky;
     left: 0;
-    // Gecko repaints a sticky element's whole box on every scroll frame rather
-    // than moving what it already drew, so a fast sideways flick outruns it and
-    // the ordinary cells underneath show through. Promoted, the compositor
-    // shifts the column instead of the main thread redrawing it. A hint, not a
-    // promise: over Firefox's budget it is dropped, which is only today's
-    // behavior back.
-    will-change: transform;
   }
 
   tbody {
@@ -254,10 +263,14 @@
 }
 
 // A phone reads the tighter table, set on `.table` itself above. Room enough, and
-// both go back up.
+// these go back up.
 @include roomy-screen {
   .table {
     font-size: var(--rak-text-md);
     --rak-table-row-height: 32px;
+    // About twenty-four characters of a name here, against seventeen on a phone.
+    // The larger text alone would have bought only a wider letter, not more of
+    // them, since the width above grows with it.
+    --rak-table-player-width: 17em;
   }
 }

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -161,19 +161,23 @@
       // is the same arithmetic but puts the cell on a rendering surface of its
       // own. A finger landing on a cell is the moment before a fling, so on a
       // phone that surface is built and torn down exactly as the scroll starts.
-
-      // A step of its own, well past the one between an odd row and an even one,
-      // so a hovered odd row is never mistaken for the striped row below it.
+      // Both steps are named in `index.scss`, beside the stripe they clear.
       @include can-hover {
         &:hover {
-          background-color: color-mix(in srgb, var(--rak-cell-fill) 75%, black);
+          background-color: color-mix(
+            in srgb,
+            var(--rak-cell-fill) var(--rak-hover-strength),
+            black
+          );
         }
       }
 
-      // As dark as a cell goes. Black text on a striped knocked-out cell still
-      // clears 5:1 here.
       &:active {
-        background-color: color-mix(in srgb, var(--rak-cell-fill) 68%, black);
+        background-color: color-mix(
+          in srgb,
+          var(--rak-cell-fill) var(--rak-press-strength),
+          black
+        );
       }
     }
 

--- a/src/components/table/TableShell.tsx
+++ b/src/components/table/TableShell.tsx
@@ -18,6 +18,7 @@ export default function TableShell({
   className = "",
   ariaBusy = false,
   ariaHidden = false,
+  standInRows = 0,
   children,
 }: {
   /** What the table shows, read by a screen reader alone: visually hidden. */
@@ -32,10 +33,24 @@ export default function TableShell({
    * cost a screen reader ~1500 empty cells.
    */
   ariaHidden?: boolean;
+  /**
+   * The field a table with no real rows of its own stands in for.
+   *
+   * Set, the filler runs to whichever is the more of this and one row past the
+   * bottom of the box. Filling to the bottom alone leaves a table exactly as tall
+   * as the box, which is one row short of scrolling, so on a tall enough screen a
+   * stand-in for a table that scrolls would not. The count matters as well as the
+   * overflow: it is what sets how far the bar thinks it has to go.
+   *
+   * Left unset, the filler only makes up what the real rows do not reach.
+   */
+  standInRows?: number;
   children?: ReactNode;
 }) {
   const tableRef = useRef<HTMLTableElement>(null);
-  const fillerRows = useFillerRows(tableRef);
+  const measuredRows = useFillerRows(tableRef);
+  const fillerRows =
+    standInRows > 0 ? Math.max(measuredRows + 1, standInRows) : measuredRows;
 
   return (
     <table

--- a/src/components/table/picks/PicksTable.scss
+++ b/src/components/table/picks/PicksTable.scss
@@ -1,19 +1,19 @@
 // A pick's fill is the ramp its status already has elsewhere in the app: a right
 // pick is the success green, a wrong one the danger red, one that cannot be scored
-// the warning yellow. Naming the fill is all a cell does. `Table.scss` paints it,
+// the warning yellow. Naming the color is all a cell does. `Table.scss` paints it,
 // and derives the even-row stripe from it.
 .table {
   tbody {
     .table__pick.--yes {
-      --rak-cell-fill: var(--rak-success-300);
+      --rak-cell-base: var(--rak-success-300);
     }
 
     .table__pick.--no {
-      --rak-cell-fill: var(--rak-danger-300);
+      --rak-cell-base: var(--rak-danger-300);
     }
 
     .table__pick.--unscoreable {
-      --rak-cell-fill: var(--rak-warning-300);
+      --rak-cell-base: var(--rak-warning-300);
     }
   }
 }

--- a/src/components/table/picks/PicksTable.tsx
+++ b/src/components/table/picks/PicksTable.tsx
@@ -100,7 +100,7 @@ function PicksTable({ scores }: { scores?: RakMadnessScores | null }) {
             {player.college.map((result, index) => (
               <td
                 key={`${player.name}-${collegeLabels[index]}`}
-                className={`table__center table__pick --${result.status}`}
+                className={`table__pick --${result.status}`}
               >
                 <PickCell
                   result={result}
@@ -109,11 +109,11 @@ function PicksTable({ scores }: { scores?: RakMadnessScores | null }) {
                 />
               </td>
             ))}
-            <td className="table__center">{player.score.college}</td>
+            <td>{player.score.college}</td>
             {player.pro.map((result, index) => (
               <td
                 key={`${player.name}-${proLabels[index]}`}
-                className={`table__center table__pick --${result.status}`}
+                className={`table__pick --${result.status}`}
               >
                 <PickCell
                   result={result}
@@ -122,8 +122,8 @@ function PicksTable({ scores }: { scores?: RakMadnessScores | null }) {
                 />
               </td>
             ))}
-            <td className="table__center">{player.score.pro}</td>
-            <td className="table__center">
+            <td>{player.score.pro}</td>
+            <td>
               <b>{player.score.total}</b>
             </td>
           </tr>

--- a/src/components/table/playerName/PlayerName.scss
+++ b/src/components/table/playerName/PlayerName.scss
@@ -7,12 +7,19 @@
   // it never draws.
   gap: var(--rak-player-icon-gap);
 
-  // The cell's font is monospace, so 18ch is exactly 18 characters. A longer name
-  // is cut short rather than wrapped, because a wrapped name would make its row
-  // taller than every other row in the table. The whole name is in the player
-  // analysis the cell opens.
+  // The icon keeps its size whatever the name is. Left to shrink it would be the
+  // one thing in the row that gets smaller as a name gets longer.
+  > .player-status-icon {
+    flex-shrink: 0;
+  }
+
+  // The room the column leaves a name, worked out in `Table.scss` beside the
+  // width it comes out of. Cut short rather than wrapped, because a wrapped name
+  // would make its row taller than every other row in the table. The whole name
+  // is in the player analysis the cell opens.
   .player-name__name {
-    max-width: 18ch;
+    min-width: 0;
+    max-width: var(--rak-table-player-name-width);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/index.scss
+++ b/src/index.scss
@@ -78,6 +78,9 @@
   --rak-z-below: -1;
   --rak-z-sticky-cell: 10;
   --rak-z-sticky-header: 20;
+  // The header cell of the column that also sticks left. Above the header cells
+  // after it in the table, which pass under it as the table scrolls sideways.
+  --rak-z-sticky-corner: 25;
   --rak-z-skeleton: 30;
   --rak-z-navbar: 100;
   --rak-z-overlay: 200;

--- a/src/index.scss
+++ b/src/index.scss
@@ -157,11 +157,17 @@
 
   // How far an even row is taken from the fill its cells already carry. One value
   // for every column, so a striped name cell, a striped pick, and a striped score
-  // are all the same step apart from their odd-row neighbours. The hover and
-  // active steps in `Table.scss` are set past this one, so a cell darkened by the
-  // pointer is never read as a striped row.
+  // are all the same step apart from their odd-row neighbours.
   --rak-stripe-strength: 86%;
   --rak-stripe-with: var(--rak-primary-800);
+
+  // How far a cell under the pointer is taken from the fill it carries, striped
+  // or not. Both are set well past the stripe above, so a cell darkened by the
+  // pointer is never read as the striped row below it. The pressed step is as
+  // dark as a cell goes: black text on a striped knocked-out cell still clears
+  // 5:1 there.
+  --rak-hover-strength: 75%;
+  --rak-press-strength: 68%;
 
   // The status icon beside a player's name, drawn the same size wherever the
   // name is. The wireframe leaves this much room without drawing one.

--- a/src/index.scss
+++ b/src/index.scss
@@ -76,7 +76,6 @@
   // decided in one place. A z-index outside this list orders an element against
   // its own siblings and nothing else.
   --rak-z-below: -1;
-  --rak-z-sticky-cell: 10;
   --rak-z-sticky-header: 20;
   // The header cell of the column that also sticks left. Above the header cells
   // after it in the table, which pass under it as the table scrolls sideways.

--- a/src/types/ESPN.ts
+++ b/src/types/ESPN.ts
@@ -39,7 +39,6 @@ export type EspnCompetition = {
 };
 
 export type EspnVenue = {
-  fullName?: string;
   address?: {
     city?: string;
     state?: string;

--- a/src/types/LeagueResult.ts
+++ b/src/types/LeagueResult.ts
@@ -15,12 +15,6 @@ export type Possession = {
   downDistanceText?: string;
 };
 
-export type GameVenue = {
-  name: string;
-  city?: string;
-  state?: string;
-};
-
 export type GameSide = {
   team: Team;
   score: number;
@@ -51,7 +45,11 @@ export type LeagueResult = {
    * against it, so the two sides are only ever said to be home and away where they are.
    */
   isNeutralSite: boolean;
-  venue?: GameVenue;
+  /**
+   * The town the game is played in, like `Orchard Park, NY`. Absent where ESPN sent
+   * no address for the ground, which the smaller college venues have.
+   */
+  venue?: string;
   possession: Possession;
   winner: {
     team: Team | null;

--- a/src/utils/espnCache.ts
+++ b/src/utils/espnCache.ts
@@ -17,7 +17,7 @@ import localStorageCache from "./localStorageCache";
 /** A size guard, not a history. A week of both leagues is tens of KB. */
 const MAX_CACHED_WEEKS = 6;
 /** Bumped where a stored shape changes, which makes every older entry a miss. */
-const VERSION = 1;
+const VERSION = 2;
 
 /** A game as it was stored, whose date has been through JSON and is text again. */
 type StoredGame = (Omit<LeagueResult, "date"> & { date: string }) | null;

--- a/src/utils/getLeagueResults.test.ts
+++ b/src/utils/getLeagueResults.test.ts
@@ -317,23 +317,16 @@ describe("getLeagueResults, mapping", () => {
     expect(result.away.linescores).toEqual([]);
   });
 
-  it("carries the venue", async () => {
+  it("carries the town the game is played in", async () => {
     mockFetch([
       espnEvent({
         home: "BUF",
         away: "KC",
-        venue: {
-          fullName: "Highmark Stadium",
-          address: { city: "Orchard Park", state: "NY" },
-        },
+        venue: { address: { city: "Orchard Park", state: "NY" } },
       }),
     ]);
     const [result] = await getLeagueResults(League.PRO, WEEK, [BUF_KC]);
-    expect(result.venue).toEqual({
-      name: "Highmark Stadium",
-      city: "Orchard Park",
-      state: "NY",
-    });
+    expect(result.venue).toBe("Orchard Park, NY");
   });
 
   it("carries each side's logo, and neither where ESPN sent none", async () => {
@@ -356,10 +349,16 @@ describe("getLeagueResults, mapping", () => {
     expect(result.away.team.logoUrl).toBeUndefined();
   });
 
-  it("leaves the venue out where ESPN sent none", async () => {
+  it("leaves the venue out where ESPN sent no address for the ground", async () => {
+    // A ground with no address, and no ground at all, are both a game with nowhere
+    // to say it is played.
+    mockFetch([espnEvent({ home: "BUF", away: "KC", venue: {} }), bufVsKc]);
+    const [withVenue] = await getLeagueResults(League.PRO, WEEK, [BUF_KC]);
+    expect(withVenue.venue).toBeUndefined();
+
     mockFetch([bufVsKc]);
-    const [result] = await getLeagueResults(League.PRO, WEEK, [BUF_KC]);
-    expect(result.venue).toBeUndefined();
+    const [withNone] = await getLeagueResults(League.PRO, WEEK, [BUF_KC]);
+    expect(withNone.venue).toBeUndefined();
   });
 });
 

--- a/src/utils/getLeagueResults.ts
+++ b/src/utils/getLeagueResults.ts
@@ -6,12 +6,7 @@ import {
   HomeAway,
 } from "../types/ESPN";
 import { League, SeasonType, WeekInfo } from "../types/League";
-import {
-  GameSide,
-  GameVenue,
-  LeagueResult,
-  Possession,
-} from "../types/LeagueResult";
+import { GameSide, LeagueResult, Possession } from "../types/LeagueResult";
 import debugLog from "./debugLog";
 import {
   CachedGame,
@@ -147,14 +142,18 @@ function gameSide(competitor: EspnCompetitor): GameSide {
   };
 }
 
-function gameVenue(venue?: EspnVenue): GameVenue | undefined {
-  return venue?.fullName != null
-    ? {
-        name: venue.fullName,
-        city: venue.address?.city,
-        state: venue.address?.state,
-      }
-    : undefined;
+/**
+ * Where the game is played, as the town and nothing more.
+ *
+ * The ground's own name is left out: a reader who wants it has the Gamecast link the
+ * dialog carries, and the name is stored in this browser for every game of every week
+ * cached otherwise.
+ */
+function gameVenue(venue?: EspnVenue): string | undefined {
+  const place = [venue?.address?.city, venue?.address?.state]
+    .filter((it) => it != null)
+    .join(", ");
+  return place !== "" ? place : undefined;
 }
 
 /**


### PR DESCRIPTION
## What

The results tables, the frame behind them, and the game dialog a pick cell opens.

## Why

Flinging the table on Android Firefox flashes white over the pinned header and player column. Chasing it turned up a frame that stopped short of the table, a player column measured two ways, and a sheen that swept onto the page.

## Changes

- One value sets the player column's width and the characters a name is cut at, so wireframe and table cannot come apart.
- Above the phone breakpoint the frame is cut to the table, so the page's tiled blue shows either side of it.
- The wireframe stands in for sixty players, so it scrolls like the week it waits for.
- A push or a tie with no line marks both sides green. Everybody scored, so no pick missed.
- `LeagueResult.venue` is the town now, with a Gamecast link for the ground. `espnCache` VERSION is bumped for the stored shape.
- The flash is not fixed. `SCROLL-FLASH.md` holds the mechanism, the bisect, and what is ruled out.

## Notes / Follow-ups

- `debug-no-sticky` proved sticky is the cause. It and `debug-header-sticky-only` are still on the remote.

🕵️ Sanitized by [Agent Numbuh 1](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
