### PR TITLE
fix(gameStatus): hold wireframe until both team marks decode

### DIFF
--- a/src/components/gameStatus/CLAUDE.md
+++ b/src/components/gameStatus/CLAUDE.md
@@ -6,8 +6,8 @@ How a game in the week is going, opened from a pick cell.
   table column order, which the query matches. `GameMark` says where a game stands;
   `useLiveGame` keeps the chosen one fresh.
 - `GameStatusSummary`: the pool's line, the game as ESPN's boxscore says it, its kickoff,
-  town and Gamecast link. The wireframe is that layout over the week's own copy, so a
-  wait is the answer's size. `useScorelineFit` measures the scoreline and takes the full
-  names, then the marks, off one too narrow.
+  town and Gamecast link. The wireframe is that layout over the week's own copy, held
+  until both marks decode too, so neither pops in over it. `useScorelineFit`
+  takes the full names, then the marks, off one too narrow.
 - `GameStatusSummary.scss`: both sides in one grid, the dash in a track between two
   equal ones, so neither side moves it. `--rak-score-size` sizes that row.

--- a/src/components/gameStatus/GameStatusDialog.test.tsx
+++ b/src/components/gameStatus/GameStatusDialog.test.tsx
@@ -23,6 +23,7 @@ import {
   dialog,
   getGameResultMock,
   SEASON,
+  settleLogos,
   WEEK,
 } from "./gameStatusDialogTestSupport";
 
