### PR TITLE
chore(agent-config): refresh the vendored hook and PR template

### DIFF
--- a/.claude/hooks/check_conventions.py
+++ b/.claude/hooks/check_conventions.py
@@ -121,7 +121,7 @@ GIT_OPTS_WITH_VALUE = ("-C", "-c", "--git-dir", "--work-tree", "--namespace",
 TICKET_IN_BRANCH = re.compile(
     r"(?:^|[^A-Za-z0-9])([A-Z][A-Z0-9]{1,9}-\d+)(?![A-Za-z0-9])")
 CODE_SPANS = re.compile(r"```.*?```|`[^`]*`", re.DOTALL)
-FENCE = re.compile(r"(?ms)^```.*?^```")
+FENCE = re.compile(r"(?ms)^ {0,3}```.*?^ {0,3}```")
 COMMENTS = re.compile(r"<!--.*?-->", re.DOTALL)
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,9 @@ https://www.conventionalcommits.org/en/v1.0.0/
   feat(auth): [YCOM-21] add device-code login
   refactor(api)!: drop v1 response envelope
 
+Never wrap a line yourself. GitHub turns each newline into a visible break.
+One bullet is one line, however long.
+
 Shortest body a reviewer can review from, under 256 words. Bullets, one line each,
 not paragraphs. Every line must change how they read the diff. Cut every line that
 does not, and delete every section left with nothing to say. A heading, an
@@ -26,12 +29,24 @@ benchmark numbers nobody asked for, a tour of the code, or a note about your own
 machine. A reviewer reads the diff and can click the ticket.
 
 Write ASD-STE100 Simplified Technical English, for Zinsser's simplicity, brevity,
-clarity and humanity. Active voice. Simple tenses. One idea per sentence, and no
-sentence over 20 words. No -ing form as a noun: "before you run it", not "before
-running it". Condition before action. The same word for the same thing every time.
-The short common word, not the long one. Three nouns in a row at most. Keep the
-articles. No slang, no idiom, no metaphor. No em-dashes, no semicolons. Leave no
-empty headings.
+clarity and humanity.
+
+- Active voice, imperative for an instruction: "Run the test", not "The test should be run".
+- Simple present or past tense. No perfect and no progressive.
+- One idea per sentence, 20 words max. No clause-chains: split them.
+- Cut every word that changes nothing for the reader. Simplicity, then brevity.
+- Plain and direct, never stiff. Write for a person, not for a committee.
+- No `-ing` form as a noun: "before you run it", not "before running it".
+- Condition before action: "If the check fails, the run stops."
+- Same word for the same thing every time. No synonym for variety.
+- American English spellings: `color` not `colour`, `analyze` not `analyse`.
+- Short common word: `use` not `utilize`, `fix` not `remediate`, `start` not `initiate`.
+- Max three nouns in a row. Break a longer cluster with a preposition or a verb.
+- Keep articles and relative pronouns. No slang, idiom, or metaphor. Technical names and code stay exact.
+- No hedging unless the uncertainty is real.
+- No em-dashes, no semicolons, no parenthetical asides, no antithesis, no aphorisms, no meta-commentary.
+
+Leave no empty headings.
 -->
 
 ## What


### PR DESCRIPTION
## What

Refresh the two vendored agent files that drifted from their source in `claude-tools`: the `check_conventions.py` commit hook and the PR template.

## Changes

- The hook's fence regex now matches a fenced block indented up to three spaces, so an indented code fence no longer counts as prose.
- The template spells out the writing rules as a list, and adds the rule that you never wrap a line yourself.

## Verification

- The commit on this branch went through the refreshed hook.

🕵️ Neutralized by [Agent Juni Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
