### PR TITLE
fix(results): match table backdrop and last row to caption color

### DIFF
--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -25,8 +25,9 @@
   // The trailing row's own fill, behind the column rather than only in that row.
   // Filler rows come whole, so what is left under the last of them is under a row
   // height; painted the same, it reads as that row being the taller for it rather
-  // than as the page running out before the table does.
-  background-color: var(--rak-primary-800);
+  // than as the page running out before the table does. The caption's own color,
+  // not the header's: this is the frame around the table, not the table itself.
+  background-color: var(--rak-primary-600);
   // The table is the app's screen, so the dark band around it is drawn as the
   // bezel holding it: lit along its top edge and shadowed along its bottom. Inset,
   // so it costs no room and nothing inside the frame moves.

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -323,9 +323,11 @@
     }
 
     // Keeps the last real row clear of a phone's rounded corners and home
-    // indicator. A row tall, in the header's color, so it reads as the table's own
-    // bottom edge, plus the device's inset where there is one. `index.html` asks
-    // for `viewport-fit=cover`, without which the inset is always zero.
+    // indicator. A row tall, in the frame's color (`ResultsFrame.scss`'s
+    // `.results-scores`), so it reads as that frame reaching up to meet the table
+    // rather than as the table's own bottom edge, plus the device's inset where
+    // there is one. `index.html` asks for `viewport-fit=cover`, without which the
+    // inset is always zero.
     tr:last-child.table__last-row td {
       height: calc(
         var(--rak-table-row-height) + env(safe-area-inset-bottom, 0px)
@@ -333,7 +335,7 @@
       padding: 0;
       // The last real row already carries the table's bottom edge.
       border: var(--rak-table-no-border);
-      background-color: var(--rak-primary-800);
+      background-color: var(--rak-primary-600);
     }
   }
 }


### PR DESCRIPTION
## What

The results table's backdrop and last row now match the caption's color, not the header's.

## Why

Both fills read `--rak-primary-800`, the header's own color. At the bottom of a scroll, this looked like a second header instead of a continuation of the caption bar.

🕵️ Sanitized by [Agent Kim Possible](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
