### PR TITLE
feat: name the season and week over the table, and hold the rotate overlay to phones

### DIFF
--- a/src/App.results.test.tsx
+++ b/src/App.results.test.tsx
@@ -14,6 +14,7 @@ import {
   buildSpreadsheetBufferMock,
   mountLoadedApp,
   uploadSpreadsheet,
+  resultsCaption,
   scoresHeaderButtons,
   setUpAppTest,
 } from "./appTestFixtures";
@@ -62,6 +63,20 @@ describe("the app, results views", () => {
     await user.click(scoreboard);
     expect(screen.getByText("MNF Points Pick")).toBeInTheDocument();
     expect(scoreboard).toHaveAttribute("aria-pressed", "true");
+  });
+
+  // The navbar already marks which view you are on, so the caption names the week
+  // and nothing else. Switching views must not change a word of it.
+  it("names the same week across both views", async () => {
+    const user = await mountWithScores();
+    await user.click(screen.getByText("View Results"));
+
+    const expected = `Rak Madness · ${SEASON} Season · Week ${CURRENT_WEEK}`;
+    expect(resultsCaption()).toHaveTextContent(expected);
+
+    const [, picks] = scoresHeaderButtons();
+    await user.click(picks);
+    expect(resultsCaption()).toHaveTextContent(expected);
   });
 
   it("returns home from the logo button", async () => {

--- a/src/App.routes.test.tsx
+++ b/src/App.routes.test.tsx
@@ -12,6 +12,7 @@ import {
   getPlayerScoresMock,
   mountApp,
   mountLoadedApp,
+  resultsCaption,
   scoresHeaderButtons,
   spreadsheetResponse,
   setUpAppTest,
@@ -120,6 +121,55 @@ describe("the app: the URL decides which week is fetched, and what shows while i
     await mountApp(`/${SEASON}/${CURRENT_WEEK}`);
 
     expect(await screen.findByText("MNF Points Pick")).toBeInTheDocument();
+  });
+
+  it("names the season and week over each table", async () => {
+    fetchMock.mockResolvedValue(spreadsheetResponse());
+    await mountApp(`/${SEASON}/${CURRENT_WEEK}/scoreboard`);
+    await screen.findByText("MNF Points Pick");
+
+    expect(resultsCaption()).toHaveTextContent(
+      `Rak Madness · ${SEASON} Season · Week ${CURRENT_WEEK}`,
+    );
+  });
+
+  it("names the same week over the picks table", async () => {
+    fetchMock.mockResolvedValue(spreadsheetResponse());
+    await mountApp(`/${SEASON}/${CURRENT_WEEK}/picks`);
+    await screen.findByText("College Score");
+
+    expect(resultsCaption()).toHaveTextContent(
+      `Rak Madness · ${SEASON} Season · Week ${CURRENT_WEEK}`,
+    );
+  });
+
+  // The week is in the URL before the scores are worked out, so the caption the
+  // wireframe wears is the one the table keeps. Nothing under it moves.
+  it("names the week over the wireframe, and does not change when the scores land", async () => {
+    fetchMock.mockResolvedValue(spreadsheetResponse());
+    mountApp(`/${SEASON}/${CURRENT_WEEK}/scoreboard`);
+
+    const expected = `Rak Madness · ${SEASON} Season · Week ${CURRENT_WEEK}`;
+    expect(resultsCaption()).toHaveTextContent(expected);
+
+    await screen.findByText("MNF Points Pick");
+    expect(resultsCaption()).toHaveTextContent(expected);
+  });
+
+  // `getByText` reads a hidden node, so the attribute is what has to be asserted.
+  it("says the week on screen without saying it twice", async () => {
+    fetchMock.mockResolvedValue(spreadsheetResponse());
+    await mountApp(`/${SEASON}/${CURRENT_WEEK}/scoreboard`);
+    await screen.findByText("MNF Points Pick");
+
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: `${SEASON} Week ${CURRENT_WEEK} Scoreboard`,
+      }),
+    ).toBeInTheDocument();
+    expect(resultsCaption()).toHaveAttribute("aria-hidden", "true");
   });
 
   it("sends an unknown path home", async () => {

--- a/src/appTestFixtures.tsx
+++ b/src/appTestFixtures.tsx
@@ -148,6 +148,11 @@ export function scoresHeaderButtons(): Array<HTMLElement> {
   );
 }
 
+/** The line over the table naming the week, which carries no role of its own. */
+export function resultsCaption(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(".results-caption");
+}
+
 export function notFoundResponse(): Response {
   return new Response(null, { status: 404 });
 }

--- a/src/components/results/CLAUDE.md
+++ b/src/components/results/CLAUDE.md
@@ -11,4 +11,5 @@ and `/picks` by redirecting to the latest week worth showing.
   `GameStatusDialog` and both providers around the tables, and reads
   `useIsWeekDecided` for `ScoresNavbar`'s `isWeekLive`. What the tables opened is one
   piece of state, so two dialogs cannot both be up claiming the viewport insets.
-- `ResultsFrame.scss`: the column the table and the wireframe are laid in.
+- `ResultsFrame.scss`: the column the table and the wireframe are laid in, and the
+  caption naming the week over both.

--- a/src/components/results/CurrentWeekRedirect.test.tsx
+++ b/src/components/results/CurrentWeekRedirect.test.tsx
@@ -77,4 +77,14 @@ describe("CurrentWeekRedirect", () => {
       "true",
     );
   });