@@ -181,6 +182,7 @@ describe("GameStatusDialog", () => {
     // The score the fetch came back with, not the one the week was scored at. Waited
     // on by the bar, since the wireframe carries the week's own copy of the game and
     // so already reads the same in places.
+    settleLogos();
     await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"));
     expect(screen.getByText("8:42 - 3rd Quarter")).toBeInTheDocument();
     expect(screen.getByText("BUF Team")).toBeInTheDocument();
@@ -278,6 +280,7 @@ describe("GameStatusDialog", () => {
     ).toBeInTheDocument();
 
     pending.settle(upcomingGame);
+    settleLogos();
     await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"));
     expect(screen.getByText("PHI Team")).toBeInTheDocument();
     // Not started, so the search says so rather than that there is something to watch.
@@ -289,6 +292,7 @@ describe("GameStatusDialog", () => {
     const askedBeforeFinal = getGameResultMock.mock.calls.length;
     await user.click(screen.getByRole("combobox", { name: "Game" }));
     await user.click(await screen.findByRole("option", { name: /MICH @ OSU/ }));
+    settleLogos();
     expect(screen.getByText("OSU Team")).toBeInTheDocument();
     expect(screen.queryByRole("progressbar")).toBeNull();
     expect(screen.getByRole("img", { name: "Final" })).toBeInTheDocument();

--- a/src/components/gameStatus/GameStatusSummary.scss
+++ b/src/components/gameStatus/GameStatusSummary.scss
@@ -255,16 +255,6 @@
   }
 }
 
-// Stands in the same cell the real image below it also holds, so the two swap
-// with nothing else on the row moving. Static rather than the wireframe's sheen:
-// the rest of the row is the real answer already, and a sweep next to it reads
-// as the answer being unsure of itself.
-.game-status__logo.--placeholder {
-  @include skeleton-surface;
-
-  border-radius: 50%;
-}
-
 // Each side out on its own edge, and between them one block holding both scores and,
 // stacked over and under them, where the game is up to and what the offense faces.
 // Both sides are laid into the one grid rather than each into its own, so a label, a

--- a/src/components/gameStatus/GameStatusSummary.test.tsx
+++ b/src/components/gameStatus/GameStatusSummary.test.tsx
@@ -1,9 +1,29 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  fireEvent,
+  render as rtlRender,
+  screen,
+  type RenderResult,
+} from "@testing-library/react";
+import { ReactElement } from "react";
 import { GameStatus, HomeAway } from "../../types/ESPN";
 import { LeagueResult } from "../../types/LeagueResult";
 import { League } from "../../types/League";
 import { WeekGame } from "../../types/WeekGame";
 import GameStatusSummary from "./GameStatusSummary";
+
+/**
+ * jsdom never actually fetches an image, so the logos `GameStatusSummary` waits
+ * on before it leaves its wireframe would sit forever unloaded. Settling every
+ * one straight after render stands in for the common case the wait is for: the
+ * browser's image cache already warm from the dialog's own prefetch.
+ */
+function render(ui: ReactElement): RenderResult {
+  const view = rtlRender(ui);
+  document
+    .querySelectorAll<HTMLImageElement>("img[hidden]")
+    .forEach((img) => fireEvent.load(img));
+  return view;
+}
 
 const KICKOFF = new Date("2024-10-06T17:00:00Z");
 
@@ -117,6 +137,33 @@ describe("GameStatusSummary, before there is anything to show", () => {
     // game, so nothing under the dialog moves when the answer lands.
     render(<GameStatusSummary game={game(final)} />);
     expect(scoreline(".game-status.--skeleton")).toEqual(shown);
+  });
+
+  it("holds the wireframe until both marks have loaded, even once the game has", () => {
+    // `rtlRender` rather than this file's own settling `render`, since this is
+    // what that settling stands in for.
+    rtlRender(<GameStatusSummary game={game(result())} result={result()} />);
+    expect(document.querySelector(".game-status:not(.--skeleton)")).toBeNull();
+
+    const [away, home] = document.querySelectorAll("img[hidden]");
+    fireEvent.load(away);
+    // One of the two loaded is not both of them.
+    expect(document.querySelector(".game-status:not(.--skeleton)")).toBeNull();
+
+    fireEvent.load(home);
+    expect(
+      document.querySelector(".game-status:not(.--skeleton)"),
+    ).not.toBeNull();
+  });
+
+  it("shows the game without its marks rather than wait on one that never loads", () => {
+    rtlRender(<GameStatusSummary game={game(result())} result={result()} />);
+    fireEvent.error(document.querySelectorAll("img[hidden]")[0]);
+
+    expect(
+      document.querySelector(".game-status:not(.--skeleton)"),
+    ).not.toBeNull();
+    expect(logos()).toEqual([]);
   });
 
   it("says so where ESPN listed no game for the column", () => {

--- a/src/components/gameStatus/GameStatusSummary.tsx
+++ b/src/components/gameStatus/GameStatusSummary.tsx
@@ -458,6 +458,14 @@ function hasLogos(result: LeagueResult): boolean {
   return result.home.team.logoUrl != null && result.away.team.logoUrl != null;
 }
 
+/** Both logo URLs a result wears, away first as the scoreline shows them, or none
+ *  where either side has none. */
+function logoUrlsOf(result: LeagueResult): Array<string> {
+  return hasLogos(result)
+    ? [result.away.team.logoUrl as string, result.home.team.logoUrl as string]
+    : [];
+}
+
 /**
  * The lines either side of the scores, each of which is one word on one line.
  *
@@ -682,9 +690,17 @@ function Game({
 function Wireframe({
   result,
   spread,
+  pendingLogoUrls,
+  onLogoLoad,
+  onLogoError,
 }: {
   result: LeagueResult;
   spread?: GameSpread;
+  /** Every logo this game wears, decoded off screen so none of them pop in
+   *  once the wireframe gives way to the game itself. */
+  pendingLogoUrls: Array<string>;
+  onLogoLoad: (url: string) => void;
+  onLogoError: () => void;
 }) {
   return (
     <>
@@ -706,6 +722,16 @@ function Wireframe({
           }
         />
       </div>
+      {pendingLogoUrls.map((url) => (
+        <img
+          key={url}
+          src={url}
+          alt=""
+          hidden
+          onLoad={() => onLogoLoad(url)}
+          onError={onLogoError}
+        />
+      ))}
     </>
   );
 }
@@ -732,8 +758,8 @@ export default function GameStatusSummary({
   // Which game's marks failed to load, rather than a flag, so moving to another
   // game asks about its marks instead of inheriting a verdict on the last one's.
   const [logolessId, setLogolessId] = useState<string>();
-  // Every URL that has already fired its own load, so a team seen once does not
-  // go back to a placeholder on a later game or a poll of this one.
+  // Every URL that has already loaded, so a team seen once does not ask to be
+  // waited on again on a later game or a poll of this one.
   const [loadedLogoUrls, setLoadedLogoUrls] = useState<Set<string>>(new Set());
 
   if (game == null) {
@@ -747,10 +773,30 @@ export default function GameStatusSummary({
       </p>
     );
   }
-  // The wireframe rather than the game before it, so what is on screen is always the
-  // game the search names.
-  if (isLoading || result == null) {
-    return <Wireframe result={game.result} spread={game.spread} />;
+
+  // `GameStatusDialog` has already asked the browser to warm every logo the week
+  // could show, so decoding these here is almost always a cache hit rather than
+  // a fetch, and the wireframe below holds only as long as that hit takes.
+  const chosenId = game.result.id;
+  const pendingLogoUrls = logoUrlsOf(game.result);
+  const logosDone =
+    logolessId === chosenId ||
+    pendingLogoUrls.every((url) => loadedLogoUrls.has(url));
+
+  // The wireframe rather than the game before it, so what is on screen is always
+  // the game the search names, and never a mark still popping in over it.
+  if (isLoading || result == null || !logosDone) {
+    return (
+      <Wireframe
+        result={game.result}
+        spread={game.spread}
+        pendingLogoUrls={pendingLogoUrls}
+        onLogoLoad={(url) =>
+          setLoadedLogoUrls((loaded) => new Set(loaded).add(url))
+        }
+        onLogoError={() => setLogolessId(chosenId)}
+      />
+    );
   }
 
   const logos = hasLogos(result) && logolessId !== result.id;
@@ -763,34 +809,16 @@ export default function GameStatusSummary({
         gamecastHref={gamecastUrl(game.league, result.id)}
         logo={
           logos
-            ? (side) => {
-                const url = side.team.logoUrl as string;
-                const isLoaded = loadedLogoUrls.has(url);
-                return (
-                  <>
-                    {/* Stands in until the real image below fires its own load, so a
-                        team icon never pops in over an answer already on screen. */}
-                    {!isLoaded && (
-                      <span
-                        className="game-status__logo --placeholder"
-                        aria-hidden="true"
-                      />
-                    )}
-                    <img
-                      className="game-status__logo"
-                      src={url}
-                      // The team's name is beside it, so the mark says nothing a
-                      // reader of the page in words is missing.
-                      alt=""
-                      hidden={!isLoaded}
-                      onLoad={() =>
-                        setLoadedLogoUrls((loaded) => new Set(loaded).add(url))
-                      }
-                      onError={() => setLogolessId(result.id)}
-                    />
-                  </>
-                );
-              }
+            ? (side) => (
+                <img
+                  className="game-status__logo"
+                  src={side.team.logoUrl as string}
+                  // The team's name is beside it, so the mark says nothing a
+                  // reader of the page in words is missing.
+                  alt=""
+                  onError={() => setLogolessId(result.id)}
+                />
+              )
             : undefined
         }
       />

--- a/src/components/gameStatus/gameStatusDialogTestSupport.tsx
+++ b/src/components/gameStatus/gameStatusDialogTestSupport.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from "@testing-library/react";
 import { MockedFunction } from "vitest";
 import { WeekInfo } from "../../types/League";
 import { RakMadnessScores } from "../../types/RakMadnessScores";
@@ -26,6 +27,18 @@ export const WEEK: WeekInfo = {
   endDate: new Date("2024-10-08T00:00:00Z"),
 };
 export const SEASON = 2024;
+
+/**
+ * jsdom never actually fetches an image, so a game's marks would sit forever
+ * unloaded behind `GameStatusSummary`'s own wireframe. Settles them for the game
+ * on screen, standing in for the common case the wait is for: the browser's
+ * image cache already warm from the dialog's own prefetch.
+ */
+export function settleLogos() {
+  document
+    .querySelectorAll<HTMLImageElement>("img[hidden]")
+    .forEach((img) => fireEvent.load(img));
+}
 
 export function dialog(
   gameLabel: string | undefined,


### PR DESCRIPTION
## What

The game status modal now waits for both team marks to decode before it shows the game.

## Why

A mark mounted only once its fetch resolved. It could pop in over a score already on screen.

## Changes

- `GameStatusSummary` decodes both marks off screen and holds the wireframe until they settle.
- Drop the old placeholder-swap on the visible marks. The wireframe now covers that wait instead.
- A mark that errors is treated as settled, so a bad logo never blocks the game from showing.
