### PR TITLE
fix(navbar): harden and speed up the live-week refresh key

### DIFF
--- a/src/App.results.test.tsx
+++ b/src/App.results.test.tsx
@@ -120,6 +120,9 @@ describe("the app, results views", () => {
         ),
       ).toBeInTheDocument();
     });
+    // A refresh reuses the workbook already in memory, so a transient failure has
+    // nothing to fall back to but what was already on screen.
+    expect(screen.getByText("MNF Points Pick")).toBeInTheDocument();
   });
 });
 

--- a/src/components/button/Button.scss
+++ b/src/components/button/Button.scss
@@ -192,6 +192,11 @@
   // take away the only thing that says what they pressed.
   &.--busy {
     @include skeleton-sheen;
+    cursor: default;
+    // A key this small reads the sheen's usual loop as a slow, faint smear rather
+    // than as work happening. `dialog-sweep`'s own progress bar is the other place
+    // the app times a sweep to the box it crosses rather than to the shared loop.
+    --rak-duration-loop: 900ms;
 
     // A key is disabled for as long as it is working, so this is where most of the
     // app's waiting is seen. The sweep is white, which is invisible on the grey a

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -76,10 +76,15 @@ export function LeaderboardIcon() {
   );
 }
 
-export function RefreshIcon() {
+/**
+ * Filled rather than the outline `refresh` glyph the rest of Material Symbols
+ * offers, so the refresh key reads as solid mass beside the two filled keys next
+ * to it in the navbar rather than a step lighter.
+ */
+export function UpdateIcon() {
   return (
-    <Icon name="RefreshIcon">
-      <path d="M480-160q-133 0-226.5-93.5T160-480q0-133 93.5-226.5T480-800q85 0 149 34.5T740-671v-129h60v254H546v-60h168q-38-60-97-97t-137-37q-109 0-184.5 75.5T220-480q0 109 75.5 184.5T480-220q83 0 152-47.5T728-393h62q-29 105-115 169t-195 64Z" />
+    <Icon name="UpdateIcon">
+      <path d="M480-120q-75 0-140.5-28.5t-114-77q-48.5-48.5-77-114T120-480q0-75 28.5-140.5t77-114q48.5-48.5 114-77T480-840q82 0 155.5 35T760-706v-94h80v240H600v-80h110q-41-56-101-88t-129-32q-117 0-198.5 81.5T200-480q0 117 81.5 198.5T480-200q105 0 183.5-68T756-440h82q-15 137-117.5 228.5T480-120Zm112-192L440-464v-216h80v184l128 128-56 56Z" />
     </Icon>
   );
 }

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -78,8 +78,8 @@ export function LeaderboardIcon() {
 
 /**
  * Filled rather than the outline `refresh` glyph the rest of Material Symbols
- * offers, so the refresh key reads as solid mass beside the two filled keys next
- * to it in the navbar rather than a step lighter.
+ * offers, so the navbar's refresh key reads as solid mass beside the two filled
+ * keys next to it rather than a step lighter.
  */
 export function UpdateIcon() {
   return (

--- a/src/components/navbar/ScoresNavbar.test.tsx
+++ b/src/components/navbar/ScoresNavbar.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { act } from "react";
 import ScoresNavbar, { COLLAPSE_DURATION_MS } from "./ScoresNavbar";
 
@@ -65,5 +66,35 @@ describe("ScoresNavbar", () => {
     expect(
       screen.queryByRole("button", { name: "Refresh" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("carries the update glyph, not the outline refresh one it replaced", () => {
+    render(<ScoresNavbar {...props} isWeekLive />);
+
+    expect(screen.getByTestId("UpdateIcon")).toBeInTheDocument();
+  });
+
+  it("fires onRefresh when clicked", async () => {
+    // No delay: the suite runs under fake timers for the collapse animation
+    // above, which real userEvent delays would hang against.
+    const user = userEvent.setup({ delay: null });
+    const onRefresh = vi.fn();
+    render(<ScoresNavbar {...props} isWeekLive onRefresh={onRefresh} />);
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onRefresh while a refresh is already running", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onRefresh = vi.fn();
+    render(
+      <ScoresNavbar {...props} isWeekLive isRefreshing onRefresh={onRefresh} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(onRefresh).not.toHaveBeenCalled();
   });
 });

--- a/src/components/navbar/ScoresNavbar.tsx
+++ b/src/components/navbar/ScoresNavbar.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, useEffect, useState } from "react";
-import { FactCheckIcon, LeaderboardIcon, RefreshIcon } from "../icon/Icon";
+import { FactCheckIcon, LeaderboardIcon, UpdateIcon } from "../icon/Icon";
 import Button from "../button/Button";
 import "./ScoresNavbar.scss";
 
@@ -89,13 +89,15 @@ export default function ScoresNavbar({
             <div className="scores-nav__divider" />
             <Button
               ariaLabel="Refresh"
-              ariaDisabled={disabled}
+              // Also unavailable mid-refresh, so a second click while one is
+              // already running cannot queue another.
+              ariaDisabled={disabled || isRefreshing}
               busy={isRefreshing}
               compact
               onClick={onRefresh}
               className="scores-nav__button"
             >
-              <RefreshIcon />
+              <UpdateIcon />
             </Button>
           </div>
         </div>

--- a/src/components/table/CLAUDE.md
+++ b/src/components/table/CLAUDE.md
@@ -6,8 +6,8 @@
   `standInRows`.
 - `Table.scss`: the shared `.table` styles, sticky header and player column, touch
   feedback, striped rows, the trailing row, the `.table__cell-button` a clickable
-  cell holds, and the width a column of each kind is laid out at. Fixed, so a long
-  value is cut short rather than widening it.
+  cell holds, and each column's width. Fixed, so a long value is cut short rather
+  than widening it. `.table__cell-wipe` flashes a cell a refresh changed.
 - `SkeletonTable`: the wireframe shown while a week is worked out. Its columns are
   the real ones' width, and its sixty-odd rows scroll as the table will.
 

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -11,6 +11,33 @@
   background-color: color-mix(in srgb, var(--rak-cell-fill) $strength, black);
 }
 
+// A refresh changing a cell's status draws the color it held before over the
+// color it holds now, then wipes that away left to right, so the new value
+// reads as revealed rather than as a fill simply swapping. `--rak-cell-base`
+// names the color it wipes away, the same token every status fill and the
+// striped row beneath it already read from, set here by whichever status class
+// a change's previous value was, in `PicksTable.scss` and below.
+@keyframes rak-cell-wipe {
+  from {
+    clip-path: inset(0 0 0 0);
+  }
+  to {
+    clip-path: inset(0 0 0 100%);
+  }
+}
+
+// The striped-row mix, read back for whichever property carries a cell's fill:
+// `--rak-cell-fill`, which a pressed or hovered cell mixes further from, or
+// `background-color` directly, which a wipe overlay has no further state to mix
+// from.
+@mixin striped-fill($property) {
+  #{$property}: color-mix(
+    in srgb,
+    var(--rak-cell-base) var(--rak-stripe-strength),
+    var(--rak-stripe-with)
+  );
+}
+
 .table {
   // Centered across, and flush to the top, which is where the wireframe stands. The
   // rows below carry the table to the bottom of the window, and what is left under
@@ -145,6 +172,11 @@
     display: block;
     width: 100%;
     height: 100%;
+    // Containing block for `.table__cell-wipe`, painted over this button's own
+    // content rather than over the `<td>`, which stays un-positioned. Nothing here
+    // becomes sticky, which is what `SCROLL-FLASH.md` traces the Android fling
+    // flash to.
+    position: relative;
     // The cell's own rule reaches the text it holds directly. Said again here for
     // the two columns that wrap theirs in a button.
     overflow: hidden;
@@ -158,6 +190,23 @@
     font: inherit;
     text-align: inherit;
     cursor: pointer;
+  }
+
+  // What a refresh changing this cell's status draws over the new value, then
+  // wipes away. Rendered only where a change actually happened, so a cell whose
+  // status held steady never gains one. `--rak-cell-base` would otherwise
+  // inherit the *new* status's fill from the `<td>` around it, which is why this
+  // names its own default, `incomplete` being what a pick almost always wipes
+  // away from. `PicksTable.scss` layers the rarer previous statuses over it, and
+  // `.table__player-col` below covers the one change a name cell can show.
+  .table__cell-wipe {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    --rak-cell-base: var(--rak-surface);
+    background-color: var(--rak-cell-base);
+    animation: rak-cell-wipe var(--rak-duration-slow) var(--rak-ease-standard)
+      forwards;
   }
 
   // A pick's or a player's status, said in words for the fill color a sighted
@@ -219,6 +268,13 @@
       &.--knocked-out {
         --rak-cell-base: var(--rak-knocked-out-300);
       }
+
+      // The one change a name cell can show is a player just being knocked out,
+      // so the wipe always draws the fill they held before that, not the one
+      // inherited from the `<td>`'s own, already-updated class above.
+      .table__cell-wipe {
+        --rak-cell-base: var(--rak-in-contention-300);
+      }
     }
 
     td {
@@ -254,11 +310,11 @@
     }
 
     tr:nth-child(even) td {
-      --rak-cell-fill: color-mix(
-        in srgb,
-        var(--rak-cell-base) var(--rak-stripe-strength),
-        var(--rak-stripe-with)
-      );
+      @include striped-fill(--rak-cell-fill);
+    }
+
+    tr:nth-child(even) .table__cell-wipe {
+      @include striped-fill(background-color);
     }
 
     // Keeps the last real row clear of a phone's rounded corners and home

--- a/src/components/table/picks/CLAUDE.md
+++ b/src/components/table/picks/CLAUDE.md
@@ -5,8 +5,10 @@ cell sits in. Renders `PlayerName` per row, whose own click opens the player ana
 instead. Column labels via `rangeWithPrefix` (C1..., P1...), built once for the headers
 and the cells, so neither can mean a game the other does not.
 
-Each pick cell is a `PickCell`, the shared `.table__cell-button` inside the `<td>`
-carrying the status fill. Right, wrong, and unscoreable picks (`--yes`, `--no`,
-`--unscoreable`) each get a `PICK_STATUS_LABEL` entry as a `.table__sr-only` span, so a
-screen reader gets the outcome the cell's color otherwise carries alone. `incomplete`
-has no entry: it draws no color either, so there is nothing sighted to catch up on.
+Each pick cell is a `PickCell`, the shared `.table__cell-button` carrying the status
+fill. Right, wrong, and unscoreable picks (`--yes`, `--no`, `--unscoreable`) each get
+a `PICK_STATUS_LABEL` entry as a `.table__sr-only` span, so a screen reader gets what
+the color otherwise carries alone. `incomplete` has none: it draws no color either.
+
+A cell a refresh just resolved also renders a `.table__cell-wipe`, in the status it
+left.

--- a/src/components/table/picks/PicksTable.scss
+++ b/src/components/table/picks/PicksTable.scss
@@ -4,14 +4,20 @@
 // and derives the even-row stripe from it.
 .table {
   tbody {
+    // A wipe carries the same modifier class for whichever status it draws over,
+    // which is almost always `incomplete` and so has no rule of its own here:
+    // `Table.scss` names that one as `.table__cell-wipe`'s own default.
+    //
     // `--rak-text-on-pale` inverts to light ink in dark mode alongside these
     // fills, which darken there instead of staying pale.
-    .table__pick.--yes {
+    .table__pick.--yes,
+    .table__cell-wipe.--yes {
       --rak-cell-base: var(--rak-success-300);
       color: var(--rak-text-on-pale);
     }
 
-    .table__pick.--no {
+    .table__pick.--no,
+    .table__cell-wipe.--no {
       --rak-cell-base: var(--rak-danger-300);
       color: var(--rak-text-on-pale);
     }
@@ -20,7 +26,8 @@
     // that ramp step also fills the game dialog's `--invalid` mark, paired there
     // with its own fixed dark text, and the two need to move independently once
     // dark mode darkens this cell instead.
-    .table__pick.--unscoreable {
+    .table__pick.--unscoreable,
+    .table__cell-wipe.--unscoreable {
       --rak-cell-base: var(--rak-cell-unscoreable);
       color: var(--rak-text-on-pale);
     }

--- a/src/components/table/picks/PicksTable.test.tsx
+++ b/src/components/table/picks/PicksTable.test.tsx
@@ -1,3 +1,4 @@
+import { Mock } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import {
@@ -6,9 +7,18 @@ import {
   RakMadnessScores,
   Status,
 } from "../../../types/RakMadnessScores";
+import { useScoreChanges } from "../../../context/AppDataContext";
 import { GameStatusContextProvider } from "../../../context/GameStatusContext";
 import { PlayerAnalysisContextProvider } from "../../../context/PlayerAnalysisContext";
+import { pickChangeKey } from "../../../utils/scoring/gameColumns";
 import PicksTable from "./PicksTable";
+
+vi.mock("../../../context/AppDataContext", () => ({
+  useScoreChanges: vi.fn(),
+  useIsWeekDecided: () => false,
+}));
+
+const mockScoreChanges = useScoreChanges as Mock;
 
 function pick(
   label: string,
@@ -65,6 +75,10 @@ function renderPicks(showGameStatus = vi.fn()) {
   );
   return { user, showGameStatus };
 }
+
+beforeEach(() => {
+  mockScoreChanges.mockReturnValue({ picks: new Map(), players: new Map() });
+});
 
 describe("PicksTable, empty states", () => {
   it("renders nothing without scores", () => {
@@ -247,5 +261,38 @@ describe("PlayerName, rendered through the table", () => {
     );
     await user.click(screen.getByText("Bob"));
     expect(showPlayerAnalysis).toHaveBeenCalledWith("Bob");
+  });
+});
+
+describe("PicksTable, a refresh's changes", () => {
+  it("wipes a pick a refresh just resolved, carrying the status it left", () => {
+    mockScoreChanges.mockReturnValue({
+      picks: new Map([[pickChangeKey("Alice", "C1"), "incomplete"]]),
+      players: new Map(),
+    });
+    render(<PicksTable scores={scores} />);
+
+    const cell = screen.getByText("MICH").closest("button");
+    expect(cell?.querySelector(".table__cell-wipe")).toHaveClass(
+      "--incomplete",
+    );
+  });
+
+  it("wipes nothing for a cell that did not change", () => {
+    render(<PicksTable scores={scores} />);
+
+    const cell = screen.getByText("MICH").closest("button");
+    expect(cell?.querySelector(".table__cell-wipe")).not.toBeInTheDocument();
+  });
+
+  it("wipes a player's name cell once they are just knocked out", () => {
+    mockScoreChanges.mockReturnValue({
+      picks: new Map(),
+      players: new Map([["Alice", false]]),
+    });
+    render(<PicksTable scores={scores} />);
+
+    const cell = screen.getByText("Alice").closest("button");
+    expect(cell?.querySelector(".table__cell-wipe")).toBeInTheDocument();
   });
 });

--- a/src/components/table/picks/PicksTable.tsx
+++ b/src/components/table/picks/PicksTable.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import { useScoreChanges } from "../../../context/AppDataContext";
 import { useShowGameStatus } from "../../../context/GameStatusContext";
 import {
   PickResult,
@@ -7,6 +8,10 @@ import {
   Status,
 } from "../../../types/RakMadnessScores";
 import rangeWithPrefix from "../../../utils/rangeWithPrefix";
+import {
+  LEAGUE_PREFIX,
+  pickChangeKey,
+} from "../../../utils/scoring/gameColumns";
 import PlayerName from "../playerName/PlayerName";
 import TableShell, { RankCell } from "../TableShell";
 import "./PicksTable.scss";
@@ -38,11 +43,14 @@ function leagueHeaders(labels: Array<string>) {
 function PickCell({
   result,
   gameLabel,
+  previousStatus,
   onClick,
 }: {
   result: PickResult;
   /** The column this cell is in, which is what names the game behind it. */
   gameLabel: string;
+  /** Set where this refresh just changed the status, to the status it left. */
+  previousStatus?: Status;
   onClick: (gameLabel: string) => void;
 }) {
   const statusLabel = PICK_STATUS_LABEL[result.status];
@@ -54,12 +62,22 @@ function PickCell({
     >
       <span>{result.pick || "N/A"}</span>
       {statusLabel && <span className="table__sr-only">{statusLabel}</span>}
+      {previousStatus != null && (
+        // Keyed by the status arriving, so a cell changed by two refreshes in a
+        // row wipes both times rather than sitting on the first run forever.
+        <span
+          key={result.status}
+          className={`table__cell-wipe --${previousStatus}`}
+          aria-hidden="true"
+        />
+      )}
     </button>
   );
 }
 
 function PicksTable({ scores }: { scores?: RakMadnessScores | null }) {
   const showGameStatus = useShowGameStatus();
+  const { picks: pickChanges } = useScoreChanges();
 
   if (scores == null) {
     return null;
@@ -71,8 +89,8 @@ function PicksTable({ scores }: { scores?: RakMadnessScores | null }) {
   const columnCount = FIXED_COLUMN_COUNT + collegeCount + proCount;
   // Built once for the headers and every row's cells, so a cell and the column it
   // sits under cannot disagree about which game they mean.
-  const collegeLabels = rangeWithPrefix(collegeCount, "C");
-  const proLabels = rangeWithPrefix(proCount, "P");
+  const collegeLabels = rangeWithPrefix(collegeCount, LEAGUE_PREFIX.college);
+  const proLabels = rangeWithPrefix(proCount, LEAGUE_PREFIX.pro);
 
   return (
     <TableShell
@@ -99,12 +117,15 @@ function PicksTable({ scores }: { scores?: RakMadnessScores | null }) {
             <PlayerName player={player} />
             {player.college.map((result, index) => (
               <td
-                key={`${player.name}-${collegeLabels[index]}`}
+                key={pickChangeKey(player.name, collegeLabels[index])}
                 className={`table__pick --${result.status}`}
               >
                 <PickCell
                   result={result}
                   gameLabel={collegeLabels[index]}
+                  previousStatus={pickChanges.get(
+                    pickChangeKey(player.name, collegeLabels[index]),
+                  )}
                   onClick={showGameStatus}
                 />
               </td>
@@ -112,12 +133,15 @@ function PicksTable({ scores }: { scores?: RakMadnessScores | null }) {
             <td>{player.score.college}</td>
             {player.pro.map((result, index) => (
               <td
-                key={`${player.name}-${proLabels[index]}`}
+                key={pickChangeKey(player.name, proLabels[index])}
                 className={`table__pick --${result.status}`}
               >
                 <PickCell
                   result={result}
                   gameLabel={proLabels[index]}
+                  previousStatus={pickChanges.get(
+                    pickChangeKey(player.name, proLabels[index]),
+                  )}
                   onClick={showGameStatus}
                 />
               </td>

--- a/src/components/table/playerName/CLAUDE.md
+++ b/src/components/table/playerName/CLAUDE.md
@@ -9,3 +9,6 @@ color.
 `PlayerStatusIcon`: that icon on its own, sized from `--rak-player-icon-size`. The
 player analysis search renders it too, so the same player wears the same icon in
 both places.
+
+A player a refresh just knocked out renders a `.table__cell-wipe`, from
+`useScoreChanges()`, over the fill they held before that.

--- a/src/components/table/playerName/PlayerName.tsx
+++ b/src/components/table/playerName/PlayerName.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import { useScoreChanges } from "../../../context/AppDataContext";
 import { PlayerScore } from "../../../types/RakMadnessScores";
 import getClasses from "../../../utils/getClasses";
 import { useShowPlayerAnalysis } from "../../../context/PlayerAnalysisContext";
@@ -7,6 +8,8 @@ import "./PlayerName.scss";
 
 function PlayerName({ player }: { player: PlayerScore }) {
   const showPlayerAnalysis = useShowPlayerAnalysis();
+  const { players: playerChanges } = useScoreChanges();
+  const justKnockedOut = playerChanges.has(player.name);
 
   return (
     <td
@@ -26,6 +29,9 @@ function PlayerName({ player }: { player: PlayerScore }) {
         <span className="table__sr-only">
           {player.status.isKnockedOut ? "Knocked out" : "Still in contention"}
         </span>
+        {justKnockedOut && (
+          <span className="table__cell-wipe" aria-hidden="true" />
+        )}
       </button>
     </td>
   );

--- a/src/context/AppDataContext.tsx
+++ b/src/context/AppDataContext.tsx
@@ -13,9 +13,10 @@ import usePicksSeasons from "../hooks/usePicksSeasons";
 import usePlayerScores from "../hooks/usePlayerScores";
 import { WeekInfo } from "../types/League";
 import isWeekDecided from "../utils/scoring/isWeekDecided";
+import { NO_SCORE_CHANGES, ScoreChanges } from "../utils/scoring/scoreChanges";
 
 type AppData = ReturnType<typeof useLeagueWeeks> &
-  ReturnType<typeof usePlayerScores> &
+  Omit<ReturnType<typeof usePlayerScores>, "scoreChanges"> &
   ReturnType<typeof usePicksSeasons> & {
     /**
      * The `WeekInfo` for a week number, or undefined if the season has no such
@@ -50,6 +51,14 @@ const AppDataContext = createContext<AppData | undefined>(undefined);
  * own with scores handed straight to it.
  */
 const WeekDecidedContext = createContext(false);
+
+/**
+ * What the most recent scoring attempt changed, so a table can flash only the
+ * cells that moved. Its own context for the same reason `WeekDecidedContext` is:
+ * every pick and player cell reads it, and `AppData` re-renders on every loading
+ * flag it carries.
+ */
+const ScoreChangesContext = createContext<ScoreChanges>(NO_SCORE_CHANGES);
 
 /** The season and week a results URL names, from `/<year>/<week>/…`. Empty elsewhere. */
 function routeFromPath(pathname: string): { season?: number; week?: number } {
@@ -111,7 +120,7 @@ export function AppDataContextProvider({
     [weeks],
   );
 
-  const { scores } = playerScores;
+  const { scores, scoreChanges } = playerScores;
   const weekDecided = useMemo(
     () => scores != null && isWeekDecided(scores),
     [scores],
@@ -158,7 +167,9 @@ export function AppDataContextProvider({
   return (
     <AppDataContext.Provider value={value}>
       <WeekDecidedContext.Provider value={weekDecided}>
-        {children}
+        <ScoreChangesContext.Provider value={scoreChanges}>
+          {children}
+        </ScoreChangesContext.Provider>
       </WeekDecidedContext.Provider>
     </AppDataContext.Provider>
   );
@@ -174,4 +185,8 @@ export function useAppData(): AppData {
 
 export function useIsWeekDecided(): boolean {
   return useContext(WeekDecidedContext);
+}
+
+export function useScoreChanges(): ScoreChanges {
+  return useContext(ScoreChangesContext);
 }

--- a/src/context/CLAUDE.md
+++ b/src/context/CLAUDE.md
@@ -2,7 +2,8 @@
 
 - `AppDataContext`: the season list, week list, picks, and scores, held above the
   routes, with the season and week derived from the pathname. Publishes
-  `WeekDecidedContext` separately.
+  `WeekDecidedContext` and `ScoreChangesContext` separately, the latter what a
+  refresh just changed, for the tables to flash.
 - `ToastContext`: the toast list, split from its actions.
 - `PlayerAnalysisContext`: how a player's name in a table opens the player analysis
   on them. One callback, a no-op with no provider above.

--- a/src/hooks/usePlayerScores.test.tsx
+++ b/src/hooks/usePlayerScores.test.tsx
@@ -153,3 +153,57 @@ describe("usePlayerScores", () => {
     expect(result.current.scores?.tiebreaker).toBe(2);
   });
 });
+
+describe("usePlayerScores, refresh", () => {
+  it("does not re-fetch the picks spreadsheet", async () => {
+    getPlayerScoresMock.mockResolvedValue(scoresFor(5));
+    const { result } = renderHook(() => usePlayerScores(WEEK_5, SEASON), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.scores).toEqual(scoresFor(5)));
+    const fetchCallsBeforeRefresh = (
+      global.fetch as MockedFunction<typeof fetch>
+    ).mock.calls.length;
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(getPlayerScoresMock).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenCalledTimes(fetchCallsBeforeRefresh);
+  });
+
+  it("collapses two refreshes started together into one scoring pass", async () => {
+    getPlayerScoresMock.mockResolvedValue(scoresFor(5));
+    const { result } = renderHook(() => usePlayerScores(WEEK_5, SEASON), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.scores).toEqual(scoresFor(5)));
+    expect(getPlayerScoresMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      // Neither call is awaited before the next fires, the way two clicks in the
+      // same tick would land.
+      result.current.refresh();
+      result.current.refresh();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(getPlayerScoresMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the scores on screen when a refresh's scoring throws", async () => {
+    getPlayerScoresMock.mockResolvedValue(scoresFor(5));
+    const { result } = renderHook(() => usePlayerScores(WEEK_5, SEASON), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.scores).toEqual(scoresFor(5)));
+
+    getPlayerScoresMock.mockRejectedValueOnce(new Error("espn down"));
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.scores).toEqual(scoresFor(5));
+  });
+});

--- a/src/hooks/usePlayerScores.ts
+++ b/src/hooks/usePlayerScores.ts
@@ -7,6 +7,10 @@ import loadStoredPicks from "../utils/loadStoredPicks";
 import { writeCachedPicks } from "../utils/picksCache";
 import { readFileToBuffer } from "../utils/readFileToBuffer";
 import { getPlayerScores } from "../utils/scoring/getPlayerScores";
+import scoreChanges, {
+  NO_SCORE_CHANGES,
+  ScoreChanges,
+} from "../utils/scoring/scoreChanges";
 
 /** Long enough that holding the refresh button down sends one request. */
 const REFRESH_THROTTLE_MS = 500;
@@ -30,6 +34,13 @@ type ScoringRequest = {
   /** Shown when the picks arrived but scoring them threw. */
   onScoreFailure: Toast;
   onSuccess?: Toast;
+  /**
+   * Set on a refresh, where the scores already on screen came from the same
+   * workbook and are still the best answer there is. Unset elsewhere, where
+   * scoring has never succeeded for this week and there is nothing to fall back
+   * to.
+   */
+  keepScoresOnFailure?: boolean;
 };
 
 /**
@@ -55,6 +66,8 @@ export default function usePlayerScores(
 
   const [picksBuffer, setPicksBuffer] = useState<ArrayBuffer>();
   const [scores, setScores] = useState<RakMadnessScores>();
+  const [scoreChangesState, setScoreChangesState] =
+    useState<ScoreChanges>(NO_SCORE_CHANGES);
   const [attemptedFor, setAttemptedFor] = useState<LastAttempt>();
   const [isScoresLoading, setScoresLoading] = useState(true);
   const [isRefreshing, setRefreshing] = useState(false);
@@ -62,6 +75,15 @@ export default function usePlayerScores(
   // over the week that replaced it. Two can be in flight whenever the selected
   // week changes while the first is still loading.
   const latestAttempt = useRef(0);
+  // Set for the length of an attempt, so a second click cannot start another one
+  // before the state update announcing the first has even landed.
+  const isAttemptInFlight = useRef(false);
+  // The scores an attempt can be diffed against, and the week and season they are
+  // for. A week or season switch leaves this behind, so the new week's first
+  // score is never read as a change from the old week's last one.
+  const previousScores = useRef<
+    { key: string; scores: RakMadnessScores } | undefined
+  >(undefined);
 
   // Every path into the scores runs through here, so the loading flags and the
   // failure toasts cannot drift between them.
@@ -71,13 +93,16 @@ export default function usePlayerScores(
       onLoadFailure,
       onScoreFailure,
       onSuccess,
+      keepScoresOnFailure = false,
     }: ScoringRequest) => {
       if (!selectedWeek || season == null) return;
       const attempt = ++latestAttempt.current;
       const isLatest = () => latestAttempt.current === attempt;
+      isAttemptInFlight.current = true;
       setScoresLoading(true);
 
       const attempted = { season, week: selectedWeek.value };
+      const key = `${attempted.season}:${attempted.week}`;
 
       let buffer: ArrayBuffer;
       try {
@@ -91,8 +116,11 @@ export default function usePlayerScores(
           error,
         );
         setScores(undefined);
+        previousScores.current = undefined;
+        setScoreChangesState(NO_SCORE_CHANGES);
         setAttemptedFor(attempted);
         setScoresLoading(false);
+        isAttemptInFlight.current = false;
         showToast(onLoadFailure);
         return;
       }
@@ -100,6 +128,12 @@ export default function usePlayerScores(
       try {
         const weekScores = await getPlayerScores(selectedWeek, buffer, season);
         if (!isLatest()) return;
+        const before =
+          previousScores.current?.key === key
+            ? previousScores.current.scores
+            : undefined;
+        setScoreChangesState(scoreChanges(before, weekScores));
+        previousScores.current = { key, scores: weekScores };
         setScores(weekScores);
         if (onSuccess) {
           showToast(onSuccess);
@@ -107,12 +141,17 @@ export default function usePlayerScores(
       } catch (error) {
         if (!isLatest()) return;
         console.error("Failed to calculate scores", error);
-        setScores(undefined);
+        if (!keepScoresOnFailure) {
+          setScores(undefined);
+          previousScores.current = undefined;
+          setScoreChangesState(NO_SCORE_CHANGES);
+        }
         showToast(onScoreFailure);
       } finally {
         if (isLatest()) {
           setScoresLoading(false);
           setAttemptedFor(attempted);
+          isAttemptInFlight.current = false;
         }
       }
     },
@@ -174,40 +213,56 @@ export default function usePlayerScores(
   // function literal, so useCallback cannot see its dependencies.
   const refreshThrottled = useMemo(
     () =>
-      throttle(async () => {
-        if (picksBuffer == null || selectedWeek == null) return;
-        setRefreshing(true);
-        clearToasts();
-        // Refreshing rescores the workbook already in memory, so there is no
-        // separate way for loading it to fail.
-        const failure = scoringFailed(selectedWeek.value);
-        try {
-          await attemptScoring({
-            loadPicks: async () => picksBuffer,
-            onLoadFailure: failure,
-            onScoreFailure: failure,
-            onSuccess: new Toast(
-              "success",
-              "Success",
-              "Results successfully updated",
-            ),
-          });
-        } finally {
-          setRefreshing(false);
-        }
-      }, REFRESH_THROTTLE_MS),
+      throttle(
+        async () => {
+          if (picksBuffer == null || selectedWeek == null) return;
+          setRefreshing(true);
+          clearToasts();
+          // Refreshing rescores the workbook already in memory, so there is no
+          // separate way for loading it to fail.
+          const failure = scoringFailed(selectedWeek.value);
+          try {
+            await attemptScoring({
+              loadPicks: async () => picksBuffer,
+              onLoadFailure: failure,
+              onScoreFailure: failure,
+              onSuccess: new Toast(
+                "success",
+                "Success",
+                "Results successfully updated",
+              ),
+              keepScoresOnFailure: true,
+            });
+          } finally {
+            setRefreshing(false);
+          }
+          // No trailing edge: a second click inside the window is dropped rather
+          // than queued, so it cannot fire a request of its own once the window
+          // ends. `attemptInFlight` below is what actually blocks it meanwhile.
+        },
+        REFRESH_THROTTLE_MS,
+        { trailing: false },
+      ),
     [picksBuffer, selectedWeek, attemptScoring, clearToasts],
   );
 
+  // Cancels a trailing call this throttle would otherwise still owe once the
+  // component holding it is gone.
+  useEffect(() => () => refreshThrottled.cancel(), [refreshThrottled]);
+
   const refresh = useCallback(async () => {
-    if (isScoresLoading) return;
+    // A ref rather than the `isScoresLoading` state, which two clicks in the same
+    // tick would both still read as false: the state update announcing the first
+    // click's attempt has not landed yet.
+    if (isAttemptInFlight.current) return;
     await refreshThrottled();
-  }, [isScoresLoading, refreshThrottled]);
+  }, [refreshThrottled]);
 
   // Memoized so `AppDataContext` can memoize the value it publishes.
   return useMemo(
     () => ({
       scores,
+      scoreChanges: scoreChangesState,
       attemptedFor,
       isScoresLoading,
       isRefreshing,
@@ -216,6 +271,7 @@ export default function usePlayerScores(
     }),
     [
       scores,
+      scoreChangesState,
       attemptedFor,
       isScoresLoading,
       isRefreshing,

--- a/src/styles/_skeleton.scss
+++ b/src/styles/_skeleton.scss
@@ -2,9 +2,9 @@
 @use "breakpoints" as *;
 
 // The one way the app says it is still working. A wireframe stands in for content
-// that is not there yet; a sheen crosses content that is there but stale. Nothing
-// spins, and no button shimmers, so a wait always looks like a wait wherever it
-// happens.
+// that is not there yet; a sheen crosses content that is there but stale,
+// including a button's own face while it works. Nothing spins, so a wait always
+// looks like a wait wherever it happens.
 //
 // Unlike the other partials here this one emits CSS, the keyframes below. A Sass
 // module is evaluated once however many files `@use` it, so they are written out

--- a/src/utils/getLeagueResults.test.ts
+++ b/src/utils/getLeagueResults.test.ts
@@ -536,3 +536,36 @@ describe("getLeagueResults, what it does not ask twice", () => {
     ]);
   });
 });
+
+describe("getLeagueResults, a scoreboard request ESPN could not answer", () => {
+  it("throws rather than reads events off an error response", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 503 }) as unknown as typeof fetch;
+
+    await expect(getLeagueResults(League.PRO, WEEK, [BUF_KC])).rejects.toThrow(
+      "503",
+    );
+  });
+
+  it("throws rather than treat a body with no events array as an empty week", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    }) as unknown as typeof fetch;
+
+    await expect(getLeagueResults(League.PRO, WEEK, [BUF_KC])).rejects.toThrow(
+      /events/,
+    );
+  });
+
+  it("throws for a college group the same way", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 500 }) as unknown as typeof fetch;
+
+    await expect(
+      getLeagueResults(League.COLLEGE, WEEK, [new Set(["OSU", "MICH"])]),
+    ).rejects.toThrow("500");
+  });
+});

--- a/src/utils/getLeagueResults.ts
+++ b/src/utils/getLeagueResults.ts
@@ -85,9 +85,20 @@ async function getLeagueEvents(
     const collegePromises = COLLEGE_GROUPS.map((groupId: number) => {
       const requestUrl = `${baseRequestUrl}&limit=400&groups=${groupId}`;
       return fetch(requestUrl)
-        .then((response) =>
-          response.json().then((json) => json.events as Array<EspnEvent>),
-        )
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(
+              `ESPN scoreboard request failed: ${response.status}`,
+            );
+          }
+          return response.json();
+        })
+        .then((json) => {
+          if (!Array.isArray(json.events)) {
+            throw new Error("ESPN scoreboard response had no events array");
+          }
+          return json.events as Array<EspnEvent>;
+        })
         .then((events) => {
           // ESPN jams the entire college postseason into one week.
           // So, we need to remove events that happen before the given NFL week.
@@ -113,7 +124,13 @@ async function getLeagueEvents(
 
   // For pro, we can just return the raw events list fetched from the API.
   const response = await fetch(baseRequestUrl);
+  if (!response.ok) {
+    throw new Error(`ESPN scoreboard request failed: ${response.status}`);
+  }
   const json = await response.json();
+  if (!Array.isArray(json.events)) {
+    throw new Error("ESPN scoreboard response had no events array");
+  }
   return json.events as Array<EspnEvent>;
 }
 

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -3,19 +3,20 @@
 The picks-to-scoreboard pipeline, sequenced by `getPlayerScores`.
 
 - `parsePicksWorkbook`: xlsx buffer to rows, keys, matchups
-- `parsePick`: one cell to a team and a spread
-- `validateSpreads`: rows disagreeing on a spread
-- `marginAgainstSpread`: a side's margin, line applied
+- `parsePick`: a cell to team and spread
+- `validateSpreads`: rows disagreeing on spread
+- `marginAgainstSpread`: a side's margin, spread applied
 - `getPickResults`: picks scored, plus `getStatus`
 - `gameColumns`: `LEAGUES`, `LEAGUE_PREFIX`, `gameLabels`
-- `weekGames`: each column, its game, its line
+- `weekGames`: each column, its game and line
 - `getTiebreakerScore`: the Monday night total
-- `scorePlayers`: per-player totals, sorted
+- `scorePlayers`: per-player totals
 - `comparePlayerScores`: rank order, on merit
 - `isWeekDecided`: whether knockouts settled it
 - `remainingGames`: the open games
-- `unscoreableGames`: games nobody scores on
-- `isWeekOver`: whether the week has finished
+- `unscoreableGames`: games nobody scores
+- `isWeekOver`: whether the week finished
 - `applyKnockouts`: who can still win, why not
+- `scoreChanges`: what a refresh changed
 - `getPlayerAnalysis`: what a player must do
 - `leagueResultFixtures`: test game builders

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -8,9 +8,9 @@ The picks-to-scoreboard pipeline, sequenced by `getPlayerScores`.
 - `marginAgainstSpread`: a side's margin, spread applied
 - `getPickResults`: picks scored, plus `getStatus`
 - `gameColumns`: `LEAGUES`, `LEAGUE_PREFIX`, `gameLabels`
-- `weekGames`: each column, its game and line
+- `weekGames`: each column, game and line
 - `getTiebreakerScore`: the Monday night total
-- `scorePlayers`: per-player totals
+- `scorePlayers`: per-player totals, sorted
 - `comparePlayerScores`: rank order, on merit
 - `isWeekDecided`: whether knockouts settled it
 - `remainingGames`: the open games

--- a/src/utils/scoring/applyKnockouts.test.ts
+++ b/src/utils/scoring/applyKnockouts.test.ts
@@ -125,6 +125,17 @@ describe("applyKnockouts", () => {
     );
   });
 
+  it("omits the remaining-picks clause once the week is fully resolved", () => {
+    const result = applyKnockouts([
+      player({ name: "Alice", total: 3, pro: [pickResult("BUF", "yes")] }),
+      player({ name: "Bob", total: 1, pro: [pickResult("BUF", "yes")] }),
+    ]);
+
+    expect(result[1].status.explanation).toBe(
+      "Knocked out on Total Score by Alice. Behind by 2.",
+    );
+  });
+
   it("leaves a trailing player standing while different picks can close the gap", () => {
     const result = applyKnockouts([
       player({
@@ -162,6 +173,31 @@ describe("applyKnockouts", () => {
     expect(result[1].status.explanation).toBe(
       "Knocked out on College Score tiebreaker by Alice. " +
         "Behind by 1 with 0 different college picks remaining.",
+    );
+  });
+
+  it("omits the remaining-picks clause on the college tiebreaker once resolved", () => {
+    const result = applyKnockouts([
+      player({
+        name: "Alice",
+        total: 5,
+        collegeScore: 3,
+        proScore: 2,
+        college: [pickResult("OSU", "yes")],
+        tiebreakerPick: 40,
+      }),
+      player({
+        name: "Bob",
+        total: 5,
+        collegeScore: 2,
+        proScore: 3,
+        college: [pickResult("OSU", "yes")],
+        tiebreakerPick: 40,
+      }),
+    ]);
+
+    expect(result[1].status.explanation).toBe(
+      "Knocked out on College Score tiebreaker by Alice. Behind by 1.",
     );
   });
 
@@ -216,6 +252,36 @@ describe("applyKnockouts", () => {
     expect(result[1].status.explanation).toBe(
       "Knocked out on Pro Score Against the Spread tiebreaker by Alice. " +
         "Behind by 1 with 0 different picks remaining for pro games with spreads.",
+    );
+  });
+
+  it("omits the remaining-picks clause on the spread tiebreaker once resolved", () => {
+    const result = applyKnockouts([
+      player({
+        name: "Alice",
+        total: 4,
+        collegeScore: 2,
+        proScore: 2,
+        proAgainstTheSpread: 2,
+        college: [pickResult("OSU", "yes")],
+        pro: [pickResult("BUF -3", "yes")],
+        tiebreakerPick: 40,
+      }),
+      player({
+        name: "Bob",
+        total: 4,
+        collegeScore: 2,
+        proScore: 2,
+        proAgainstTheSpread: 1,
+        college: [pickResult("OSU", "yes")],
+        pro: [pickResult("BUF -3", "yes")],
+        tiebreakerPick: 40,
+      }),
+    ]);
+
+    expect(result[1].status.explanation).toBe(
+      "Knocked out on Pro Score Against the Spread tiebreaker by Alice. " +
+        "Behind by 1.",
     );
   });
 

--- a/src/utils/scoring/applyKnockouts.ts
+++ b/src/utils/scoring/applyKnockouts.ts
@@ -1,4 +1,5 @@
 import { PlayerScore } from "../../types/RakMadnessScores";
+import isWeekOver from "./isWeekOver";
 import plural from "../plural";
 import remainingGames, {
   pickDifference,
@@ -62,6 +63,9 @@ export default function applyKnockouts(
 ): Array<PlayerScore> {
   const games = remainingGames(sortedScores);
   const isCollegeDone = games.every((game) => game.league !== "college");
+  // Once the week is over there are no remaining games to differ on, so the
+  // count is always zero and saying so is redundant.
+  const weekOver = isWeekOver(sortedScores);
 
   return sortedScores.map((activeScore, activeIndex) => {
     // If a player has no picks, they're knocked out.
@@ -99,7 +103,10 @@ export default function applyKnockouts(
           return knockedOut(
             activeScore,
             `Knocked out on Total Score by ${rivalScore.name}. ` +
-              `Behind by ${totalScoreDiff} with ${plural(totalDifferentPicks, "different pick")} remaining.`,
+              `Behind by ${totalScoreDiff}` +
+              (weekOver
+                ? "."
+                : ` with ${plural(totalDifferentPicks, "different pick")} remaining.`),
           );
         } else if (totalDifferentPicks === totalScoreDiff) {
           // Either distance is absent when that player left the Monday night
@@ -122,7 +129,10 @@ export default function applyKnockouts(
               return knockedOut(
                 activeScore,
                 `Knocked out on College Score tiebreaker by ${rivalScore.name}. ` +
-                  `Behind by ${collegeScoreDiff} with ${plural(differentCollegePicks, "different college pick")} remaining.`,
+                  `Behind by ${collegeScoreDiff}` +
+                  (weekOver
+                    ? "."
+                    : ` with ${plural(differentCollegePicks, "different college pick")} remaining.`),
               );
             }
             // If college games are done and players are tied, check pro against the spread tiebreaker.
@@ -137,8 +147,11 @@ export default function applyKnockouts(
                 return knockedOut(
                   activeScore,
                   `Knocked out on Pro Score Against the Spread tiebreaker by ${rivalScore.name}. ` +
-                    `Behind by ${proAgainstTheSpreadScoreDiff} with ${plural(differentProPicksWithSpreads, "different pick")} remaining ` +
-                    `for pro games with spreads.`,
+                    `Behind by ${proAgainstTheSpreadScoreDiff}` +
+                    (weekOver
+                      ? "."
+                      : ` with ${plural(differentProPicksWithSpreads, "different pick")} remaining ` +
+                        `for pro games with spreads.`),
                 );
               }
             }

--- a/src/utils/scoring/gameColumns.ts
+++ b/src/utils/scoring/gameColumns.ts
@@ -3,6 +3,11 @@ import rangeWithPrefix from "../rangeWithPrefix";
 
 export type LeagueKey = "college" | "pro";
 
+/** `player.name`, then `C1`/`P1` etc, the key a score change is tracked under. */
+export function pickChangeKey(playerName: string, gameLabel: string): string {
+  return `${playerName}-${gameLabel}`;
+}
+
 /** Read in this order wherever a week's games are walked league by league. */
 export const LEAGUES: Array<LeagueKey> = ["college", "pro"];
 

--- a/src/utils/scoring/getPlayerScores.ts
+++ b/src/utils/scoring/getPlayerScores.ts
@@ -19,18 +19,10 @@ export async function getPlayerScores(
 ): Promise<RakMadnessScores> {
   const parsed = await parsePicksWorkbook(picksBuffer);
 
-  const collegeResults = await getLeagueResults(
-    League.COLLEGE,
-    week,
-    parsed.collegeMatchups,
-    season,
-  );
-  const proResults = await getLeagueResults(
-    League.PRO,
-    week,
-    parsed.proMatchups,
-    season,
-  );
+  const [collegeResults, proResults] = await Promise.all([
+    getLeagueResults(League.COLLEGE, week, parsed.collegeMatchups, season),
+    getLeagueResults(League.PRO, week, parsed.proMatchups, season),
+  ]);
   debugLog("league results", { collegeResults, proResults });
 
   const tiebreakerScore = getTiebreakerScore(

--- a/src/utils/scoring/parsePicksWorkbook.test.ts
+++ b/src/utils/scoring/parsePicksWorkbook.test.ts
@@ -1,0 +1,40 @@
+import * as XLSX from "xlsx-js-style";
+import parsePicksWorkbook from "./parsePicksWorkbook";
+
+function picksBuffer(): ArrayBuffer {
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(
+    workbook,
+    XLSX.utils.json_to_sheet([{ Name: "Alice", C1: "OSU -3" }]),
+    "Picks",
+  );
+  return XLSX.write(workbook, { bookType: "xlsx", type: "array" });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parsePicksWorkbook, memoized by buffer identity", () => {
+  it("parses the same buffer once, answering a second call from the first parse", async () => {
+    const buffer = picksBuffer();
+    // Two reads per parse: the row objects, then the header row by index.
+    const sheetToJson = vi.spyOn(XLSX.utils, "sheet_to_json");
+
+    const first = await parsePicksWorkbook(buffer);
+    const second = await parsePicksWorkbook(buffer);
+
+    expect(second).toBe(first);
+    expect(sheetToJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("parses two different buffers on their own", async () => {
+    const sheetToJson = vi.spyOn(XLSX.utils, "sheet_to_json");
+
+    const first = await parsePicksWorkbook(picksBuffer());
+    const second = await parsePicksWorkbook(picksBuffer());
+
+    expect(second).not.toBe(first);
+    expect(sheetToJson).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/utils/scoring/parsePicksWorkbook.ts
+++ b/src/utils/scoring/parsePicksWorkbook.ts
@@ -23,12 +23,29 @@ export type ParsedPicks = {
 };
 
 /**
+ * One buffer to the parse already run on it, so a refresh rescoring the same
+ * workbook does not pay for the xlsx parse again. Keyed by the buffer's own
+ * identity rather than its bytes: the picks a `RakMadnessScores` was built from
+ * never change without a new buffer replacing it. A `WeakMap` rather than a
+ * plain one, so a buffer this hook has moved on from can still be collected.
+ */
+const parsed = new WeakMap<ArrayBuffer, Promise<ParsedPicks>>();
+
+/**
  * `xlsx-js-style` is over half the bundle, and nothing on the first paint needs
  * it, so it is fetched when a workbook actually turns up.
  */
-export default async function parsePicksWorkbook(
+export default function parsePicksWorkbook(
   picksBuffer: ArrayBuffer,
 ): Promise<ParsedPicks> {
+  const cached = parsed.get(picksBuffer);
+  if (cached != null) return cached;
+  const parsing = parseWorkbook(picksBuffer);
+  parsed.set(picksBuffer, parsing);
+  return parsing;
+}
+
+async function parseWorkbook(picksBuffer: ArrayBuffer): Promise<ParsedPicks> {
   const XLSX = await import("xlsx-js-style");
   const workbook = XLSX.read(picksBuffer, { type: "array" });
   const picksSheet = workbook.Sheets[Object.keys(workbook.Sheets)[0]];

--- a/src/utils/scoring/scoreChanges.test.ts
+++ b/src/utils/scoring/scoreChanges.test.ts
@@ -1,0 +1,97 @@
+import {
+  PickResult,
+  PlayerScore,
+  RakMadnessScores,
+  Status,
+} from "../../types/RakMadnessScores";
+import { pickChangeKey } from "./gameColumns";
+import scoreChanges from "./scoreChanges";
+
+function pick(status: Status = "incomplete"): PickResult {
+  return { pick: "BUF -7", status, explanation: { header: "P1", message: "" } };
+}
+
+function player({
+  name,
+  pro = [pick()],
+  isKnockedOut = false,
+}: {
+  name: string;
+  pro?: Array<PickResult>;
+  isKnockedOut?: boolean;
+}): PlayerScore {
+  return {
+    name,
+    score: { total: 0, college: 0, pro: 0, proAgainstTheSpread: 0 },
+    tiebreaker: {},
+    college: [],
+    pro,
+    status: { hasNoPicks: false, isKnockedOut },
+  };
+}
+
+function scoresFor(players: Array<PlayerScore>): RakMadnessScores {
+  return { scores: players };
+}
+
+describe("scoreChanges", () => {
+  it("has nothing to compare a first load against", () => {
+    const changes = scoreChanges(
+      undefined,
+      scoresFor([player({ name: "Alice" })]),
+    );
+    expect(changes.players.size).toBe(0);
+    expect(changes.picks.size).toBe(0);
+  });
+
+  it("carries nothing forward when nothing changed", () => {
+    const before = scoresFor([player({ name: "Alice" })]);
+    const after = scoresFor([player({ name: "Alice" })]);
+
+    const changes = scoreChanges(before, after);
+
+    expect(changes.players.size).toBe(0);
+    expect(changes.picks.size).toBe(0);
+  });
+
+  it("names the status a resolved pick left, keyed to the player and the game", () => {
+    const before = scoresFor([player({ name: "Alice", pro: [pick()] })]);
+    const after = scoresFor([player({ name: "Alice", pro: [pick("yes")] })]);
+
+    const changes = scoreChanges(before, after);
+
+    expect(changes.picks.get(pickChangeKey("Alice", "P1"))).toBe("incomplete");
+    expect(changes.players.size).toBe(0);
+  });
+
+  it("names a player just knocked out, but not one already out or still in", () => {
+    const before = scoresFor([
+      player({ name: "Alice", isKnockedOut: false }),
+      player({ name: "Bob", isKnockedOut: true }),
+      player({ name: "Cara", isKnockedOut: false }),
+    ]);
+    const after = scoresFor([
+      player({ name: "Alice", isKnockedOut: true }),
+      player({ name: "Bob", isKnockedOut: true }),
+      player({ name: "Cara", isKnockedOut: false }),
+    ]);
+
+    const changes = scoreChanges(before, after);
+
+    expect(changes.players.get("Alice")).toBe(false);
+    expect(changes.players.has("Bob")).toBe(false);
+    expect(changes.players.has("Cara")).toBe(false);
+  });
+
+  it("ignores a player the previous score never had", () => {
+    const before = scoresFor([player({ name: "Alice" })]);
+    const after = scoresFor([
+      player({ name: "Alice" }),
+      player({ name: "Bob", isKnockedOut: true }),
+    ]);
+
+    const changes = scoreChanges(before, after);
+
+    expect(changes.players.size).toBe(0);
+  });
+});

--- a/src/utils/scoring/scoreChanges.ts
+++ b/src/utils/scoring/scoreChanges.ts
@@ -1,0 +1,60 @@
+import {
+  PlayerScore,
+  RakMadnessScores,
+  Status,
+} from "../../types/RakMadnessScores";
+import gameLabels, { LEAGUES, pickChangeKey } from "./gameColumns";
+
+/**
+ * What a refresh changed, so a table can flash only the cells that moved rather
+ * than every cell a new `RakMadnessScores` touches.
+ */
+export type ScoreChanges = {
+  /** `player.name` to whether they were still in contention before. */
+  players: Map<string, boolean>;
+  /** `pickChangeKey(player.name, gameLabel)` to the status the cell held before. */
+  picks: Map<string, Status>;
+};
+
+export const NO_SCORE_CHANGES: ScoreChanges = {
+  players: new Map(),
+  picks: new Map(),
+};
+
+/**
+ * `previous` and `current` for the same week, or `undefined` where there is
+ * nothing to compare against, which is every week's first score.
+ */
+export default function scoreChanges(
+  previous: RakMadnessScores | undefined,
+  current: RakMadnessScores,
+): ScoreChanges {
+  if (previous == null) return NO_SCORE_CHANGES;
+
+  const players = new Map<string, boolean>();
+  const picks = new Map<string, Status>();
+  const before = new Map<string, PlayerScore>(
+    previous.scores.map((player) => [player.name, player]),
+  );
+
+  current.scores.forEach((player) => {
+    const was = before.get(player.name);
+    if (was == null) return;
+
+    if (!was.status.isKnockedOut && player.status.isKnockedOut) {
+      players.set(player.name, was.status.isKnockedOut);
+    }
+
+    LEAGUES.forEach((league) => {
+      const labels = gameLabels(was, league);
+      was[league].forEach((result, index) => {
+        const after = player[league][index];
+        if (after != null && after.status !== result.status) {
+          picks.set(pickChangeKey(player.name, labels[index]), result.status);
+        }
+      });
+    });
+  });
+
+  return { players, picks };
+}


### PR DESCRIPTION
## What

Hardens and speeds up the navbar refresh key for a live week, and flashes a cell a refresh changed.

## Why

A failed refresh blanked the table with no way back, and a fast double click could send two scoring passes.

## Changes

- Refresh keeps the previous scores on a failed pass instead of blanking the table. The failure toast still fires.
- Refresh guards on a ref, not state, and drops trailing clicks, so a double click sends one request.
- Both leagues fetch in parallel, and a workbook is memoized per upload so a repeat refresh skips re-parsing it.
- Filled `update` glyph replaces the outline `refresh` one, matching the other navbar keys.
- A resolved pick or knocked-out player wipes in its new fill left to right, from a diff against the previous scores.
- A knockout explanation drops its "with 0 different picks remaining" clause once the week is fully resolved, since the count is always zero by then.

## Verification

Manually drove a live week through Playwright, with a synthetic ESPN response standing in for a real one.

Normal state, the busy shimmer, and the resolved wipe:
![Refresh key demo](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/refresh-key/demo.gif)

🕵️ Sanitized by [Agent Cody Banks](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