+
+  // This route knows no week to name yet, so the caption holds its room instead
+  // of naming one. Filled in, the table below it would move when the week landed.
+  it("holds the caption's room while the week is unknown", () => {
+    mount("Scoreboard", { isWeekInfoLoading: true });
+    const caption = document.querySelector(".results-caption");
+    expect(caption).toBeInTheDocument();
+    expect(caption).toHaveClass("--loading");
+    expect(caption).toBeEmptyDOMElement();
+  });
 });

--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -35,7 +35,10 @@
  */
 .results-caption {
   margin: 0;
-  padding: var(--rak-space-2) var(--rak-space-3);
+  // Across, the header cells' own padding, which is where the Rank heading lands
+  // too: that column is centered, but it comes out within half a pixel of this at
+  // both table sizes, so one value lines the caption up with it on every screen.
+  padding: var(--rak-space-2);
   // Read from the near edge, never centered. The frame is as wide as the table,
   // so a caption centered in it starts off the side of a phone and only arrives
   // once the table has been panned across.
@@ -70,8 +73,9 @@
 .results-caption__text {
   position: sticky;
   // The padding the bar would have given it, now that it is placed rather than
-  // laid out.
-  left: var(--rak-space-3);
+  // laid out. Held level with the Rank heading below on the way across, not only
+  // at rest.
+  left: var(--rak-space-2);
   // Sticky offsets are ignored on an inline box.
   display: inline-block;
 }
@@ -87,7 +91,7 @@
     content: "";
     position: absolute;
     top: 50%;
-    left: var(--rak-space-3);
+    left: var(--rak-space-2);
     width: 14em;
     height: 0.7rem;
     transform: translateY(-50%);

--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -1,4 +1,5 @@
 @use "../../styles/breakpoints" as *;
+@use "../../styles/skeleton" as *;
 
 .results-scores {
   display: flex;
@@ -27,6 +28,77 @@
   background-color: var(--rak-primary-800);
 }
 
+/**
+ * Which week the table below is. Inside the frame rather than above it, so it
+ * scrolls away with the first rows and stands on a phone's screen no longer than
+ * the reader needs it.
+ */
+.results-caption {
+  margin: 0;
+  padding: var(--rak-space-2) var(--rak-space-3);
+  // Read from the near edge, never centered. The frame is as wide as the table,
+  // so a caption centered in it starts off the side of a phone and only arrives
+  // once the table has been panned across.
+  text-align: left;
+  // The line the header cells are divided by, which is the one edge that shows
+  // against this fill. `--rak-table-border` is the frame's own color, drawn where
+  // a cell is white; here it would be invisible. Both are named on `.table`, so
+  // the value is written out rather than read from a property out of reach.
+  border-bottom: var(--rak-border-width) solid var(--rak-primary-600);
+  // No fill of its own: it stands on the frame's, so it reads as the top of the
+  // table's own head rather than a band above it, and Firefox gets no second
+  // surface to hold. No `z-index` either, so the sticky header passes over it on
+  // the way up. See SCROLL-FLASH.md.
+  color: var(--rak-on-solid);
+  // The header row's own type, so the two read as one head with a line drawn
+  // through it rather than as two bands set differently. Both values are
+  // `Table.scss`'s: the size it puts on `.table` and the weight a `<th>` carries
+  // by default. Written out because they are the table's, and this stands
+  // outside it.
+  font-size: 0.8rem;
+  font-weight: var(--rak-weight-bold);
+}
+
+/**
+ * Held at the near edge while the table pans under it, so the week is readable
+ * whichever column is on screen. Left in flow it rides off the side with the
+ * columns, because the frame is as wide as the week is long.
+ *
+ * Only the text sticks. The bar and the border under it stay in flow at the
+ * frame's full width, so the line runs the whole way across rather than stopping
+ * at the window's edge. That also keeps the sticky area to a few words, which is
+ * the smallest hole this can leave in the rasterized layer. See SCROLL-FLASH.md.
+ */
+.results-caption__text {
+  position: sticky;
+  // The padding the bar would have given it, now that it is placed rather than
+  // laid out.
+  left: var(--rak-space-3);
+  // Sticky offsets are ignored on an inline box.
+  display: inline-block;
+}
+
+// A route that has not worked out which week it is headed for yet. Its room is
+// held all the same, so nothing moves when the week lands.
+.results-caption.--loading {
+  @include skeleton-reserve;
+
+  &::after {
+    @include skeleton-surface;
+
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: var(--rak-space-3);
+    width: 14em;
+    height: 0.7rem;
+    transform: translateY(-50%);
+    // The frame is already dark, so the bar reads as a light gap in it, the same
+    // way the wireframe's header bars do.
+    background-color: var(--rak-loading-fill-on-solid);
+  }
+}
+
 // Room enough that the table does not fill the width, so the frame is cut to the
 // table and what is left either side is the page's own tiled blue, the same
 // background the home page stands on.
@@ -37,5 +109,11 @@
     // that it is the thing standing on the blue. `PageLayout.scss` gives this up
     // at the same width.
     box-shadow: var(--rak-shadow-overlay);
+  }
+
+  // The table goes up to its roomier size at this width, so the caption goes with
+  // it. `Table.scss` makes the same move at the same breakpoint.
+  .results-caption {
+    font-size: var(--rak-text-md);
   }
 }

