### PR TITLE
fix(gameStatus): cut a scoreline back to what its two names have room for

### DIFF
--- a/src/components/gameStatus/CLAUDE.md
+++ b/src/components/gameStatus/CLAUDE.md
@@ -1,13 +1,13 @@
 # gameStatus
 
-How a game in the week is going, opened from a pick cell in the picks table.
+How a game in the week is going, opened from a pick cell.
 
 - `GameStatusDialog`: `DialogShell` over a `DialogCombobox` of `scores.games`, in picks
-  table column order, which the query matches too. `GameMark` says where a game stands;
+  table column order, which the query matches. `GameMark` says where a game stands;
   `useLiveGame` keeps the chosen one fresh.
 - `GameStatusSummary`: the pool's line, the game as ESPN's boxscore says it, its kickoff,
-  town and Gamecast link. The wireframe is that layout over the week's own copy of it,
-  so a wait is the size of the answer.
+  town and Gamecast link. The wireframe is that layout over the week's own copy, so a
+  wait is the answer's size. `useScorelineFit` measures the scoreline and takes the full
+  names, then the marks, off one too narrow.
 - `GameStatusSummary.scss`: both sides in one grid, the dash in a track between two
-  equal ones, so nothing either side moves it. `--rak-score-size` sizes that row; under
-  `$breakpoint-marks` the marks come off.
+  equal ones, so neither side moves it. `--rak-score-size` sizes that row.

--- a/src/components/gameStatus/GameStatusSummary.scss
+++ b/src/components/gameStatus/GameStatusSummary.scss
@@ -46,9 +46,12 @@
 // How big the scores, the dash between them and the possession marks are set. Named
 // once here because the four have to grow and shrink together: they sit in one row,
 // and the room a phone has left over after them is what the two names get.
