### PR TITLE
fix(pageLayout): match scroll gap fill to score caption color

### DIFF
--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -93,7 +93,7 @@
     // the box, so nothing but that gap ever shows this. A roomier screen leaves
     // room beside the table, where it would show as a second dark band against the
     // header, so the surface every other page carries goes back below.
-    background-color: var(--rak-primary-800);
+    background-color: var(--rak-primary-600);
 
     // Nothing of its own, so the tiled ground behind the page shows either side of
     // the table, which is what every other page stands on. The shadow goes with


### PR DESCRIPTION
## What

The scores scroll box's overscroll fill now matches the score caption color.

## Why

On bottom overscroll, the scroll box showed `--rak-primary-800`, one shade off the `--rak-primary-600` the frame and caption use.

## Changes

- Set `.page__content.--scores` background color to `--rak-primary-600`.

## Verification

- Scrolled the scores table to the bottom at phone width and confirmed the overscroll fill matches the caption band.

🕵️ Intercepted by [Agent Numbuh 1](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
