### PR TITLE
chore(claude): name the heaviest block when a budget fails

### DIFF
--- a/.claude/hooks/check_conventions.py
+++ b/.claude/hooks/check_conventions.py
@@ -187,6 +187,40 @@ def prose_words(body):
                 if not MEDIA_TOKEN.match(word)])
 
 
+LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
+HEADING_LINE = re.compile(r"^#{1,6}\s+")
+
+
+def heaviest_blocks(body, show=3):
+    """The costliest prose blocks, as ["  42  first line", ...], heaviest first.
+
+    A budget that reports only the overage sends a writer shaving a word at a time.
+    Naming the heavy block means one cut lands. A list item is its own block, or a
+    run of bullets reads as one heavy list rather than one heavy bullet.
+    """
+    text = MEDIA.sub("", COMMENTS.sub("", FENCE.sub("", body)))
+    found, current = [], []
+
+    def flush():
+        if current:
+            words = prose_words("\n".join(current))
+            if words > 1:
+                first = current[0].strip()
+                found.append((words, first if len(first) <= 60
+                              else first[:57] + "..."))
+            del current[:]
+
+    for line in text.splitlines() + [""]:
+        if LIST_ITEM.match(line) or HEADING_LINE.match(line.strip()):
+            flush()
+        elif not line.strip():
+            flush()
+            continue
+        current.append(line)
+    flush()
+    return ["  %3d  %s" % pair for pair in sorted(found, reverse=True)[:show]]
+
+
 def empty_sections(body):
     """Headings with nothing under them."""
     parts = re.split(r"(?m)^(#{2,3}\s+.+?)\s*$", body)
@@ -234,8 +268,11 @@ def body_problems(body, template, branch=""):
             problems.append(
                 "the body is %d words, the budget is %d. Cut what the reviewer "
                 "gets from the diff or the ticket: a retelling of the ticket, "
-                "history, counts, a per-file walkthrough, self-assessment"
-                % (words, limit))
+                "history, counts, a per-file walkthrough, self-assessment.\n"
+                "    Heaviest blocks, cut one of these rather than shaving "
+                "words:\n%s"
+                % (words, limit, "\n".join("    " + row
+                                           for row in heaviest_blocks(body))))
     if PUNCTUATION_RULE in template:
         found = sorted({name for mark, name in BANNED.items()
                         if mark in prose(body)})

--- a/.claude/scripts/lint_claude_md.py
+++ b/.claude/scripts/lint_claude_md.py
@@ -14,6 +14,9 @@ Subcommands:
   dupes      <root>   Findings where a parent link restates its child's summary.
   length     <root>   Findings where a file's own prose exceeds the word ceiling.
   check      <root>   structure, dupes, length, all three always run.
+  count      <path>.. Words, headroom and the heaviest blocks. Takes files,
+                      directories, or `-` to measure a draft on stdin before it
+                      is written. Exit 1 when anything is over.
 
 `<root>` defaults to ".". Exit 0 = clean, 1 = findings, 2 = could not run.
 
@@ -389,23 +392,73 @@ EXEMPT_HEADINGS = {"subdirectories", "maintaining this tree"}
 
 HEADING_RE = re.compile(r"^(#+)\s+(.*\S)\s*$")
 
+LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
 
-def body_words(path):
-    """Word count of a CLAUDE.md outside the exempt sections.
+
+def counted_lines(text):
+    """The lines that count toward the ceiling, in order.
 
     A heading at level 1 or 2 opens or closes an exemption; deeper headings stay
     inside whatever section they belong to.
     """
-    count = 0
+    kept = []
     exempt = False
+    for line in text.splitlines():
+        m = HEADING_RE.match(line.strip())
+        if m and len(m.group(1)) <= 2:
+            exempt = m.group(2).lower() in EXEMPT_HEADINGS
+        if not exempt:
+            kept.append(line)
+    return kept
+
+
+def text_words(text):
+    """Word count of a CLAUDE.md's own prose."""
+    return sum(len(line.split()) for line in counted_lines(text))
+
+
+def body_words(path):
+    """Word count of the CLAUDE.md at `path`, outside the exempt sections."""
     with open(path, encoding="utf-8") as fh:
-        for line in fh:
-            m = HEADING_RE.match(line.strip())
-            if m and len(m.group(1)) <= 2:
-                exempt = m.group(2).lower() in EXEMPT_HEADINGS
-            if not exempt:
-                count += len(line.split())
-    return count
+        return text_words(fh.read())
+
+
+def blocks(text):
+    """Counting prose as [(words, first line)], heaviest first.
+
+    A ceiling reports how far over a file is, which says nothing about where the
+    weight sits, so a writer shaves a word at a time and re-runs. This says which
+    block to cut, and one edit lands.
+    """
+    found, current = [], []
+
+    def flush():
+        if current:
+            found.append((sum(len(l.split()) for l in current), current[0].strip()))
+            del current[:]
+
+    for line in counted_lines(text) + [""]:
+        # A list item is its own block. Without this every bullet in a run merges
+        # into one, and the report says the list is heavy rather than which bullet.
+        if LIST_ITEM.match(line):
+            flush()
+        elif not line.strip():
+            flush()
+            continue
+        current.append(line)
+    flush()
+    return sorted(found, reverse=True)
+
+
+def report_blocks(text, indent="    ", show=3):
+    """Print the heaviest blocks, so one cut is enough."""
+    heavy = [b for b in blocks(text) if b[0] > 1][:show]
+    if not heavy:
+        return
+    print("%sheaviest blocks:" % indent)
+    for words, first in heavy:
+        snippet = first if len(first) <= 64 else first[:61] + "..."
+        print("%s  %3d  %s" % (indent, words, snippet))
 
 
 def length_findings(root):
