### PR TITLE
refactor(tests): share the week fixture across suites

### DIFF
--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -12,6 +12,6 @@ description: This repo's commit and PR conventions. Read before writing any git 
 - PR body length: under 256 words, bullets one line each. Only what a reviewer needs to review the diff. No ticket retelling, no history, no counts or benchmark numbers, no per-file walkthrough, no self-assessment. Headings, an attribution footer, embedded screenshots and recordings don't count against the budget.
 - Commit body: only a why subject can't carry.
 - Prose in a subject, commit body, or PR body: ASD-STE100 Simplified Technical English, and Zinsser's simplicity, brevity, clarity, humanity. Active voice, imperative, simple tenses. One idea per sentence, no sentence over 20 words. No `-ing` form as a noun. Condition before action. Same word for the same thing. Short common word over long one. Max three nouns in a row. Keep articles. No slang, idiom, metaphor, em-dash, semicolon, or aside.
-- The hook denies the cap, the word swaps and the `-ing` nouns, in a subject, a `-m` body, and a PR body. The rest is yours to judge.
+- The hook denies three of the rules above in a subject, a `-m` body, and a PR body: a sentence over 20 words, a long word with a short swap (`utilize`, `leverage`, `prior to`, and the rest), and an `-ing` form used as a noun. It also denies a PR body over the template's word budget. The rest is yours to judge.
 - Enforced by `.claude/hooks/check_conventions.py`, `.github/workflows/pr-title.yml`.
 - No bypass. Rewrite text, don't work around hook.

--- a/src/appTestFixtures.tsx
+++ b/src/appTestFixtures.tsx
@@ -4,7 +4,8 @@ import { userEvent } from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { AppDataContextProvider } from "./context/AppDataContext";
 import { ToastContextProvider } from "./context/ToastContext";
-import { League, LeagueInfo, SeasonType, WeekInfo } from "./types/League";
+import { League, LeagueInfo, SeasonType } from "./types/League";
+import { SEASON, week } from "./weekFixtures";
 import { RakMadnessScores } from "./types/RakMadnessScores";
 import App from "./App";
 import Toaster from "./components/toaster/Toaster";
@@ -32,17 +33,7 @@ export const buildSpreadsheetBufferMock =
   buildSpreadsheetBuffer as MockedFunction<typeof buildSpreadsheetBuffer>;
 
 export const CURRENT_WEEK = 3;
-/** The year the fixture season started in, which is what its dates say. */
-export const SEASON = 2024;
-
-export function week(value: number): WeekInfo {
-  return {
-    value,
-    label: `Week ${value}`,
-    startDate: new Date(2024, 8, value),
-    endDate: new Date(2024, 8, value + 6),
-  };
-}
+export { SEASON, week };
 
 export const weeks = [week(1), week(2), week(3), week(4), week(5)];
 

--- a/src/hooks/usePlayerScores.test.tsx
+++ b/src/hooks/usePlayerScores.test.tsx
@@ -7,6 +7,7 @@ import { RakMadnessScores } from "../types/RakMadnessScores";
 import { XLSX_CONTENT_TYPE } from "../utils/buildSpreadsheetBuffer";
 import { writeCachedPicks } from "../utils/picksCache";
 import { getPlayerScores } from "../utils/scoring/getPlayerScores";
+import { SEASON, week } from "../weekFixtures";
 import usePlayerScores from "./usePlayerScores";
 
 vi.mock("../utils/scoring/getPlayerScores", () => ({
@@ -16,17 +17,6 @@ vi.mock("../utils/scoring/getPlayerScores", () => ({
 const getPlayerScoresMock = getPlayerScores as MockedFunction<
   typeof getPlayerScores
 >;
-
-const SEASON = 2024;
-
-function week(value: number): WeekInfo {
-  return {
-    value,
-    label: `Week ${value}`,
-    startDate: new Date(2024, 8, value),
-    endDate: new Date(2024, 8, value + 6),
-  };
-}
 
 /**
  * Held still, not built per render. `usePlayerScores` keys its scoring callback on

--- a/src/hooks/useWeekRouteGuard.test.tsx
+++ b/src/hooks/useWeekRouteGuard.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { Mock } from "vitest";
 import { useAppData } from "../context/AppDataContext";
 import { useToastActions } from "../context/ToastContext";
-import { WeekInfo } from "../types/League";
+import { SEASON, week } from "../weekFixtures";
 import useWeekRouteGuard from "./useWeekRouteGuard";
 
 const navigate = vi.fn();
@@ -16,17 +16,7 @@ vi.mock("../context/ToastContext", async (importOriginal) => ({
   useToastActions: vi.fn(),
 }));
 
-const SEASON = 2024;
 const CURRENT_WEEK = 5;
-
-function week(value: number): WeekInfo {
-  return {
-    value,
-    label: `Week ${value}`,
-    startDate: new Date(2024, 8, value),
-    endDate: new Date(2024, 8, value + 6),
-  };
-}
 
 const WEEKS = [week(1), week(2), week(3), week(4), week(5), week(6)];
 

--- a/src/utils/storageMockUtils.ts
+++ b/src/utils/storageMockUtils.ts
@@ -1,3 +1,5 @@
+import { vi } from "vitest";
+
 // Shared localStorage failure mocks for cache tests: a write that throws quota
 // exhaustion, and every Storage method blocked outright.
 

--- a/src/weekFixtures.ts
+++ b/src/weekFixtures.ts
@@ -1,0 +1,20 @@
+import { WeekInfo } from "./types/League";
+
+/**
+ * The one `WeekInfo` builder every suite uses.
+ *
+ * Held apart from `appTestFixtures`, which mounts `App` and so cannot be imported
+ * by a suite that mocks `react-router` or a context provider out from under it.
+ */
+
+/** The year the fixture season started in, which is what its dates say. */
+export const SEASON = 2024;
+
+export function week(value: number): WeekInfo {
+  return {
+    value,
+    label: `Week ${value}`,
+    startDate: new Date(SEASON, 8, value),
+    endDate: new Date(SEASON, 8, value + 6),
+  };
+}


### PR DESCRIPTION
## What

Three test suites declared the same `WeekInfo` builder. `src/weekFixtures.ts` now holds the one copy.

## Changes

- The builder sits in a new module, not in `appTestFixtures`. That file mounts `App` and imports `MemoryRouter`, so a suite that mocks `react-router` or a context provider cannot import it.
- `storageMockUtils` imports `vi`. It no longer depends on `globals: true` in the Vitest config.
- The `commit-and-pr` skill names the three rules the hook denies. They come from `check_conventions.py`.

## Notes / Follow-ups

- A repo-wide audit found these. Two other findings did not survive a check. The dialog popup's `outline: none` sits on a `tabindex="-1"` container. `Standing.tsx` already documents why it imports its parent's stylesheet.

🕵️ Neutralized by [Agent Spy Fox](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