+// A phone sets them a step over those names and no further down: the scores are what
+// the row is about, and a pair set as big as the two names stops reading as the answer
+// to it.
 .game-status {
-  --rak-score-size: 1.75rem;
-  --rak-marker-size: 1.75rem;
+  --rak-score-size: 1.5rem;
+  --rak-marker-size: 1.5rem;
 
   display: flex;
   flex-direction: column;
@@ -92,7 +95,7 @@
 
   // Thicker, standing in for the one line here set big enough to carry its own weight.
   .game-status__points {
-    @include wireframe-bar(1.5rem);
+    @include wireframe-bar(1.25rem);
 
     @include roomy-screen {
       @include wireframe-bar(2.25rem);
@@ -183,20 +186,17 @@
 //
 // As big as the three lines of text beside it are tall, which is as much as either
 // can take without the name it stands over having to wrap sooner.
-// Left off the narrowest screens: what it takes out of the name and record beside it
-// breaks both across lines there, and a game reads better without it than with them
-// broken. The wireframe draws its circle by the same rule, so a wait is still the
-// size of the answer.
+//
+// Whether there is room for it at all is `useScorelineFit`'s to say, since what it costs
+// the name beside it is what that name is. The last thing that hook gives up, and only
+// where cutting the name to its abbreviation left the two still short. The wireframe
+// draws its circle by the same answer, so a wait is still the size of the answer.
 .game-status__logo {
-  display: none;
+  display: block;
   align-self: center;
   object-fit: contain;
   width: 32px;
   height: 32px;
-
-  @include marks-screen {
-    display: block;
-  }
 
   @include roomy-screen {
     width: 44px;
@@ -330,6 +330,20 @@
   }
 }
 
+// Back to the abbreviation, whatever the width says, because `useScorelineFit` measured
+// a name running over its column. The first thing it gives up, so the marks are still
+// there. Only bites above `$breakpoint-roomy`, since that is the only place the full
+// name is shown at all, and the width gained there is spent on a bigger score row too.
+.game-status__scoreline.--short-names {
+  .game-status__name-full {
+    display: none;
+  }
+
+  .game-status__name-short {
+    display: inline;
+  }
+}
+
 .game-status__record {
   color: var(--rak-text-tertiary);
   font-size: var(--rak-text-sm);
@@ -401,10 +415,17 @@
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   justify-self: center;
-  gap: var(--rak-space-2);
+  // Tight around the dash on a phone, where the room either side of it is room the
+  // names have not got. A dash reads as joining the two scores at either gap, and the
+  // wider one is only worth having where there is width to spend on it.
+  gap: var(--rak-space-1);
   // Room either side of the pair, past the marker each of them already holds, so the
   // scores are never read as running into the names beside them.
   padding-inline: var(--rak-space-2);
+
+  @include roomy-screen {
+    gap: var(--rak-space-2);
+  }
 }
 
 .game-status__detail,

--- a/src/components/gameStatus/GameStatusSummary.test.tsx
+++ b/src/components/gameStatus/GameStatusSummary.test.tsx
@@ -254,8 +254,11 @@ describe("GameStatusSummary, a game that is over", () => {
     renderFinal();
     const short = [...document.querySelectorAll(".game-status__name-short")];
     expect(short.map((it) => it.textContent)).toEqual(["KC", "BUF"]);
-    // The name is the one read out, so the abbreviation beside it is not heard twice.
-    short.forEach((it) => expect(it).toHaveAttribute("aria-hidden", "true"));
+    // Neither form is hidden from a reader by hand. The stylesheet draws one and
+    // sets the other `display: none`, which takes it out of the accessibility tree
+    // as well, so whichever is on screen is the one and only one read out. Hidden
+    // here, the side would have no name at all at the widths showing this form.
+    short.forEach((it) => expect(it).not.toHaveAttribute("aria-hidden"));
   });
 
   it("wears both teams' marks, away first", () => {

--- a/src/components/gameStatus/GameStatusSummary.tsx
+++ b/src/components/gameStatus/GameStatusSummary.tsx
@@ -1,4 +1,12 @@
-import { ReactNode, useState } from "react";
+import {
+  ReactNode,
+  RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { GameStatus, HomeAway } from "../../types/ESPN";
 import { League } from "../../types/League";
 import { GameSide, LeagueResult } from "../../types/LeagueResult";
@@ -422,11 +430,14 @@ function Side({
         >
           {/* The abbreviation on a phone and the name once there is width for it.
               Both are in the page, so neither costs a measurement to choose
-              between, and the one read out is the name however narrow the screen. */}
+              between. Whichever one is drawn is the one read out: the other is
+              `display: none`, which takes it out of the accessibility tree as
+              well, so hiding either from a reader by hand would leave the side
+              with no name at all at the widths that hide the other. */}
           <span className="game-status__name-full">
             <TeamName team={side.team} />
           </span>
-          <span aria-hidden="true" className="game-status__name-short">
+          <span className="game-status__name-short">
             {side.team.abbreviation}
           </span>
         </span>
@@ -442,6 +453,121 @@ function Side({
  *  app having lost track of a team. */
 function hasLogos(result: LeagueResult): boolean {
   return result.home.team.logoUrl != null && result.away.team.logoUrl != null;
+}
+
+/**
+ * The lines either side of the scores, each of which is one word on one line.
+ *
+ * A word is set on the line whether or not the line is wide enough to hold it, so a
+ * name with too little room runs on over the mark beside it rather than wrapping under
+ * it. That is what makes a line wider than the box it was given, which is the one
+ * question asked of these.
+ */
+const SIDE_LINES =
+  ".game-status__side-label, .game-status__team-name, .game-status__record";
+
+/** Whether anything either side of the scores is wider than the room it was given. */
+function isCramped(scoreline: HTMLElement): boolean {
+  return Array.from(scoreline.querySelectorAll<HTMLElement>(SIDE_LINES)).some(
+    (line) => line.scrollWidth > line.clientWidth,
+  );
+}
+
+/**
+ * How far back a scoreline has been cut to fit, in the order it gives things up. The
+ * full names go first, down to the abbreviation ESPN says the game in, which is the
+ * same team said shorter. The marks go next, and only once shortening the names was not
+ * enough, since a mark says which team this is at a glance and the abbreviation is what
+ * a reader has left to go on.
+ *
+ * Each step leaves the names more room than the one before it, and the last is as
+ * narrow as the scoreline goes.
+ */
+const SHORT_NAMES = 1;
+const MARKS_OFF = 2;
+
+/**
+ * How much of the scoreline there is room for, measured rather than read off a width.
+ *
+ * What a side needs is what it is called, and no width tells `CONN` and `BUF` apart:
+ * the same phone holds one game's scoreline and breaks the next one's. So the whole
+ * thing goes in, the scoreline is measured, and it is cut back a step at a time for as
+ * long as a name is still running over the room it was given.
+ *
+ * Two steps rather than one because a phone names both sides in full nowhere: below
+ * `$breakpoint-roomy` the first step is already what is on screen, so it changes nothing
+ * and the marks are what has to go.
+ *
+ * The verdict is held against the game it was reached on and the width it was reached
+ * at, rather than as a flag. Either one moving puts the whole scoreline back and asks
+ * again: another game is another pair of names, and another width is other room to hold
+ * them.
+ *
+ * @param id the game on screen, which is what the verdict is about.
+ */
+function useScorelineFit(
+  id: string,
+): [RefObject<HTMLDivElement | null>, number] {
+  const scoreline = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState<number>();
+  const [cut, setCut] = useState<{
+    id: string;
+    width?: number;
+    step: number;
+  }>();
+
+  const step =
+    cut != null && cut.id === id && cut.width === width ? cut.step : 0;
+
+  const measure = useCallback(() => {
+    const element = scoreline.current;
+    if (element == null || step >= MARKS_OFF) {
+      return;
+    }
+    if (isCramped(element)) {
+      setCut({ id, width, step: step + 1 });
+    }
+  }, [id, step, width]);
+
+  // Every render, since what the scoreline holds is what decides this and a game going
+  // final rewrites half of it. Before the browser paints, so a step the scoreline is
+  // about to give up is never one the reader saw it holding.
+  useLayoutEffect(measure);
+
+  // A name measured in the fallback font was measured at the wrong width, and the swap
+  // to Inter is not a thing the page is rendered again for. Asked once more when the
+  // font is in, which on a warm cache is straight away. Guarded because jsdom, which
+  // has no layout to measure in the first place, has no font set either.
+  useEffect(() => {
+    let live = true;
+    document.fonts?.ready.then(() => {
+      if (live) {
+        measure();
+      }
+    });
+    return () => {
+      live = false;
+    };
+  }, [measure]);
+
+  // The width alone. Every cut makes the scoreline shorter, and a height this answered
+  // would put the question again on the strength of its own answer, forever.
+  //
+  // Guarded on `ResizeObserver` itself, as `useFillerRows` is, so a runtime without one
+  // holds the width it opened at rather than throwing on the way in.
+  useEffect(() => {
+    const element = scoreline.current;
+    if (element == null || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(([entry]) =>
+      setWidth(entry.contentRect.width),
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return [scoreline, step];
 }
 
 /**
@@ -468,6 +594,7 @@ function Game({
    */
   gamecastHref?: string;
 }) {
+  const [scoreline, fit] = useScorelineFit(result.id);
   // The link rides with the place rather than the kickoff, so it ends the strip at
   // every width rather than moving when the two halves stack. Both parts are their
   // own, so a game ESPN sent no address for still carries the link.
@@ -502,12 +629,17 @@ function Game({
         {SPREAD_LABEL}:{" "}
         {spread != null ? `${spread.team} ${spread.points}` : NO_SPREAD}
       </p>
-      <div className="game-status__scoreline">
+      <div
+        className={getClasses("game-status__scoreline", {
+          "--short-names": fit >= SHORT_NAMES,
+        })}
+        ref={scoreline}
+      >
         <Side
           side={result.away}
           homeAway={HomeAway.AWAY}
           isNeutralSite={result.isNeutralSite}
-          logo={logo?.(result.away)}
+          logo={fit < MARKS_OFF ? logo?.(result.away) : undefined}
           outcome={outcomeOf(result.away)}
         />
         <Center result={result} spread={spread} outcomeOf={outcomeOf} />
@@ -515,7 +647,7 @@ function Game({
           side={result.home}
           homeAway={HomeAway.HOME}
           isNeutralSite={result.isNeutralSite}
-          logo={logo?.(result.home)}
+          logo={fit < MARKS_OFF ? logo?.(result.home) : undefined}
           outcome={outcomeOf(result.home)}
         />
       </div>

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -7,14 +7,6 @@
 // floor a finger needs would be the exception rather than the default.
 
 /**
- * Above the narrowest screen a team's mark is worth the room it takes. Measured in
- * the game status dialog, where the two marks stand beside the two names: at 330px
- * and under, a record as short as `4-1` is broken across two lines by them, and at
- * 340px it holds.
- */
-$breakpoint-marks: 340px;
-
-/**
  * Above the widest phone held in portrait. Below it the tables and the navbar
  * tighten up and every target is a full `--rak-touch-target`. Measured against
  * the flagships, whose logical widths run to 440px.
@@ -35,13 +27,6 @@ $breakpoint-labelled-navbar: 561px;
  * rather than about what fits in one bar.
  */
 $breakpoint-wide: 601px;
-
-/** Room enough beside a team's mark for the name and record it stands by. */
-@mixin marks-screen {
-  @media (min-width: $breakpoint-marks) {
-    @content;
-  }
-}
 
 /** Room enough for the tables and the navbar to loosen up. */
 @mixin roomy-screen {


### PR DESCRIPTION
## What

A team's name painted over its logo on a narrow phone. The scoreline now gives up its
full names, then its marks, where room runs out.

## Why

`CONN VS ARMY` in 2025 week 17, at 375px, gave each name a 35px column for 60px of
text. A breakpoint cannot decide this: what a side needs is what it is called.

## Changes

- `useScorelineFit` measures after layout and cuts the scoreline back while a label,
  name or record outgrows its box.
- Names go first, down to the abbreviation. A mark says which team this is at a glance,
  so it goes only where that failed.
- The verdict is keyed to game and width, so a rotate re-asks.
- The wireframe follows the same rule.
- `$breakpoint-marks` is gone, subsumed by the measurement.
- Scores, dash and markers are a step smaller on a phone.
- The abbreviation was `aria-hidden` beside a `display: none` name, so Chromium's tree
  named neither side below 481px. Now it does.
- No unit test for the fit. jsdom reports every rect as zero.

## Verification

Chrome, 320px to 900px, plus the accessibility tree at three widths. Clean from 360px up.

🕵️ Intercepted by [Agent Numbuh 1](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
