### PR TITLE
fix(button): dish the key face, darken navbar press

### DIFF
--- a/src/components/button/Button.scss
+++ b/src/components/button/Button.scss
@@ -11,6 +11,7 @@
   transform: translateY(calc(var(--rak-key-lift) - #{$lift}));
   box-shadow:
     var(--rak-key-top),
+    var(--rak-key-dish),
     0 #{$lift} 0 var(--rak-key-edge);
 }
 

--- a/src/components/navbar/Navbar.scss
+++ b/src/components/navbar/Navbar.scss
@@ -16,11 +16,11 @@
   // A key set into the bar is lit a step over it, so it is a control before its edge
   // is read. Elsewhere a solid key stands on white and needs no lift.
   //
-  // The whole ramp shifts, not the rest fill alone: every state stays one step from
-  // the one before it, so a press deepens once rather than crossing two steps and
-  // reading as the key going down twice.
+  // The pressed/selected fill lands one step past the bar itself, not on it: a fill
+  // level with the bar reads as no press at all, since the key and its surface are
+  // the same color.
   --rak-key-face: var(--rak-primary-400);
-  --rak-key-active: var(--rak-primary-500);
+  --rak-key-active: var(--rak-primary-600);
 }
 
 .navbar__content {

--- a/src/index.scss
+++ b/src/index.scss
@@ -336,6 +336,10 @@
   // a key stands on is not here: it is that key's own color one step down, which
   // only `Button.scss` knows.
   --rak-key-top: inset 0 1px 0 rgb(255 255 255 / 18%);
+  // The face dishes rather than sitting flat: a shadow along its lower inside
+  // edge, where a concave cap tips away from the light `--rak-key-top` catches
+  // at the rim.
+  --rak-key-dish: inset 0 -2px 3px rgb(0 0 0 / 14%);
   --rak-bezel:
     inset 0 1px 0 rgb(255 255 255 / 10%), inset 0 -1px 0 rgb(0 0 0 / 30%);
   --rak-well: inset 0 1px 2px rgb(0 0 0 / 35%);


### PR DESCRIPTION
## What

The button key now dishes inward. A selected or pressed navbar button reads a step darker than the bar behind it.

![Navbar press](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/concave-button-keys/navbar-crop.png)
![Home page buttons](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/concave-button-keys/home-crop.png)

## Why

A flat key face did not read as a physical key. A selected navbar button matched the bar's own fill, so it did not read as pressed.

## Changes

- Add `--rak-key-dish`, an inset shadow the key mixin layers onto every solid button.
- Move the navbar's `--rak-key-active` one step past the bar fill instead of onto it.

🕵️ Handled by [Agent Numbuh 1](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