--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -40,15 +40,13 @@
   // so a caption centered in it starts off the side of a phone and only arrives
   // once the table has been panned across.
   text-align: left;
-  // The line the header cells are divided by, which is the one edge that shows
-  // against this fill. `--rak-table-border` is the frame's own color, drawn where
-  // a cell is white; here it would be invisible. Both are named on `.table`, so
-  // the value is written out rather than read from a property out of reach.
-  border-bottom: var(--rak-border-width) solid var(--rak-primary-600);
-  // No fill of its own: it stands on the frame's, so it reads as the top of the
-  // table's own head rather than a band above it, and Firefox gets no second
-  // surface to hold. No `z-index` either, so the sticky header passes over it on
-  // the way up. See SCROLL-FLASH.md.
+  // Between the navbar above and the header below, so the three step down into
+  // the table. No border under it: the step off this fill is what divides the
+  // caption from the header, and a rule drawn in either neighbour's color would
+  // be a line one of them could not show.
+  background-color: var(--rak-primary-600);
+  // No `z-index`, so the sticky header passes over it on the way up.
+  // See SCROLL-FLASH.md.
   color: var(--rak-on-solid);
   // The header row's own type, so the two read as one head with a line drawn
   // through it rather than as two bands set differently. Both values are

--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -65,10 +65,10 @@
  * whichever column is on screen. Left in flow it rides off the side with the
  * columns, because the frame is as wide as the week is long.
  *