@@ -430,8 +483,12 @@ def report_length(root):
         print("  %s" % path)
         print("    %d words, %d over (Subdirectories and the root's maintenance "
               "note excluded)" % (count, count - BODY_WORD_LIMIT))
+        with open(path, encoding="utf-8") as fh:
+            report_blocks(fh.read())
         print("    fix: cut prose, or move what is read only during one kind of "
-              "work into a repo skill under .claude/skills/.\n")
+              "work into a repo skill under .claude/skills/.")
+        print("    draft first: `lint_claude_md.py count -` reads a draft on "
+              "stdin, so a rewrite is measured before it lands.\n")
     return 1
 
 
@@ -449,6 +506,49 @@ def report_check(root):
     return 1 if any(codes) else 0
 
 
+# A file this close to the ceiling has no room for the next edit, so it gets the
+# same block breakdown a failure does. Landing at exactly the limit is what makes
+# the next writer repeat the shave.
+TIGHT = 10
+
+
+def report_count(targets):
+    """Words, headroom and the heaviest blocks, for a draft or for files on disk.
+
+    Exists so a rewrite is measured before it lands. Writing a file, running the
+    linter, and shaving a word at a time is the loop this removes.
+    """
+    items = []
+    for target in targets or ["."]:
+        if target == "-":
+            items.append(("(stdin)", sys.stdin.read()))
+        elif os.path.isdir(target):
+            for rel in sorted(claude_md_dirs(target)):
+                path = os.path.join(target, rel, CLAUDE_MD)
+                with open(path, encoding="utf-8") as fh:
+                    items.append((path, fh.read()))
+        elif os.path.isfile(target):
+            with open(target, encoding="utf-8") as fh:
+                items.append((target, fh.read()))
+        else:
+            print("error: no such file or directory: %s" % target, file=sys.stderr)
+            return 2
+
+    over = 0
+    print("%6s %6s  %s" % ("words", "left", "file"))
+    for path, text in items:
+        count = text_words(text)
+        left = BODY_WORD_LIMIT - count
+        print("%6d %6d  %s" % (count, left, path))
+        if left < 0:
+            over += 1
+        if left <= TIGHT:
+            report_blocks(text, indent="        ")
+    if over:
+        print("\n%d file(s) over the %d-word ceiling." % (over, BODY_WORD_LIMIT))
+    return 1 if over else 0
+
+
 COMMANDS = {
     "plan": report_plan,
     "structure": report_structure,
@@ -462,9 +562,13 @@ def main(argv):
     if len(argv) > 1 and argv[1] in ("-h", "--help"):
         print(__doc__.strip())
         return 0
+    # count takes files, directories or `-`, where every other subcommand takes one
+    # root, so it parses its own arguments.
+    if len(argv) > 1 and argv[1] == "count":
+        return report_count(argv[2:])
     if len(argv) < 2 or argv[1] not in COMMANDS:
-        print("error: expected one of %s (try --help)" % ", ".join(COMMANDS),
-              file=sys.stderr)
+        print("error: expected one of count, %s (try --help)"
+              % ", ".join(COMMANDS), file=sys.stderr)
         return 2
     root = argv[2] if len(argv) > 2 else "."
     if not os.path.isdir(root):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,13 @@ absolute path: `manifest.json`, the `favicon.ico` and `logo*.png` icons, and
 Navigation index. Changed a dir: update its CLAUDE.md summary and the parent's
 link. New meaningful dir: add a CLAUDE.md, link it. Pointer <= 70 chars. Every
 CLAUDE.md: 120 words max outside its Subdirectories list and this block. Ceiling,
-not target, and `make lint-docs` enforces it. Over it, the detail belongs at the
-point of definition, in a comment or docblock beside the code. A skill under
-`.claude/skills/` is for what no one file can hold. `public/` is the exception to
-the tree: it is served as-is, so it is described above instead.
+not target: land under it, or the next edit pays to shave. `make lint-docs`
+enforces it. Over it, the detail belongs at the point of definition, in a comment
+or docblock beside the code. A skill under `.claude/skills/` is for what no one
+file can hold. `public/` is the exception to the tree: it is served as-is, so it
+is described above instead.
+
+Measure a rewrite before writing it, which is one pass rather than several:
+
+    python3 .claude/scripts/lint_claude_md.py count -    # draft on stdin
+    python3 .claude/scripts/lint_claude_md.py count DIR  # words, headroom, heaviest blocks


### PR DESCRIPTION
## What

Refreshes the two vendored agentify files that fell behind their upstream in `claude-tools`, and brings the root maintenance block along with them.

## Why

Both word budgets here reported the overage and nothing about where the weight sat, so a rewrite meant write, fail, shave a word, repeat.

## Changes

- `lint_claude_md.py` and `check_conventions.py` are verbatim copies of the installed agentify skills. Read them upstream, not here.
- `count` measures a file, a directory, or a draft on stdin, so a rewrite is one pass.
- A CLAUDE.md within ten words of the ceiling gets the block breakdown, not only one already over.
- The root block keeps this repo's own sentences about `make lint-docs`, `public/`, and skills.

## Verification

- `lint_claude_md.py structure .` reports the same findings before and after the swap, so the refresh changes no verdict.

## Notes / Follow-ups

- Those structure findings are preexisting and still unfixed. `make lint-docs` runs `length` alone, so they do not gate.

🕵️ Sanitized by [Agent Cody Banks](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
