### PR TITLE
feat: name the app Rakulator, and set it in a 14-segment display face

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Rakulator
+# Rakulator
 
 Simple auto-scoring web application for [Rak Madness](https://rakmadness.net/). The [public site](https://rak.cullenrombach.com/) is hosted on [CloudFlare Pages](https://developers.cloudflare.com/pages/).
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       user's mobile device or desktop. See https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest
     -->
     <link rel="manifest" href="/manifest.json" />
-    <title>The Rakulator</title>
+    <title>Rakulator</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "rak-sadness-web",
+  "name": "rak-madness-calculator",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rak-sadness-web",
+      "name": "rak-madness-calculator",
       "version": "0.1.0",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-rc.0",
         "@fontsource-variable/inter": "^5.3.0",
+        "@fontsource/dseg14-classic": "^5.3.0",
         "lodash.throttle": "^4.1.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -1384,6 +1385,15 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
       "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/dseg14-classic": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/dseg14-classic/-/dseg14-classic-5.3.0.tgz",
+      "integrity": "sha512-UTHoHDxGQfWijJo26Co5hxoJoJvCoqJGryMELi9wgJtephHwt+Nh2NQ6kyeXAC7hQIlxFLcMj7aiAtbdsa2sow==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rak-madness-calculator",
-  "productName": "Rak Madness Scoreboard",
+  "productName": "Rakulator",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -25,6 +25,7 @@
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-rc.0",
     "@fontsource-variable/inter": "^5.3.0",
+    "@fontsource/dseg14-classic": "^5.3.0",
     "lodash.throttle": "^4.1.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "The Rakulator",
-  "name": "The Rakulator",
+  "short_name": "Rakulator",
+  "name": "Rakulator",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/App.picks.test.tsx
+++ b/src/App.picks.test.tsx
@@ -185,8 +185,10 @@ describe("the app, first load", () => {
     await mountLoadedApp();
     // The heading is visually hidden, so this is what a screen reader is told
     // the page is, not a second copy of the wordmark on screen.
+    // Matched whole rather than by substring, so the unlit segments drawn over
+    // the name have to stay out of the button's accessible name to pass.
     expect(
-      screen.getByRole("button", { name: /Rakulator/ }),
+      screen.getByRole("button", { name: "Rakulator" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { level: 1, name: "Rakulator" }),

--- a/src/App.picks.test.tsx
+++ b/src/App.picks.test.tsx
@@ -186,10 +186,10 @@ describe("the app, first load", () => {
     // The heading is visually hidden, so this is what a screen reader is told
     // the page is, not a second copy of the wordmark on screen.
     expect(
-      screen.getByRole("button", { name: /The Rakulator/ }),
+      screen.getByRole("button", { name: /Rakulator/ }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { level: 1, name: "The Rakulator" }),
+      screen.getByRole("heading", { level: 1, name: "Rakulator" }),
     ).toBeInTheDocument();
   });
 

--- a/src/appTestFixtures.tsx
+++ b/src/appTestFixtures.tsx
@@ -158,7 +158,7 @@ export function notFoundResponse(): Response {
 }
 
 export function htmlResponse(): Response {
-  return new Response("<!doctype html><title>The Rakulator</title>", {
+  return new Response("<!doctype html><title>Rakulator</title>", {
     status: 200,
     headers: { "content-type": "text/html" },
   });

--- a/src/components/home/HomePage.scss
+++ b/src/components/home/HomePage.scss
@@ -44,11 +44,15 @@
   // `gap`, because a button that hides itself collapses its own margin as part
   // of that transition, which a gap on the container cannot do.
   --rak-control-gap: var(--rak-space-3);
+  // What every control down this column stands, fields and buttons alike. Taller
+  // than the touch target a button asks for on its own, so saying it here is what
+  // keeps the two from standing at different heights in the same stack.
+  --rak-control-height: 3.5rem;
 }
 
 .home__week-input {
   width: 100%;
-  height: 3.5rem;
+  height: var(--rak-control-height);
 }
 
 .home__season-input {
@@ -62,6 +66,7 @@
 .home__controls .home__button {
   width: 100%;
   min-width: min-content;
+  min-height: var(--rak-control-height);
   transition-property: height, min-height, opacity, color, background-color;
   transition-duration: var(--rak-duration-slow);
   transition-timing-function: var(--rak-ease-standard);

--- a/src/components/navbar/CLAUDE.md
+++ b/src/components/navbar/CLAUDE.md
@@ -6,7 +6,9 @@
   played gets, for the results routes. Clearing `isWeekLive` collapses the refresh
   button and the divider before it.
 - `LogoButton`: the logo and `APP_NAME`, which it exports, as one target. Used by
-  the home page and the results frame as well as here.
+  the home page and the results frame as well as here. The name is set in
+  `--rak-font-display`, a 14-segment face, over a dim row of its all-on
+  character.
 
 Nothing here opens the player analysis. A player's name does, in either table, on a
 finished week as well as a live one.

--- a/src/components/navbar/LogoButton.scss
+++ b/src/components/navbar/LogoButton.scss
@@ -62,6 +62,9 @@
     position: absolute;
     top: 0;
     left: 0;
+    // Out of any selection the user drags over the bar. Selectable, copying the
+    // name carried the row of tildes out with it.
+    user-select: none;
     // Enough to read as segments that could light, not so much that it crowds the
     // ones that are lit. Measured against the navbar's own fill at this size.
     color: rgb(255 255 255 / 18%);

--- a/src/components/navbar/LogoButton.scss
+++ b/src/components/navbar/LogoButton.scss
@@ -1,3 +1,5 @@
+@use "../../styles/breakpoints" as *;
+
 .logo-button {
   // A flex item will not shrink below what it holds unless it is told it may, and
   // the name cannot give up its room until the button it sits in can.
@@ -21,17 +23,47 @@
   // Reads as the navbar's own heading rather than as button text, which is what
   // it looked like before the two became one button.
   &__name {
-    font-size: 1rem;
-    font-weight: bold;
+    font-family: var(--rak-font-display);
+    // As large as the narrowest phone can hold, because segments spell a letter
+    // in far less ink than a drawn face does and this is hard to read below it.
+    // The bound is the results routes: a week still being played takes 170px of
+    // the bar for its own buttons, which leaves the name the screen less 250px.
+    // A 360px phone is 110px of that, and the name measures 102.8px here. One
+    // step up is 110.2px, which is why this is the step it stops at.
+    font-size: var(--rak-text-sm);
+    // The bold cut, which `src/index.tsx` is what loads. It is the only one the
+    // app asks for: the face is monospaced, so the heavier segments advance
+    // exactly as far as the light ones and cost nothing across a bar this tight.
+    font-weight: var(--rak-weight-bold);
     text-align: left;
+    // The unlit segments are laid under the name rather than beside it.
+    position: relative;
     // One line at every width. The navbar is sized for it, and a wrapped app name
     // pushed the bar taller than the buttons standing next to it.
     white-space: nowrap;
     // Where the buttons leave too little room, the name gives up its end to an
     // ellipsis. Clipped instead it stopped mid-letter, which reads as the bar
-    // being broken rather than as a name too long for the screen.
+    // being broken rather than as a name too long for the screen. The face has no
+    // ellipsis of its own, so the one drawn here comes from the fallback stack.
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    @include roomy-screen {
+      font-size: var(--rak-text-md);
+    }
+  }
+
+  // The segments the display leaves dark. Every glyph in the face advances the
+  // same width, so this sits exactly over the name without being measured. Over
+  // rather than under, because being positioned it paints last, and it makes no
+  // difference: every segment the name lights is one this lights too.
+  &__name-ghost {
+    position: absolute;
+    top: 0;
+    left: 0;
+    // Enough to read as segments that could light, not so much that it crowds the
+    // ones that are lit. Measured against the navbar's own fill at this size.
+    color: rgb(255 255 255 / 18%);
   }
 }

--- a/src/components/navbar/LogoButton.tsx
+++ b/src/components/navbar/LogoButton.tsx
@@ -5,7 +5,14 @@ import "./LogoButton.scss";
 const OUTLINE_RADIUS_PX = 1;
 
 /** Shown in the navbar on every page, whichever view is open. */
-export const APP_NAME = "The Rakulator";
+export const APP_NAME = "Rakulator";
+
+/**
+ * The character DSEG14 draws with every segment lit. A row of them behind the
+ * name is the display's unlit segments, the way a real readout shows the shapes
+ * it is not currently using.
+ */
+const ALL_SEGMENTS_ON = "~";
 
 export default function LogoButton({ onClick }: { onClick: () => void }) {
   // Unique per instance, so two logos on the same page never share a filter: an
@@ -50,7 +57,17 @@ export default function LogoButton({ onClick }: { onClick: () => void }) {
         alt=""
         style={{ filter: `url(#${outlineFilterId})` }}
       />
-      <span className="logo-button__name">{APP_NAME}</span>
+      {/*
+        The name is the element's own text rather than a third span, so that
+        running out of room still ends it in an ellipsis. `text-overflow` reaches
+        in-flow inline content only, and would skip a positioned one.
+      */}
+      <span className="logo-button__name">
+        <span className="logo-button__name-ghost" aria-hidden="true">
+          {ALL_SEGMENTS_ON.repeat(APP_NAME.length)}
+        </span>
+        {APP_NAME}
+      </span>
     </Button>
   );
 }

--- a/src/components/navbar/Navbar.scss
+++ b/src/components/navbar/Navbar.scss
@@ -39,8 +39,8 @@
   align-items: center;
   gap: var(--rak-space-3);
   font-weight: var(--rak-weight-bold);
-  // The app name does not wrap, so without this the name pushes the buttons off
-  // a 320px screen rather than giving up its own room.
+  // The app name does not wrap, so without this it pushes the buttons off the end
+  // of a bar too narrow to hold both rather than giving up its own room.
   min-width: 0;
   overflow: hidden;
 }

--- a/src/components/pageLayout/PageLayout.tsx
+++ b/src/components/pageLayout/PageLayout.tsx
@@ -107,7 +107,7 @@ export default function PageLayout({
         </span>
         <p className="page__rotate-message">Turn your phone upright</p>
         <p className="page__rotate-detail">
-          The Rakulator does not support landscape on a phone.
+          Rakulator does not support landscape on a phone.
         </p>
       </div>
     </div>

--- a/src/index.scss
+++ b/src/index.scss
@@ -20,6 +20,14 @@
   // advance width is narrow enough to change how many columns fit.
   --rak-font-mono:
     ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  // The app name alone, in the 14-segment display face a calculator reads out
+  // through. It has no lowercase and draws every letter as a capital, so the
+  // name stays ordinary mixed-case text in the DOM. `src/index.tsx` loads its
+  // bold cut, and only that one, so anything set in this has to ask for bold.
+  // The fallback is the mono stack rather than the body one: the name is drawn
+  // over a row of all-segments-on characters, and only a fixed advance keeps the
+  // two layers on top of each other while the face is still downloading.
+  --rak-font-display: "DSEG14 Classic", var(--rak-font-mono);
 
   --rak-text-xs: 0.75rem;
   --rak-text-sm: 0.875rem;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import App from "./App";
 import "@fontsource-variable/inter";
+import "@fontsource/dseg14-classic/700.css";
 import { AppDataContextProvider } from "./context/AppDataContext";
 import { ToastContextProvider } from "./context/ToastContext";
 import Toaster from "./components/toaster/Toaster";


### PR DESCRIPTION
## What

The app is now Rakulator, and the navbar sets that name in a 14-segment display face, the way a calculator readout would.

![The navbar on a 390px phone](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/rakulator-display-font/navbar-390.png)

## Changes

- DSEG14, not DSEG7. There is no 7-segment form for `k`, and DSEG7 draws it broken.
- Only the bold cut ships. The face is monospaced, so bold advances the same and costs no width.
- The phone size stops at `--rak-text-sm`. A live week leaves the name 110px at 360px and it measures 102.8px there. One step up is 110.2px.
- A dim row of the all-on character sits over the name as the unlit segments. It is `aria-hidden`, so the button and the `<h1>` still read "Rakulator".
- "The" is dropped everywhere the name appears, `productName` included. `package.json`'s `name` is left alone.
- Home page buttons now stand at the height the selects already did, named once as `--rak-control-height`.

## Verification

Measured the name against real `ScoresNavbar` widths at 360, 375, 390, 412 and 430px. Nothing truncates.

## Notes / Follow-ups

- Under 360px the name truncates, and the ellipsis is drawn from the fallback stack because the face carries none.
- npm rewrote `package-lock.json`'s stale `name` field to match `package.json`.

🕵️ Sanitized by [Agent P (Perry the Platypus)](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