- * Only the text sticks. The bar and the border under it stay in flow at the
- * frame's full width, so the line runs the whole way across rather than stopping
- * at the window's edge. That also keeps the sticky area to a few words, which is
- * the smallest hole this can leave in the rasterized layer. See SCROLL-FLASH.md.
+ * Only the text sticks. The bar stays in flow at the frame's full width, so its
+ * fill runs the whole way across rather than stopping at the window's edge. That
+ * also keeps the sticky area to a few words, which is the smallest hole this can
+ * leave in the rasterized layer. See SCROLL-FLASH.md.
  */
 .results-caption__text {
   position: sticky;

--- a/src/components/results/ResultsFrame.tsx
+++ b/src/components/results/ResultsFrame.tsx
@@ -5,6 +5,7 @@ import { GameStatusContextProvider } from "../../context/GameStatusContext";
 import { PlayerAnalysisContextProvider } from "../../context/PlayerAnalysisContext";
 import { WeekInfo } from "../../types/League";
 import { RakMadnessScores } from "../../types/RakMadnessScores";
+import getClasses from "../../utils/getClasses";
 import GameStatusDialog from "../gameStatus/GameStatusDialog";
 import LogoButton, { APP_NAME } from "../navbar/LogoButton";
 import ScoresNavbar, { ScoresView } from "../navbar/ScoresNavbar";
@@ -14,6 +15,12 @@ import SkeletonTable from "../table/SkeletonTable";
 import "./ResultsFrame.scss";
 
 const doNothing = () => undefined;
+
+/** The pool the app scores, which is not the app's own name. */
+const POOL_NAME = "Rak Madness";
+
+/** What the caption is sized from on a route that does not know the week yet. */
+const CAPTION_STAND_IN = `${POOL_NAME} · 0000 Season · Week 00`;
 
 /**
  * What the tables have opened, which is one thing at a time.
@@ -61,6 +68,7 @@ export default function ResultsFrame({
   // Absent on the redirect routes, which render this frame before they know which
   // week they are headed for.
   const { season: seasonParam, week } = useParams();
+  const hasWeek = Boolean(seasonParam && week);
   // Once every game is final there is nothing left to fetch, so the refresh button
   // and the divider beside it go rather than sit there doing nothing.
   const isWeekDecided = useIsWeekDecided();
@@ -84,9 +92,7 @@ export default function ResultsFrame({
   return (
     <PageLayout
       title={
-        seasonParam && week
-          ? `${seasonParam} Week ${week} ${view}`
-          : `${APP_NAME} ${view}`
+        hasWeek ? `${seasonParam} Week ${week} ${view}` : `${APP_NAME} ${view}`
       }
       // True while loading too: the wireframe is shaped like the table it stands
       // in for, so it wants the same content area.
@@ -108,6 +114,26 @@ export default function ResultsFrame({
       }
     >
       <div className="results-scores">
+        {/*
+          Which week this is, for everyone who cannot hear the `<h1>` above. Hidden
+          from a screen reader because that heading already says it, and says the
+          view too.
+
+          Not held back until the scores land: the week is in the URL before they
+          are, so the wireframe wears the caption the table will and nothing under
+          it moves when the week arrives.
+        */}
+        <p
+          className={getClasses("results-caption", { "--loading": !hasWeek })}
+          data-skeleton-text={hasWeek ? undefined : CAPTION_STAND_IN}
+          aria-hidden="true"
+        >
+          {hasWeek && (
+            <span className="results-caption__text">
+              {`${POOL_NAME} · ${seasonParam} Season · Week ${week}`}
+            </span>
+          )}
+        </p>
         <PlayerAnalysisContextProvider showPlayerAnalysis={showPlayerAnalysis}>
           <GameStatusContextProvider showGameStatus={showGameStatus}>
             {isReady ? children : <SkeletonTable view={view} />}

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -65,9 +65,17 @@ $breakpoint-wide: 601px;
 }
 
 /**
- * A phone turned on its side. The height is what tells it apart from a tablet or
- * a window: every phone in landscape is under 500px tall, and the shortest tablet
- * is well over it.
+ * A phone turned on its side. Three things have to agree, because the overlay
+ * takes the whole screen and there is no way past it.
+ *
+ * The pointer is what tells a phone from a desktop. A window dragged short and
+ * wide answers every measurement below, and used to raise the overlay on a
+ * machine that cannot be turned at all. A mouse reports `hover` and a fine
+ * pointer, so asking for neither leaves only touch.
+ *
+ * The height is what tells a phone from a tablet, which is also touch and also
+ * turns: every phone in landscape is under 500px tall, and the shortest tablet is
+ * well over it.
  *
  * The ratio is what tells it apart from a phone held upright with a keyboard up,
  * which `index.html` asks the browser to take out of the layout viewport. A 360px
@@ -78,7 +86,7 @@ $breakpoint-wide: 601px;
  * controls, and a phone on its side has no room for either.
  */
 @mixin phone-landscape {
-  @media (orientation: landscape) and (max-height: 500px) and (min-aspect-ratio: 3/2) {
+  @media (orientation: landscape) and (max-height: 500px) and (min-aspect-ratio: 3/2) and (hover: none) and (pointer: coarse) {
     @content;
   }
 }


### PR DESCRIPTION
## What

A caption over the results tables naming the pool, season, and week, scrolling away with the table. Plus the rotate overlay held to phones.

## Why

Season and week lived in the URL and a hidden `<h1>`, so only a screen reader got them.

## Changes

- Inside `.results-scores`, not a sibling in `main`, a flex row centering its children.
- Only the text is sticky, held at the near edge while the table pans. The bar stays in flow at full width.
- Fill is `--rak-primary-600`, between the navbar and the header.
- Not gated on `isReady`, so the wireframe wears the caption the table keeps.
- `phone-landscape` asks for a touch pointer. A short, wide desktop window used to raise the overlay on a screen nobody can turn.

## Verification

- The sticky header still pins flush under the navbar.
- Caption text starts within half a pixel of the centered Rank heading at 320px, 390px, and 1440px, and holds there panned fully right.
- Overlay, emulated: desktop 1200x500 clear, phone landscape still covered, tablet unchanged.

| At rest | Panned right | Roomy screen |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/results-week-caption/phone-rest.png" width="250"> | <img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/results-week-caption/phone-panned.png" width="250"> | <img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/results-week-caption/desktop.png" width="250"> |

| Overlay, desktop before | Overlay, desktop after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/landscape-overlay-phones-only/before.png" width="380"> | <img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/landscape-overlay-phones-only/after.png" width="380"> |

## Notes / Follow-ups

- Adds one sticky element, which `SCROLL-FLASH.md` names as the open bug's cause.

🕵️ Neutralized by [Agent Juni Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
