### PR TITLE
fix(navbar): truncate the app name rather than clip it

### DIFF
--- a/src/components/navbar/LogoButton.scss
+++ b/src/components/navbar/LogoButton.scss
@@ -1,4 +1,8 @@
 .logo-button {
+  // A flex item will not shrink below what it holds unless it is told it may, and
+  // the name cannot give up its room until the button it sits in can.
+  min-width: 0;
+
   &__filter {
     position: absolute;
     width: 0;
@@ -8,6 +12,8 @@
   &__logo {
     width: 20px;
     height: 20px;
+    // The name gives up the room, not the mark beside it.
+    flex-shrink: 0;
     // The matching `<filter>` id is unique per instance, set inline in
     // `LogoButton.tsx` rather than here, where it would have to be static.
   }
@@ -21,5 +27,11 @@
     // One line at every width. The navbar is sized for it, and a wrapped app name
     // pushed the bar taller than the buttons standing next to it.
     white-space: nowrap;
+    // Where the buttons leave too little room, the name gives up its end to an
+    // ellipsis. Clipped instead it stopped mid-letter, which reads as the bar
+    // being broken rather than as a name too long for the screen.
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }


### PR DESCRIPTION
## What

The app name in the navbar gives up its end to an ellipsis when the buttons leave too little room.

## Why

`.navbar__content-left` clipped the name with `overflow: hidden` and nothing else, so at 320px it stopped mid-letter. That reads as the bar being broken rather than as a name too long for the screen.

## Changes

- `min-width: 0` on the button as well as the name. A flex item will not shrink below its content until it is told it may, so without the button the name never got the chance.
- `flex-shrink: 0` on the logo, so the name gives up the room and the mark beside it does not.

## Verification

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/navbar-truncate-app-name/before.png" width="320"> | <img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/navbar-truncate-app-name/after.png" width="320"> |

🕵️ Intercepted by [Agent Juni Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
