### PR TITLE
fix(navbar): let the logo's shadow bleed past the button

### DIFF
--- a/src/components/navbar/LogoButton.scss
+++ b/src/components/navbar/LogoButton.scss
@@ -20,6 +20,10 @@
 // the panel they are set into. `&__name` sets its own instead.
 .button.logo-button {
   padding: 0;
+  // `.button`'s own `overflow: hidden` is there to contain the `--busy` sheen,
+  // which this key never sets. Visible instead, so the glass's own shadow can
+  // throw past this box.
+  overflow: visible;
 }
 
 .logo-button {

--- a/src/components/navbar/Navbar.scss
+++ b/src/components/navbar/Navbar.scss
@@ -49,9 +49,11 @@
   gap: var(--rak-space-3);
   font-weight: var(--rak-weight-bold);
   // The app name does not wrap, so without this it pushes the buttons off the end
-  // of a bar too narrow to hold both rather than giving up its own room.
+  // of a bar too narrow to hold both rather than giving up its own room. Explicit
+  // zero rather than `overflow: hidden` doing it, so the name's own glass can still
+  // throw its shadow past this box.
   min-width: 0;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .navbar__content-right {


### PR DESCRIPTION
## What

The navbar logo's shadow (the `lcd-glass` bezel it shares with the game status dialog's scoreline) was invisible. Two ancestors clipped it with `overflow: hidden`.

## Changes

- `.button.logo-button` now sets `overflow: visible`. Its base `overflow: hidden` only exists to contain the `--busy` sheen, which the logo button never sets.
- `.navbar__content-left` overflow changed from `hidden` to `visible`. Its explicit `min-width: 0` is what allows the flex item to shrink below content size, not the overflow value, so the shrink-to-fit behavior is unaffected.
- `_lcd.scss` and the game status dialog's scoreline are untouched. That glass was never clipped and is the visual baseline this now matches.

## Verification

- Checked in-browser at desktop width and at 360px: both shadow rings now paint, and match the game status dialog's scoreline.
- At 360px the shadow doesn't crowd the adjacent scoreboard/picks buttons, so no shortening of the app name was needed.
- Tab-focused the logo button: focus outline still renders correctly, not clipped.

🕵️ Encoded by [Agent Carmen Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
