### PR TITLE
chore(claude): refresh the vendored agentify copies

### DIFF
--- a/.claude/hooks/check_conventions.py
+++ b/.claude/hooks/check_conventions.py
@@ -61,6 +61,12 @@ MEDIA = re.compile(
     r"|<\s*/?\s*(?:img|video|source|picture|figure|figcaption)\b[^>]*>",
     re.IGNORECASE)
 MEDIA_TOKEN = re.compile(r"^<?\S*%s\S*>?$" % MEDIA_TARGET, re.IGNORECASE)
+LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
+# A heading is the template's word, not the writer's, and an attribution footer is
+# appended after the body is drafted. Charging the budget for either spends it on
+# text nobody chose.
+HEADING_LINE = re.compile(r"^#{1,6}\s+")
+SIGNATURE = re.compile(r"^\s*\U0001f575️?\s.+\sby\s\[[^\]]+\]\(https?://[^)]+\)\s*$")
 
 SEPARATORS = ("&&", "||", ";", "|", "&", "\n")
 WRAPPERS = ("timeout", "time", "nice", "nohup", "stdbuf", "command", "builtin",
@@ -167,12 +173,15 @@ def headings(text):
 
 
 def prose_words(body):
-    """Words a reviewer reads. A fenced block, a table, a checklist and an embedded
-    image or video are not prose, so none of them counts against the budget."""
+    """Words a reviewer reads. A fenced block, a table, a checklist, a heading, an
+    attribution footer and an embedded image or video are not prose the writer chose,
+    so none of them counts against the budget."""
     text = MEDIA.sub("", COMMENTS.sub("", FENCE.sub("", body)))
     kept, skipping_item = [], False
     for line in text.splitlines():
-        if TABLE_ROW.match(line):
+        if TABLE_ROW.match(line) or HEADING_LINE.match(line.strip()):
+            continue
+        if SIGNATURE.match(line):
             continue
         if CHECKLIST_ITEM.match(line):
             skipping_item = True
@@ -185,10 +194,6 @@ def prose_words(body):
         kept.append(line)
     return len([word for word in " ".join(kept).split()
                 if not MEDIA_TOKEN.match(word)])
-
-
-LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
-HEADING_LINE = re.compile(r"^#{1,6}\s+")
 
 
 def heaviest_blocks(body, show=3):

--- a/.claude/scripts/lint_claude_md.py
+++ b/.claude/scripts/lint_claude_md.py
@@ -382,11 +382,35 @@ def report_dupes(root):
 
 # --- length ----------------------------------------------------------------
 
-# Hard ceiling on a CLAUDE.md's own prose, in words. Exempt: the Subdirectories
-# list and the root's maintenance note, which grow with the repo rather than with
-# what the file chose to say. A ceiling, not a target. Most files stay far under
-# it: a one-line summary plus links is the format.
+# Floor on a CLAUDE.md's own prose, in words, and the whole budget for a file that
+# describes nothing item by item. Exempt: the Subdirectories list and the root's
+# maintenance note, which grow with the repo rather than with what the file chose to
+# say. A ceiling, not a target. Most files stay far under it: a one-line summary plus
+# links is the format.
 BODY_WORD_LIMIT = 120
+
+# A leaf index earns room per file it describes, since its length is set by how many
+# files sit beside it rather than by how much it chose to say. A flat ceiling taxed
+# exactly the files doing their job: on this repo the six index files sat at 118 to
+# 120 and every edit to one had to buy its words back out of another entry.
+#
+# Eight is one line: a name, then a clause saying what it is for. The base covers the
+# heading and any sentence before the list. A file that lists nothing gets the floor
+# and nothing more, so prose cannot buy room by adding bullets.
+ENTRY_BASE = 40
+ENTRY_WORDS = 8
+
+# An item that describes a file, which is a bullet opening with a code span. Prose
+# bullets do not earn room, since they are what the floor is already for.
+DESCRIBED = re.compile(r"^\s*[-*+]\s+`")
+
+# The names at the head of such a bullet, before the dash that starts its description.
+# One line often covers a family, and charging it for one file while it describes four
+# is the flat ceiling again in miniature. Stopping at the dash is what keeps a code
+# span inside the description from earning room: `--out DIR` in a clause is the file
+# explaining itself, not another file.
+NAMED = re.compile(r"`([^`\n]+)`")
+HEAD = re.compile(r"\s+[\u2014-]\s")
 
 EXEMPT_HEADINGS = {"subdirectories", "maintaining this tree"}
 
@@ -400,14 +424,19 @@ def counted_lines(text):
 
     A heading at level 1 or 2 opens or closes an exemption; deeper headings stay
     inside whatever section they belong to.
+
+    No heading counts, at any level. A section title is navigation rather than
+    something the file chose to say, and charging for it taxes the split that makes
+    a file readable: three short sections cost more than one long one saying the
+    same. `lint_readme.py` has always dropped them, and this is the same rule.
     """
     kept = []
     exempt = False
     for line in text.splitlines():
-        m = HEADING_RE.match(line.strip())
-        if m and len(m.group(1)) <= 2:
-            exempt = m.group(2).lower() in EXEMPT_HEADINGS
-        if not exempt:
+        heading = HEADING_RE.match(line.strip())
+        if heading and len(heading.group(1)) <= 2:
+            exempt = heading.group(2).lower() in EXEMPT_HEADINGS
+        if not exempt and not heading:
             kept.append(line)
     return kept
 
@@ -417,10 +446,27 @@ def text_words(text):
     return sum(len(line.split()) for line in counted_lines(text))
 
 
+def described(text):
+    """How many files this CLAUDE.md describes, counting names rather than bullets."""
+    return sum(len(NAMED.findall(HEAD.split(line, 1)[0]))
+               for line in counted_lines(text) if DESCRIBED.match(line))
+
+
+def budget(text):
+    """This file's word budget: the floor, or an allowance per file it describes."""
+    return max(BODY_WORD_LIMIT, ENTRY_BASE + ENTRY_WORDS * described(text))
+
+
 def body_words(path):
     """Word count of the CLAUDE.md at `path`, outside the exempt sections."""
     with open(path, encoding="utf-8") as fh:
         return text_words(fh.read())
+
+
+def body_budget(path):
+    """The word budget of the CLAUDE.md at `path`."""
+    with open(path, encoding="utf-8") as fh:
+        return budget(fh.read())
 
 
 def blocks(text):
@@ -462,27 +508,26 @@ def report_blocks(text, indent="    ", show=3):
 
 
 def length_findings(root):
-    """(path, word count) per CLAUDE.md over the ceiling."""
+    """(path, word count, budget) per CLAUDE.md over its own budget."""
     findings = []
     for rel in sorted(claude_md_dirs(root)):
         path = os.path.join(root, rel, CLAUDE_MD)
-        count = body_words(path)
-        if count > BODY_WORD_LIMIT:
-            findings.append((path, count))
+        count, allowed = body_words(path), body_budget(path)
+        if count > allowed:
+            findings.append((path, count, allowed))
     return findings
 
 
 def report_length(root):
     findings = length_findings(root)
     if not findings:
-        print("OK: every CLAUDE.md is within %d words" % BODY_WORD_LIMIT)
+        print("OK: every CLAUDE.md is within its word budget")
         return 0
-    print("%d CLAUDE.md file(s) over the %d-word ceiling:\n"
-          % (len(findings), BODY_WORD_LIMIT))
-    for path, count in findings:
+    print("%d CLAUDE.md file(s) over budget:\n" % len(findings))
+    for path, count, allowed in findings:
         print("  %s" % path)
-        print("    %d words, %d over (Subdirectories and the root's maintenance "
-              "note excluded)" % (count, count - BODY_WORD_LIMIT))
+        print("    %d words against %d, %d over (Subdirectories and the root's "
+              "maintenance note excluded)" % (count, allowed, count - allowed))
         with open(path, encoding="utf-8") as fh:
             report_blocks(fh.read())
         print("    fix: cut prose, or move what is read only during one kind of "
@@ -535,17 +580,17 @@ def report_count(targets):
             return 2
 
     over = 0
-    print("%6s %6s  %s" % ("words", "left", "file"))
+    print("%6s %7s %6s  %s" % ("words", "budget", "left", "file"))
     for path, text in items:
-        count = text_words(text)
-        left = BODY_WORD_LIMIT - count
-        print("%6d %6d  %s" % (count, left, path))
+        count, allowed = text_words(text), budget(text)
+        left = allowed - count
+        print("%6d %7d %6d  %s" % (count, allowed, left, path))
         if left < 0:
             over += 1
         if left <= TIGHT:
             report_blocks(text, indent="        ")
     if over:
-        print("\n%d file(s) over the %d-word ceiling." % (over, BODY_WORD_LIMIT))
+        print("\n%d file(s) over budget." % over)
     return 1 if over else 0
 
 

--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -9,7 +9,7 @@ description: This repo's commit and PR conventions. Read before writing any git 
 - Scope = module. `[<issue>]` = main ticket ID: `feat(auth): [YCOM-21] add device-code login`.
 - PR body: build from `.github/pull_request_template.md`, write over its comments. `--body`/`--body-file` skip prefill.
 - PR body links every ticket work belongs to, title's key first. Hook only sees branch's key, rest is on you. No ticket: link nothing, never invent key.
-- PR body length: under 200 words, bullets one line each. Only what a reviewer needs to review the diff. No ticket retelling, no history, no counts or benchmark numbers, no per-file walkthrough, no self-assessment. Embedded screenshots and recordings don't count against the budget.
+- PR body length: under 256 words, bullets one line each. Only what a reviewer needs to review the diff. No ticket retelling, no history, no counts or benchmark numbers, no per-file walkthrough, no self-assessment. Headings, an attribution footer, embedded screenshots and recordings don't count against the budget.
 - Commit body: only a why subject can't carry.
 - Enforced by `.claude/hooks/check_conventions.py`, `.github/workflows/pr-title.yml`.
 - No bypass. Rewrite text, don't work around hook.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,11 +13,12 @@ https://www.conventionalcommits.org/en/v1.0.0/
   feat(auth): [YCOM-21] add device-code login
   refactor(api)!: drop v1 response envelope
 
-Shortest body a reviewer can review from, under 200 words. Bullets, one line each,
+Shortest body a reviewer can review from, under 256 words. Bullets, one line each,
 not paragraphs. Every line must change how they read the diff. Cut every line that
-does not, and delete every section left with nothing to say. An embedded screenshot
-or recording does not count against the budget. Add one where seeing the change
-beats reading about it, usually a UX change, not as a matter of course.
+does not, and delete every section left with nothing to say. A heading, an
+attribution footer and an embedded screenshot or recording do not count against
+the budget. Add one where seeing the change beats reading about it,
+usually a UX change, not as a matter of course.
 
 Never in the body: a retelling of the ticket, the path taken to the change,
 alternatives rejected, counts of files or lines or tests, timings, coverage or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ absolute path: `manifest.json`, the `favicon.ico` and `logo*.png` icons, and
 
 Navigation index. Changed a dir: update its CLAUDE.md summary and the parent's
 link. New meaningful dir: add a CLAUDE.md, link it. Pointer <= 70 chars. Every
-CLAUDE.md: 120 words max outside its Subdirectories list and this block. Ceiling,
+CLAUDE.md, outside its Subdirectories list and this block: 120 words, or 40 plus
+8 for each file a bullet names, whichever is larger. Ceiling,
 not target: land under it, or the next edit pays to shave. `make lint-docs`
 enforces it. Over it, the detail belongs at the point of definition, in a comment
 or docblock beside the code. A skill under `.claude/skills/` is for what no one


### PR DESCRIPTION
## What

Refreshes the vendored agentify copies under `.claude/` and `.github/`: the PR body budget, what the conventions hook charges for, and how `lint_claude_md.py` sizes a `CLAUDE.md`.

## Why

A flat 120-word ceiling taxed the files doing their job. Every index file here sits within a couple of words of the ceiling, so each edit to one has to buy its words back out of another entry.

## Changes

- A `CLAUDE.md` budget is now `max(120, 40 + 8 * files named)`, so an index earns room per file it describes.
- Only a bullet opening with a code span earns room. Prose cannot buy budget by adding bullets.
- Names count up to the dash that starts the description. One bullet naming four files earns four allowances, and a code span inside the description earns nothing.
- Headings stop counting, in the `CLAUDE.md` budget and in the hook's PR body budget both. `lint_readme.py` already dropped them.
- PR body budget goes to 256 words, and no longer charges for the attribution footer an agent appends after drafting.

🕵️ Encoded by [Agent Numbuh 1](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
