### PR TITLE
feat(settings): add a settings dialog for the theme and the reader's own name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ TypeScript, react-router, Base UI, SCSS. Vitest for tests, ESLint flat config.
 Scores an uploaded weekly picks spreadsheet against ESPN game results, exports XLSX.
 Home page at `/`, a week's results at `/:season/:week/scoreboard` and
 `/:season/:week/picks`, and `/scoreboard` and `/picks` redirect to the latest week
-worth showing. `/settings` holds the reader's theme and their own name. Deployed to Cloudflare Pages (`wrangler`), which serves the picks
+worth showing. A dialog off the home page footer holds the reader's theme and own name. Deployed to Cloudflare Pages (`wrangler`), which serves the picks
 API in `functions/` beside the built app.
 
 `index.html` at the repo root is the HTML shell Vite builds from. Its inline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ TypeScript, react-router, Base UI, SCSS. Vitest for tests, ESLint flat config.
 Scores an uploaded weekly picks spreadsheet against ESPN game results, exports XLSX.
 Home page at `/`, a week's results at `/:season/:week/scoreboard` and
 `/:season/:week/picks`, and `/scoreboard` and `/picks` redirect to the latest week
-worth showing. Deployed to Cloudflare Pages (`wrangler`), which serves the picks
+worth showing. `/settings` holds the reader's theme and their own name. Deployed to Cloudflare Pages (`wrangler`), which serves the picks
 API in `functions/` beside the built app.
 
 `index.html` at the repo root is the HTML shell Vite builds from.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ Home page at `/`, a week's results at `/:season/:week/scoreboard` and
 worth showing. `/settings` holds the reader's theme and their own name. Deployed to Cloudflare Pages (`wrangler`), which serves the picks
 API in `functions/` beside the built app.
 
-`index.html` at the repo root is the HTML shell Vite builds from.
+`index.html` at the repo root is the HTML shell Vite builds from. Its inline
+script sets `data-theme` from storage before the first paint.
 
 [`SCROLL-FLASH.md`](SCROLL-FLASH.md): an open bug, read before changing sticky.
 

--- a/index.html
+++ b/index.html
@@ -33,6 +33,20 @@
     -->
     <link rel="manifest" href="/manifest.json" />
     <title>Rakulator</title>
+    <!-- The saved theme, before the first paint. src/context/SettingsContext.tsx
+         sets the same attribute once React is up, which is too late: a reader who
+         chose dark on a light OS would see a light flash on every load. The key is
+         the one src/utils/settingsStore.ts writes. -->
+    <script>
+      try {
+        var theme = localStorage.getItem("rak-madness:settings:theme");
+        if (theme === "light" || theme === "dark") {
+          document.documentElement.dataset.theme = theme;
+        }
+      } catch (error) {
+        // A browser refusing storage has no saved theme to honour anyway.
+      }
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.results.test.tsx
+++ b/src/App.results.test.tsx
@@ -15,7 +15,6 @@ import {
   mountLoadedApp,
   uploadSpreadsheet,
   resultsCaption,
-  scoresHeaderButtons,
   setUpAppTest,
 } from "./appTestFixtures";
 
@@ -49,9 +48,8 @@ describe("the app, results views", () => {
     const user = await mountWithScores();
     await user.click(screen.getByText("View Results"));
 
-    const [scoreboard, picks] = scoresHeaderButtons();
-    expect(scoreboard).toHaveTextContent("Scoreboard");
-    expect(picks).toHaveTextContent("Picks");
+    const scoreboard = screen.getByRole("button", { name: "Scoreboard" });
+    const picks = screen.getByRole("button", { name: "Picks" });
     expect(scoreboard).toHaveAttribute("aria-pressed", "true");
     expect(picks).toHaveAttribute("aria-pressed", "false");
 
@@ -75,8 +73,7 @@ describe("the app, results views", () => {
     const expected = `Rak Madness · ${SEASON} Season · Week ${CURRENT_WEEK}`;
     expect(resultsCaption()).toHaveTextContent(expected);
 
-    const [, picks] = scoresHeaderButtons();
-    await user.click(picks);
+    await user.click(screen.getByRole("button", { name: "Picks" }));
     expect(resultsCaption()).toHaveTextContent(expected);
   });
 

--- a/src/App.routes.test.tsx
+++ b/src/App.routes.test.tsx
@@ -148,4 +148,13 @@ describe("the app: the URL decides which week is fetched, and what shows while i
 
     expect(screen.getByText("Use Local Spreadsheet")).toBeInTheDocument();
   });
+
+  it("opens the settings page on /settings", async () => {
+    mountApp("/settings");
+
+    expect(
+      await screen.findByRole("group", { name: "Theme" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Your name")).toBeInTheDocument();
+  });
 });

--- a/src/App.routes.test.tsx
+++ b/src/App.routes.test.tsx
@@ -149,12 +149,11 @@ describe("the app: the URL decides which week is fetched, and what shows while i
     expect(screen.getByText("Use Local Spreadsheet")).toBeInTheDocument();
   });
 
-  it("opens the settings page on /settings", async () => {
-    mountApp("/settings");
+  it("opens the settings over the home page, from the footer", async () => {
+    const user = mountApp("/");
+    await user.click(await screen.findByRole("button", { name: "Settings" }));
 
-    expect(
-      await screen.findByRole("group", { name: "Theme" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Theme" })).toBeInTheDocument();
     expect(screen.getByLabelText("Your Player Name")).toBeInTheDocument();
   });
 });

--- a/src/App.routes.test.tsx
+++ b/src/App.routes.test.tsx
@@ -155,6 +155,6 @@ describe("the app: the URL decides which week is fetched, and what shows while i
     expect(
       await screen.findByRole("group", { name: "Theme" }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText("Your name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Your Player Name")).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import CurrentWeekRedirect from "./components/results/CurrentWeekRedirect";
 import PicksRoute from "./components/results/PicksRoute";
 import ResultsLayout from "./components/results/ResultsLayout";
 import ScoreboardRoute from "./components/results/ScoreboardRoute";
-import SettingsPage from "./components/settings/SettingsPage";
 
 export default function App() {
   return (
@@ -16,7 +15,6 @@ export default function App() {
         element={<CurrentWeekRedirect view="Scoreboard" />}
       />
       <Route path="/picks" element={<CurrentWeekRedirect view="Picks" />} />
-      <Route path="/settings" element={<SettingsPage />} />
       <Route path="/:season/:week" element={<ResultsLayout />}>
         <Route index element={<Navigate to="scoreboard" replace />} />
         <Route path="scoreboard" element={<ScoreboardRoute />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import CurrentWeekRedirect from "./components/results/CurrentWeekRedirect";
 import PicksRoute from "./components/results/PicksRoute";
 import ResultsLayout from "./components/results/ResultsLayout";
 import ScoreboardRoute from "./components/results/ScoreboardRoute";
+import SettingsPage from "./components/settings/SettingsPage";
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
         element={<CurrentWeekRedirect view="Scoreboard" />}
       />
       <Route path="/picks" element={<CurrentWeekRedirect view="Picks" />} />
+      <Route path="/settings" element={<SettingsPage />} />
       <Route path="/:season/:week" element={<ResultsLayout />}>
         <Route index element={<Navigate to="scoreboard" replace />} />
         <Route path="scoreboard" element={<ScoreboardRoute />} />

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -18,7 +18,7 @@ under an opening dialog. Base UI is unstyled, so tokens plus SCSS carry the whol
 - [`components/pageLayout/`](components/pageLayout/CLAUDE.md) — the chrome every page shares
 - [`components/playerAnalysis/`](components/playerAnalysis/CLAUDE.md) — where a player stands, and why
 - [`components/results/`](components/results/CLAUDE.md) — results routes, layout, redirect
-- [`components/settings/`](components/settings/CLAUDE.md) — theme and the reader's own name
+- [`components/settings/`](components/settings/CLAUDE.md) — theme and own name, in a dialog
 - [`components/table/`](components/table/CLAUDE.md) — shared frame and the results tables
 - [`components/toaster/`](components/toaster/CLAUDE.md) — toast notification renderer
 - [`context/`](context/CLAUDE.md) — app data, toast, and analysis providers

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,10 +1,10 @@
 # src
 
-`index.tsx`: Vite entry, loaded by the root `index.html`. React 19 `createRoot` mount into `#root`, wraps `App` in `BrowserRouter`, `ToastContextProvider`, and `AppDataContextProvider`, with `Toaster` beside it. `App.tsx`: the route table, which the root `CLAUDE.md` lists. `index.scss`: global resets, the body baseline, every `--rak-*` design token, and
-a `prefers-color-scheme: dark` override for the color ones. It
+`index.tsx`: Vite entry, loaded by the root `index.html`. React 19 `createRoot` mount into `#root`, wraps `App` in `BrowserRouter`, `SettingsContextProvider`, `ToastContextProvider`, and `AppDataContextProvider`, with `Toaster` beside it. `App.tsx`: the route table, which the root `CLAUDE.md` lists. `index.scss`: global resets, the body baseline, every `--rak-*` design token, and
+a `dark-tokens` mixin the OS or a saved `data-theme` applies. It
 hides `<html>`'s overflow, because no route scrolls the page itself and saying so
 keeps Base UI's scroll lock from reserving a scrollbar gutter that shifts everything
-under an opening dialog. No theme provider: Base UI is unstyled, so tokens plus SCSS carry the whole look. `setupTests.ts`: Vitest setup, jest-dom plus a `jest` global shim that @testing-library/dom needs to drive fake timers.
+under an opening dialog. Base UI is unstyled, so tokens plus SCSS carry the whole look. `setupTests.ts`: Vitest setup, jest-dom plus a `jest` global shim that @testing-library/dom needs to drive fake timers.
 
 ## Subdirectories
 
@@ -18,6 +18,7 @@ under an opening dialog. No theme provider: Base UI is unstyled, so tokens plus 
 - [`components/pageLayout/`](components/pageLayout/CLAUDE.md) — the chrome every page shares
 - [`components/playerAnalysis/`](components/playerAnalysis/CLAUDE.md) — where a player stands, and why
 - [`components/results/`](components/results/CLAUDE.md) — results routes, layout, redirect
+- [`components/settings/`](components/settings/CLAUDE.md) — theme and the reader's own name
 - [`components/table/`](components/table/CLAUDE.md) — shared frame and the results tables
 - [`components/toaster/`](components/toaster/CLAUDE.md) — toast notification renderer
 - [`context/`](context/CLAUDE.md) — app data, toast, and analysis providers

--- a/src/appTestFixtures.tsx
+++ b/src/appTestFixtures.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { AppDataContextProvider } from "./context/AppDataContext";
+import { SettingsContextProvider } from "./context/SettingsContext";
 import { ToastContextProvider } from "./context/ToastContext";
 import { League, LeagueInfo, SeasonType } from "./types/League";
 import { SEASON, week } from "./weekFixtures";
@@ -100,12 +101,14 @@ export function mountApp(path = "/") {
   const user = userEvent.setup();
   render(
     <MemoryRouter initialEntries={[path]}>
-      <ToastContextProvider>
-        <AppDataContextProvider>
-          <App />
-        </AppDataContextProvider>
-        <Toaster />
-      </ToastContextProvider>
+      <SettingsContextProvider>
+        <ToastContextProvider>
+          <AppDataContextProvider>
+            <App />
+          </AppDataContextProvider>
+          <Toaster />
+        </ToastContextProvider>
+      </SettingsContextProvider>
     </MemoryRouter>,
   );
   return user;

--- a/src/appTestFixtures.tsx
+++ b/src/appTestFixtures.tsx
@@ -135,7 +135,11 @@ export async function uploadSpreadsheet(
   await user.upload(fileInput(), file);
 }
 
-/** Scoreboard, Picks, Refresh, in the order ScoresNavbar renders them. */
+/**
+ * Refresh, Scoreboard, Picks, in the order `ScoresNavbar` renders them. Refresh is
+ * there only while the week is live, so index into this by name rather than by
+ * position.
+ */
 export function scoresHeaderButtons(): Array<HTMLElement> {
   return Array.from(
     document.querySelectorAll<HTMLElement>(".scores-nav__button"),

--- a/src/components/dialog/CLAUDE.md
+++ b/src/components/dialog/CLAUDE.md
@@ -1,10 +1,10 @@
 # dialog
 
-The dialog the player analysis and the game status are shown in, and the search each
-is pointed with.
+The dialog the player analysis, the game status, and the settings are shown in,
+and the search the first two are pointed with.
 
-- `DialogShell`: `Dialog.Root` down to the scrolling body. Takes a `search` holding
-  still above the body's hairline rule, and `busy` for the bar drawn there.
+- `DialogShell`: `Dialog.Root` down to the scrolling body. Optionally a `search`
+  holding still above the body's hairline rule, and `busy` for the bar drawn there.
 - `DialogShell.scss`: a bottom sheet, a centered modal at `wide-screen`, sized against
   `useViewportInsets` so a keyboard covers nothing and the sheet still reaches the
   bottom edge. `--rak-dialog-inset` stands the bar on the rule.

--- a/src/components/dialog/DialogShell.scss
+++ b/src/components/dialog/DialogShell.scss
@@ -67,7 +67,12 @@ $keyboard-gap: 12px;
       min(var(--rak-keyboard-inset, 0px), #{$keyboard-gap})
   );
   border-radius: var(--rak-radius-lg) var(--rak-radius-lg) 0 0;
-  background-color: var(--rak-surface);
+  // The one edge the sheet meets the page on. Its other three run off the sides
+  // and the bottom of the screen, where a line would read as an artifact rather
+  // than as an edge. Transparent in light mode, so the box measures the same
+  // either way and a theme switched with the dialog open moves nothing.
+  border-top: var(--rak-border-width-hairline) solid var(--rak-dialog-edge);
+  background-color: var(--rak-surface-raised);
   box-shadow: var(--rak-shadow-modal);
   transition:
     opacity 200ms ease,
@@ -189,6 +194,8 @@ $bar-height: 2px;
     // phone's sheet does not, so it never needed the mobile-only 18px above.
     padding-inline: 20px;
     border-radius: var(--rak-radius-lg);
+    // All four, since a centered window meets the page on every side.
+    border: var(--rak-border-width-hairline) solid var(--rak-dialog-edge);
     transform: translate(-50%, -50%);
 
     // The fade alone, at the transform it rests at, so the window opens where it

--- a/src/components/dialog/DialogShell.tsx
+++ b/src/components/dialog/DialogShell.tsx
@@ -24,7 +24,6 @@ export default function DialogShell({
   title,
   search,
   busy = false,
-  busyLabel,
   children,
 }: PropsWithChildren<{
   open: boolean;
@@ -32,11 +31,14 @@ export default function DialogShell({
   title: string;
   /** The control that picks what the body is about. */
   search?: ReactNode;
-  /** Set while the next answer is being worked out. Draws the bar on the rule. */
-  busy?: boolean;
-  /** The bar's accessible name, which says what is being worked out. Required of
-      any dialog that can set `busy`. */
-  busyLabel?: string;
+  /**
+   * Set while the next answer is being worked out. Draws the bar on the rule,
+   * named by `label`, which says what is being worked out.
+   *
+   * The name travels with the flag rather than beside it, so a dialog cannot draw
+   * a bar with nothing to call it. A dialog that never waits passes nothing.
+   */
+  busy?: false | { label: string };
 }>) {
   // Tapping a search opens a keyboard over the bottom of the screen, which the
   // sheet is sized and padded against. Only while the dialog is up, since nothing
@@ -68,7 +70,7 @@ export default function DialogShell({
                 className="dialog__progress"
                 role="progressbar"
                 aria-busy="true"
-                aria-label={busyLabel}
+                aria-label={busy.label}
               />
             )}
             {/* Polite, so a new answer replacing the last one is read once the

--- a/src/components/dialog/DialogShell.tsx
+++ b/src/components/dialog/DialogShell.tsx
@@ -34,8 +34,9 @@ export default function DialogShell({
   search?: ReactNode;
   /** Set while the next answer is being worked out. Draws the bar on the rule. */
   busy?: boolean;
-  /** The bar's accessible name, which says what is being worked out. */
-  busyLabel: string;
+  /** The bar's accessible name, which says what is being worked out. Required of
+      any dialog that can set `busy`. */
+  busyLabel?: string;
 }>) {
   // Tapping a search opens a keyboard over the bottom of the screen, which the
   // sheet is sized and padded against. Only while the dialog is up, since nothing

--- a/src/components/footer/CLAUDE.md
+++ b/src/components/footer/CLAUDE.md
@@ -1,5 +1,6 @@
 # footer
 
-`Footer`: fixed-bottom links to Standings (rakmadness.net) and the GitHub repo, each
+`Footer`: fixed-bottom links to Standings (rakmadness.net), the GitHub repo, and
+the settings page, the last a `Link` since it stays in the app. Each is
 marked with an `Icon.tsx` icon rather than an emoji, so the mark is the same on every
 platform and can be colored. Hidden below 528px viewport height.

--- a/src/components/footer/CLAUDE.md
+++ b/src/components/footer/CLAUDE.md
@@ -1,6 +1,6 @@
 # footer
 
-`Footer`: fixed-bottom links to the settings page, Standings (rakmadness.net),
+`Footer`: the home page's fixed-bottom links to the settings page, Standings (rakmadness.net),
 and the GitHub repo. The first is a `Link`, since it stays in the app. Each is
 marked with an `Icon.tsx` icon rather than an emoji, so the mark is the same on every
 platform and can be colored. Hidden below 540px viewport height, where the links would sit under the home

--- a/src/components/footer/CLAUDE.md
+++ b/src/components/footer/CLAUDE.md
@@ -3,4 +3,5 @@
 `Footer`: fixed-bottom links to the settings page, Standings (rakmadness.net),
 and the GitHub repo. The first is a `Link`, since it stays in the app. Each is
 marked with an `Icon.tsx` icon rather than an emoji, so the mark is the same on every
-platform and can be colored. Hidden below 528px viewport height.
+platform and can be colored. Hidden below 540px viewport height, where the links would sit under the home
+page's last button.

--- a/src/components/footer/CLAUDE.md
+++ b/src/components/footer/CLAUDE.md
@@ -1,6 +1,6 @@
 # footer
 
-`Footer`: fixed-bottom links to Standings (rakmadness.net), the GitHub repo, and
-the settings page, the last a `Link` since it stays in the app. Each is
+`Footer`: fixed-bottom links to the settings page, Standings (rakmadness.net),
+and the GitHub repo. The first is a `Link`, since it stays in the app. Each is
 marked with an `Icon.tsx` icon rather than an emoji, so the mark is the same on every
 platform and can be colored. Hidden below 528px viewport height.

--- a/src/components/footer/CLAUDE.md
+++ b/src/components/footer/CLAUDE.md
@@ -1,7 +1,7 @@
 # footer
 
-`Footer`: the home page's fixed-bottom links to the settings page, Standings (rakmadness.net),
-and the GitHub repo. The first is a `Link`, since it stays in the app. Each is
-marked with an `Icon.tsx` icon rather than an emoji, so the mark is the same on every
-platform and can be colored. Hidden below 540px viewport height, where the links would sit under the home
-page's last button.
+`Footer`: the home page's fixed-bottom row. A button opening `SettingsDialog`,
+then links to Standings (rakmadness.net) and the GitHub repo. Each is marked
+with an `Icon.tsx` icon rather than an emoji, so the mark is the same on every
+platform and can be colored. Hidden below 540px viewport height, where the row
+would sit under the home page's last button.

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -42,10 +42,22 @@
   }
 }
 
-// The controls stack is one control taller since the season picker joined it, so
-// the links have to give up sooner: 56px for the picker and 12px for the gap
-// above it.
-@media (max-height: 528px) {
+// Below this the links would sit under the home page's last button, so they give
+// up the screen instead. `position: fixed` keeps that from moving anything either
+// way, so this is only about overlap.
+//
+// The height it takes to clear the stack, worked from the pieces rather than
+// guessed. The stack stands 360px: five controls of `--rak-control-height` plus
+// four `--rak-control-gap` between them, inside its own 16px of padding. The
+// content box centers it, so half of whatever is left over falls below it. These
+// links stand 56px, and 16px more keeps them off the button rather than merely
+// clear of it.
+//
+//   360 + 2 * (56 + 16 - 16) + 68 = 540
+//
+// The last term is the navbar, at its tallest. 539px is the last height that
+// cannot fit that, so it is the last height with no links.
+@media (max-height: 539px) {
   .footer {
     display: none;
   }

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -28,14 +28,6 @@
   align-items: center;
   gap: var(--rak-space-2);
 
-  // The page this link is already on. Set in the ink the app reads its own body
-  // copy in, a long way up from the quiet grey the other two keep, and bolder
-  // with it, so the mark does not rest on the color alone.
-  &[aria-current="page"] {
-    color: var(--rak-text);
-    font-weight: var(--rak-weight-bold);
-  }
-
   > svg {
     width: var(--rak-icon-sm);
     height: var(--rak-icon-sm);

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -28,6 +28,14 @@
   align-items: center;
   gap: var(--rak-space-2);
 
+  // The page this link is already on. Set in the ink the app reads its own body
+  // copy in, a long way up from the quiet grey the other two keep, and bolder
+  // with it, so the mark does not rest on the color alone.
+  &[aria-current="page"] {
+    color: var(--rak-text);
+    font-weight: var(--rak-weight-bold);
+  }
+
   > svg {
     width: var(--rak-icon-sm);
     height: var(--rak-icon-sm);

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -27,6 +27,13 @@
   display: flex;
   align-items: center;
   gap: var(--rak-space-2);
+  // For the settings button, which is a `<button>` among two `<a>`s and has to
+  // read as the third of three. Costs the two links nothing.
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  cursor: pointer;
 
   > svg {
     width: var(--rak-icon-sm);

--- a/src/components/footer/Footer.test.tsx
+++ b/src/components/footer/Footer.test.tsx
@@ -1,33 +1,31 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
+import { userEvent } from "@testing-library/user-event";
+import { SettingsContextProvider } from "../../context/SettingsContext";
 import Footer from "./Footer";
 
-function renderFooter() {
+function mountFooter() {
+  const user = userEvent.setup();
   render(
-    <MemoryRouter>
+    <SettingsContextProvider>
       <Footer />
-    </MemoryRouter>,
+    </SettingsContextProvider>,
   );
+  return user;
 }
 
 describe("Footer", () => {
-  it("links to the settings page, the standings, and the repo, in that order", () => {
-    renderFooter();
-    const hrefs = screen
-      .getAllByRole("link")
-      .map((link) => link.getAttribute("href"));
-    expect(hrefs).toEqual([
-      "/settings",
-      "https://rakmadness.net/standings-pickem",
-      "https://github.com/crombach/rak-madness-calculator",
-    ]);
+  it("offers the settings, the standings, and the repo, in that order", () => {
+    mountFooter();
+    const labels = Array.from(document.querySelectorAll(".footer__link")).map(
+      (control) => control.textContent,
+    );
+
+    expect(labels).toEqual(["Settings", "Standings", "GitHub"]);
   });
 
   it("opens every link that leaves the app in a new tab, without the referrer", () => {
-    renderFooter();
-    const leaving = screen
-      .getAllByRole("link")
-      .filter((link) => link.getAttribute("href")?.startsWith("http"));
+    mountFooter();
+    const leaving = screen.getAllByRole("link");
 
     expect(leaving).toHaveLength(2);
     leaving.forEach((link) => {
@@ -36,18 +34,20 @@ describe("Footer", () => {
     });
   });
 
-  it("keeps the settings link in the app", () => {
-    renderFooter();
+  it("opens the settings over the page, rather than linking away to them", async () => {
+    const user = mountFooter();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
-    expect(screen.getByRole("link", { name: "Settings" })).not.toHaveAttribute(
-      "target",
-    );
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Settings" }),
+    ).toBeInTheDocument();
   });
 
   it("names each link by its text, not the decorative icon beside it", () => {
-    renderFooter();
+    mountFooter();
     expect(screen.getByRole("link", { name: "Standings" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "GitHub" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Settings" })).toBeInTheDocument();
   });
 });

--- a/src/components/footer/Footer.test.tsx
+++ b/src/components/footer/Footer.test.tsx
@@ -2,24 +2,24 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import Footer from "./Footer";
 
-function renderFooter() {
+function renderFooter(path = "/") {
   render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[path]}>
       <Footer />
     </MemoryRouter>,
   );
 }
 
 describe("Footer", () => {
-  it("links to the standings, the repo, and the settings page", () => {
+  it("links to the settings page, the standings, and the repo, in that order", () => {
     renderFooter();
     const hrefs = screen
       .getAllByRole("link")
       .map((link) => link.getAttribute("href"));
     expect(hrefs).toEqual([
+      "/settings",
       "https://rakmadness.net/standings-pickem",
       "https://github.com/crombach/rak-madness-calculator",
-      "/settings",
     ]);
   });
 
@@ -41,6 +41,23 @@ describe("Footer", () => {
 
     expect(screen.getByRole("link", { name: "Settings" })).not.toHaveAttribute(
       "target",
+    );
+  });
+
+  it("marks the settings link on the settings page", () => {
+    renderFooter("/settings");
+
+    expect(screen.getByRole("link", { name: "Settings" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("marks nothing on any other page", () => {
+    renderFooter("/");
+
+    expect(screen.getByRole("link", { name: "Settings" })).not.toHaveAttribute(
+      "aria-current",
     );
   });
 

--- a/src/components/footer/Footer.test.tsx
+++ b/src/components/footer/Footer.test.tsx
@@ -27,7 +27,10 @@ describe("Footer", () => {
     mountFooter();
     const leaving = screen.getAllByRole("link");
 
-    expect(leaving).toHaveLength(2);
+    expect(leaving.map((link) => link.getAttribute("href"))).toEqual([
+      "https://rakmadness.net/standings-pickem",
+      "https://github.com/crombach/rak-madness-calculator",
+    ]);
     leaving.forEach((link) => {
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", "noreferrer");

--- a/src/components/footer/Footer.test.tsx
+++ b/src/components/footer/Footer.test.tsx
@@ -2,9 +2,9 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import Footer from "./Footer";
 
-function renderFooter(path = "/") {
+function renderFooter() {
   render(
-    <MemoryRouter initialEntries={[path]}>
+    <MemoryRouter>
       <Footer />
     </MemoryRouter>,
   );
@@ -41,23 +41,6 @@ describe("Footer", () => {
 
     expect(screen.getByRole("link", { name: "Settings" })).not.toHaveAttribute(
       "target",
-    );
-  });
-
-  it("marks the settings link on the settings page", () => {
-    renderFooter("/settings");
-
-    expect(screen.getByRole("link", { name: "Settings" })).toHaveAttribute(
-      "aria-current",
-      "page",
-    );
-  });
-
-  it("marks nothing on any other page", () => {
-    renderFooter("/");
-
-    expect(screen.getByRole("link", { name: "Settings" })).not.toHaveAttribute(
-      "aria-current",
     );
   });
 

--- a/src/components/footer/Footer.test.tsx
+++ b/src/components/footer/Footer.test.tsx
@@ -1,29 +1,53 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import Footer from "./Footer";
 
+function renderFooter() {
+  render(
+    <MemoryRouter>
+      <Footer />
+    </MemoryRouter>,
+  );
+}
+
 describe("Footer", () => {
-  it("links to the standings and the repo", () => {
-    render(<Footer />);
+  it("links to the standings, the repo, and the settings page", () => {
+    renderFooter();
     const hrefs = screen
       .getAllByRole("link")
       .map((link) => link.getAttribute("href"));
     expect(hrefs).toEqual([
       "https://rakmadness.net/standings-pickem",
       "https://github.com/crombach/rak-madness-calculator",
+      "/settings",
     ]);
   });
 
-  it("opens every link in a new tab without leaking the referrer", () => {
-    render(<Footer />);
-    screen.getAllByRole("link").forEach((link) => {
+  it("opens every link that leaves the app in a new tab, without the referrer", () => {
+    renderFooter();
+    const leaving = screen
+      .getAllByRole("link")
+      .filter((link) => link.getAttribute("href")?.startsWith("http"));
+
+    expect(leaving).toHaveLength(2);
+    leaving.forEach((link) => {
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", "noreferrer");
     });
   });
 
+  it("keeps the settings link in the app", () => {
+    renderFooter();
+
+    expect(screen.getByRole("link", { name: "Settings" })).not.toHaveAttribute(
+      "target",
+    );
+  });
+
   it("names each link by its text, not the decorative icon beside it", () => {
-    render(<Footer />);
+    renderFooter();
     expect(screen.getByRole("link", { name: "Standings" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "GitHub" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Settings" })).toBeInTheDocument();
   });
 });

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "react-router";
+import { Link } from "react-router";
 import { EmojiEventsIcon, GitHubIcon, SettingsIcon } from "../icon/Icon";
 import "./Footer.scss";
 
@@ -6,13 +6,11 @@ export default function Footer() {
   return (
     <div className="footer">
       {/* The one link here that stays in the app, so a router link rather than
-          an `<a>`: the others leave it, and a reload would cost the loaded week.
-          `NavLink` over `Link` for the `aria-current` it sets on the page it is
-          already on, which the stylesheet draws and a screen reader says. */}
-      <NavLink className="footer__link" to="/settings">
+          an `<a>`: the others leave it, and a reload would cost the loaded week. */}
+      <Link className="footer__link" to="/settings">
         <SettingsIcon />
         Settings
-      </NavLink>
+      </Link>
       |
       <a
         className="footer__link"

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,4 +1,5 @@
-import { EmojiEventsIcon, GitHubIcon } from "../icon/Icon";
+import { Link } from "react-router";
+import { EmojiEventsIcon, GitHubIcon, SettingsIcon } from "../icon/Icon";
 import "./Footer.scss";
 
 export default function Footer() {
@@ -23,6 +24,13 @@ export default function Footer() {
         <GitHubIcon />
         GitHub
       </a>
+      |
+      {/* The one link here that stays in the app, so a `Link` rather than an
+          `<a>`: the others leave it, and a reload would cost the loaded week. */}
+      <Link className="footer__link" to="/settings">
+        <SettingsIcon />
+        Settings
+      </Link>
     </div>
   );
 }

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,16 +1,24 @@
-import { Link } from "react-router";
+import { useState } from "react";
 import { EmojiEventsIcon, GitHubIcon, SettingsIcon } from "../icon/Icon";
+import SettingsDialog from "../settings/SettingsDialog";
 import "./Footer.scss";
 
 export default function Footer() {
+  const [isSettingsOpen, setSettingsOpen] = useState(false);
+
   return (
     <div className="footer">
-      {/* The one link here that stays in the app, so a router link rather than
-          an `<a>`: the others leave it, and a reload would cost the loaded week. */}
-      <Link className="footer__link" to="/settings">
+      {/* The one thing here that goes nowhere, so a button beside two links. The
+          settings open over the page rather than replacing it, which is what the
+          player analysis and the game status do too. */}
+      <button
+        type="button"
+        className="footer__link"
+        onClick={() => setSettingsOpen(true)}
+      >
         <SettingsIcon />
         Settings
-      </Link>
+      </button>
       |
       <a
         className="footer__link"
@@ -31,6 +39,7 @@ export default function Footer() {
         <GitHubIcon />
         GitHub
       </a>
+      <SettingsDialog open={isSettingsOpen} onOpenChange={setSettingsOpen} />
     </div>
   );
 }

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,10 +1,19 @@
-import { Link } from "react-router";
+import { NavLink } from "react-router";
 import { EmojiEventsIcon, GitHubIcon, SettingsIcon } from "../icon/Icon";
 import "./Footer.scss";
 
 export default function Footer() {
   return (
     <div className="footer">
+      {/* The one link here that stays in the app, so a router link rather than
+          an `<a>`: the others leave it, and a reload would cost the loaded week.
+          `NavLink` over `Link` for the `aria-current` it sets on the page it is
+          already on, which the stylesheet draws and a screen reader says. */}
+      <NavLink className="footer__link" to="/settings">
+        <SettingsIcon />
+        Settings
+      </NavLink>
+      |
       <a
         className="footer__link"
         href="https://rakmadness.net/standings-pickem"
@@ -24,13 +33,6 @@ export default function Footer() {
         <GitHubIcon />
         GitHub
       </a>
-      |
-      {/* The one link here that stays in the app, so a `Link` rather than an
-          `<a>`: the others leave it, and a reload would cost the loaded week. */}
-      <Link className="footer__link" to="/settings">
-        <SettingsIcon />
-        Settings
-      </Link>
     </div>
   );
 }

--- a/src/components/gameStatus/GameStatusDialog.tsx
+++ b/src/components/gameStatus/GameStatusDialog.tsx
@@ -188,8 +188,7 @@ export default function GameStatusDialog({
       title="Game Status"
       // Every fetch, a poll of the game already on screen included, so a live game
       // being asked about again is said the way a first fetch is.
-      busy={isFetching}
-      busyLabel="Fetching the game"
+      busy={isFetching && { label: "Fetching the game" }}
       search={
         <DialogCombobox<WeekGame>
           ariaLabel="Game"

--- a/src/components/gameStatus/GameStatusSummary.scss
+++ b/src/components/gameStatus/GameStatusSummary.scss
@@ -236,6 +236,11 @@
 // As big as the three lines of text beside it are tall, which is as much as either
 // can take without the name it stands over having to wrap sooner.
 //
+// Laid in the name's own row rather than across all three. Across them it centers on
+// the grid, whose first row is as tall as the line over the scores rather than as
+// tall as a side's label, which stood the mark above the name, the record block and
+// the glass alike. In this row it is level with all three.
+//
 // Whether there is room for it at all is `useScorelineFit`'s to say, since what it costs
 // the name beside it is what that name is. The last thing that hook gives up, and only
 // where cutting the name to its abbreviation left the two still short. The wireframe
@@ -290,7 +295,7 @@
   text-align: left;
 
   .game-status__logo {
-    grid-row: 1 / 4;
+    grid-row: 2;
     grid-column: 1;
   }
 
@@ -314,7 +319,7 @@
   text-align: right;
 
   .game-status__logo {
-    grid-row: 1 / 4;
+    grid-row: 2;
     grid-column: 5;
   }
 

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -212,6 +212,14 @@ export function PossessionIcon() {
   );
 }
 
+export function SettingsIcon() {
+  return (
+    <Icon name="SettingsIcon">
+      <path d="m370-80-16-128q-13-5-24.5-12T307-235l-119 50L78-375l103-78q-1-7-1-13.5v-27q0-6.5 1-13.5L78-585l110-190 119 50q11-8 23-15t24-12l16-128h220l16 128q13 5 24.5 12t22.5 15l119-50 110 190-103 78q1 7 1 13.5v27q0 6.5-2 13.5l103 78-110 190-118-50q-11 8-23 15t-24 12L590-80H370Zm112-260q58 0 99-41t41-99q0-58-41-99t-99-41q-59 0-99.5 41T342-480q0 58 40.5 99t99.5 41Z" />
+    </Icon>
+  );
+}
+
 export function GitHubIcon() {
   return (
     <Icon name="GitHubIcon" viewBox="0 0 24 24">

--- a/src/components/navbar/CLAUDE.md
+++ b/src/components/navbar/CLAUDE.md
@@ -2,9 +2,9 @@
 
 - `Navbar`: `<header>` with `left`/`right` `ReactNode` slots, solid primary fill.
   Owns the padding and the phone-sized touch target of every button it contains.
-- `ScoresNavbar`: the scoreboard/picks switch plus the refresh a week still being
-  played gets, for the results routes. Clearing `isWeekLive` collapses the refresh
-  button and the divider before it.
+- `ScoresNavbar`: the results routes' scoreboard/picks switch, led by the refresh
+  a live week gets, so the switch keeps its place. Clearing `isWeekLive` collapses
+  refresh and the divider after it.
 - `LogoButton`: `APP_NAME`, which it exports, as a target that goes home. The
   results frame and the home page use it too. The name is set in
   `--rak-font-display` over a dim row of its all-on character, sunk into a well.

--- a/src/components/navbar/ScoresNavbar.scss
+++ b/src/components/navbar/ScoresNavbar.scss
@@ -26,24 +26,26 @@
   background-color: var(--rak-on-solid);
 }
 
-// What a week still being played gets: the refresh button and the divider before
+// What a week still being played gets: the refresh button and the divider after
 // it, collapsed together once the week is decided. A grid column from `1fr` to
 // `0fr` narrows them, because they measure whatever their padding and their icon
 // come to, and `auto` cannot be interpolated.
+// Ahead of the view switch, so those two buttons keep their place on the bar
+// whether or not the week is still live.
 // `--collapse-duration` comes from `ScoresNavbar`, which unmounts this after it.
 .scores-nav__live {
   display: grid;
   grid-template-columns: 1fr;
-  transition-property: grid-template-columns, margin-inline-start, opacity;
+  transition-property: grid-template-columns, margin-inline-end, opacity;
   transition-duration: var(--collapse-duration);
   transition-timing-function: var(--rak-ease-standard);
 
   &.--collapsed {
     grid-template-columns: 0fr;
     opacity: 0;
-    // The navbar's gap sits to the left of this, and would be left behind on its
+    // The navbar's gap sits to the right of this, and would be left behind on its
     // own once the width is gone.
-    margin-inline-start: calc(-1 * var(--navbar-gap));
+    margin-inline-end: calc(-1 * var(--navbar-gap));
 
     // Only while collapsing. Expanded, this would clip the button's focus outline.
     .scores-nav__live-content {
@@ -56,8 +58,8 @@
   display: flex;
   align-items: center;
   // The bar's own gap, so the divider sits as far from the refresh button beside
-  // it as it does from the picks button on its other side, which is `.scores-nav`'s
-  // own gap and not this one.
+  // it as it does from the scoreboard button on its other side, which is
+  // `.scores-nav`'s own gap and not this one.
   gap: var(--navbar-gap);
   // So the column can narrow past what the divider and button measure.
   min-width: 0;

--- a/src/components/navbar/ScoresNavbar.test.tsx
+++ b/src/components/navbar/ScoresNavbar.test.tsx
@@ -30,6 +30,15 @@ describe("ScoresNavbar", () => {
     expect(liveWrapper()).not.toHaveClass("--collapsed");
   });
 
+  it("puts refresh ahead of the switch, so the switch keeps its place", () => {
+    render(<ScoresNavbar {...props} isWeekLive />);
+    const names = Array.from(
+      document.querySelectorAll<HTMLElement>(".scores-nav__button"),
+    ).map((button) => button.getAttribute("aria-label") ?? button.textContent);
+
+    expect(names).toEqual(["Refresh", "Scoreboard", "Picks"]);
+  });
+
   it("marks them collapsed, and keeps them mounted, while they animate out", () => {
     const { rerender } = render(<ScoresNavbar {...props} isWeekLive />);
 

--- a/src/components/navbar/ScoresNavbar.tsx
+++ b/src/components/navbar/ScoresNavbar.tsx
@@ -87,6 +87,35 @@ export default function ScoresNavbar({
     // The two views are the only way through the results, so they are navigation
     // rather than a pair of loose buttons.
     <nav className="scores-nav" aria-label="Results view">
+      {isLiveMounted && (
+        <div
+          className={`scores-nav__live ${isWeekLive ? "" : "--collapsed"}`}
+          style={
+            {
+              "--collapse-duration": `${COLLAPSE_DURATION_MS}ms`,
+            } as CSSProperties
+          }
+          // On its way out it is still painted, so it has to stop being reachable
+          // by pointer, keyboard, and screen reader on its own.
+          inert={!isWeekLive}
+        >
+          <div className="scores-nav__live-content">
+            <Button
+              ariaLabel="Refresh"
+              // Also unavailable mid-refresh, so a second click while one is
+              // already running cannot queue another.
+              ariaDisabled={disabled || isRefreshing}
+              busy={isRefreshing}
+              compact
+              onClick={onRefresh}
+              className="scores-nav__button"
+            >
+              <UpdateIcon />
+            </Button>
+            <div className="scores-nav__divider" />
+          </div>
+        </div>
+      )}
       <ViewButton
         view="Scoreboard"
         icon={<LeaderboardIcon />}
@@ -105,35 +134,6 @@ export default function ScoresNavbar({
         disabled={disabled}
         onViewChange={onViewChange}
       />
-      {isLiveMounted && (
-        <div
-          className={`scores-nav__live ${isWeekLive ? "" : "--collapsed"}`}
-          style={
-            {
-              "--collapse-duration": `${COLLAPSE_DURATION_MS}ms`,
-            } as CSSProperties
-          }
-          // On its way out it is still painted, so it has to stop being reachable
-          // by pointer, keyboard, and screen reader on its own.
-          inert={!isWeekLive}
-        >
-          <div className="scores-nav__live-content">
-            <div className="scores-nav__divider" />
-            <Button
-              ariaLabel="Refresh"
-              // Also unavailable mid-refresh, so a second click while one is
-              // already running cannot queue another.
-              ariaDisabled={disabled || isRefreshing}
-              busy={isRefreshing}
-              compact
-              onClick={onRefresh}
-              className="scores-nav__button"
-            >
-              <UpdateIcon />
-            </Button>
-          </div>
-        </div>
-      )}
     </nav>
   );
 }

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -98,8 +98,7 @@ export default function PlayerAnalysisDialog({
       open={open}
       onOpenChange={onOpenChange}
       title="Player Analysis"
-      busy={isSearching}
-      busyLabel="Working out the paths"
+      busy={isSearching && { label: "Working out the paths" }}
       search={
         <DialogCombobox<PlayerOption>
           ariaLabel="Player"

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -4,7 +4,9 @@ import { PlayerAnalysis } from "../../types/PlayerAnalysis";
 import { RakMadnessScores } from "../../types/RakMadnessScores";
 import getClasses from "../../utils/getClasses";
 import matching from "../../utils/matching";
-import getPlayerAnalysis from "../../utils/scoring/getPlayerAnalysis";
+import getPlayerAnalysis, {
+  getSettledAnalysis,
+} from "../../utils/scoring/getPlayerAnalysis";
 import DialogCombobox from "../dialog/DialogCombobox";
 import DialogShell from "../dialog/DialogShell";
 import PlayerStatusIcon from "../table/playerName/PlayerStatusIcon";
@@ -67,10 +69,20 @@ export default function PlayerAnalysisDialog({
     setQuery(name);
   });
 
+  // The answers the week already holds: a knocked out player, and a week the
+  // knockouts have settled. Both are a walk of the players, so they are read here
+  // rather than waited for below, where the bar used to stand over an answer that
+  // was ready and then grow the dialog under it.
+  const settled = useMemo(() => {
+    if (scores == null || player == null) return undefined;
+    const paths = getSettledAnalysis(scores, player.name);
+    return paths == null ? undefined : { scores, name: player.name, paths };
+  }, [scores, player]);
+
   // The search is thousands of scenarios and holds the thread while it runs, so
   // it waits for the bar that says so to paint first.
   useEffect(() => {
-    if (scores == null || player == null) return;
+    if (scores == null || player == null || settled != null) return;
     let timer = 0;
     const frame = requestAnimationFrame(() => {
       timer = window.setTimeout(() =>
@@ -85,12 +97,13 @@ export default function PlayerAnalysisDialog({
       cancelAnimationFrame(frame);
       window.clearTimeout(timer);
     };
-  }, [scores, player]);
+  }, [scores, player, settled]);
 
   // The answer already on screen stays there while the next one is worked out, so
   // moving between players reads as one answer replacing another rather than as the
   // dialog emptying and filling again. Only a rescore takes it away.
-  const shown = found?.scores === scores ? found : undefined;
+  const searched = found?.scores === scores ? found : undefined;
+  const shown = settled ?? searched;
   const isSearching = player != null && shown?.name !== player.name;
 
   return (

--- a/src/components/results/ResultsFrame.tsx
+++ b/src/components/results/ResultsFrame.tsx
@@ -5,6 +5,7 @@ import { GameStatusContextProvider } from "../../context/GameStatusContext";
 import { PlayerAnalysisContextProvider } from "../../context/PlayerAnalysisContext";
 import { WeekInfo } from "../../types/League";
 import { RakMadnessScores } from "../../types/RakMadnessScores";
+import doNothing from "../../utils/doNothing";
 import getClasses from "../../utils/getClasses";
 import GameStatusDialog from "../gameStatus/GameStatusDialog";
 import LogoButton, { APP_NAME } from "../navbar/LogoButton";
@@ -13,8 +14,6 @@ import PageLayout from "../pageLayout/PageLayout";
 import PlayerAnalysisDialog from "../playerAnalysis/PlayerAnalysisDialog";
 import SkeletonTable from "../table/SkeletonTable";
 import "./ResultsFrame.scss";
-
-const doNothing = () => undefined;
 
 /** The pool the app scores, which is not the app's own name. */
 const POOL_NAME = "Rak Madness";

--- a/src/components/settings/CLAUDE.md
+++ b/src/components/settings/CLAUDE.md
@@ -1,8 +1,10 @@
 # settings
 
 `SettingsPage`: the `/settings` route, reached from the home page footer. Two
-sections. Appearance is three `Button`s with `selected`, the navbar's own
-switch idiom, over `SettingsContext`. Your name is an `lcd-field` text input
-whose value marks that player's row in both tables.
+sections. Theme is three `Button`s with `selected`, the navbar's own
+switch idiom, over `SettingsContext`. Your Player Name is an `lcd-field` shell
+holding a text input and a clear button. Its value marks that player's row in
+both tables.
 
-`SettingsPage.scss`: the column, its labels, and the field's well.
+`SettingsPage.scss`: the column, its labels, and the well the field and its
+clear button share. The well takes the focus ring, not the input.

--- a/src/components/settings/CLAUDE.md
+++ b/src/components/settings/CLAUDE.md
@@ -1,7 +1,8 @@
 # settings
 
-`SettingsPage`: the `/settings` route, reached from the home page footer. Two
-sections. Theme is three `Button`s with `selected`, the navbar's own
+`SettingsPage`: the `/settings` route, reached from the home page footer, which
+is the only page drawing that footer. A close button in the navbar leaves. Two
+sections under a `Settings` heading. Theme is three `Button`s with `selected`, the navbar's own
 switch idiom, over `SettingsContext`. Your Player Name is an `lcd-field` shell
 holding a text input and a clear button. Its value marks that player's row in
 both tables.

--- a/src/components/settings/CLAUDE.md
+++ b/src/components/settings/CLAUDE.md
@@ -1,11 +1,11 @@
 # settings
 
-`SettingsPage`: the `/settings` route, reached from the home page footer, which
-is the only page drawing that footer. A close button in the navbar leaves. Two
-sections under a `Settings` heading. Theme is three `Button`s with `selected`, the navbar's own
-switch idiom, over `SettingsContext`. Your Player Name is an `lcd-field` shell
-holding a text input and a clear button. Its value marks that player's row in
-both tables.
+`SettingsDialog`: the theme and the reader's own name, in the `DialogShell` the
+player analysis and the game status use. Opened from the home page footer, which
+is the only thing that opens it. Theme is three `Button`s with `selected`, the
+navbar's own switch idiom, over `SettingsContext`. Your Player Name is an
+`lcd-field` shell holding a text input and a clear button. Its value marks that
+player's row in both tables.
 
-`SettingsPage.scss`: the column, its labels, and the well the field and its
+`SettingsDialog.scss`: the column, its labels, and the well the field and its
 clear button share. The well takes the focus ring, not the input.

--- a/src/components/settings/CLAUDE.md
+++ b/src/components/settings/CLAUDE.md
@@ -1,0 +1,8 @@
+# settings
+
+`SettingsPage`: the `/settings` route, reached from the home page footer. Two
+sections. Appearance is three `Button`s with `selected`, the navbar's own
+switch idiom, over `SettingsContext`. Your name is an `lcd-field` text input
+whose value marks that player's row in both tables.
+
+`SettingsPage.scss`: the column, its labels, and the field's well.

--- a/src/components/settings/CLAUDE.md
+++ b/src/components/settings/CLAUDE.md
@@ -2,10 +2,10 @@
 
 `SettingsDialog`: the theme and the reader's own name, in the `DialogShell` the
 player analysis and the game status use. Opened from the home page footer, which
-is the only thing that opens it. Theme is three `Button`s with `selected`, the
-navbar's own switch idiom, over `SettingsContext`. Your Player Name is an
-`lcd-field` shell holding a text input and a clear button. Its value marks that
-player's row in both tables.
+is the only thing that opens it. Your Player Name comes first: an `lcd-field`
+shell holding a text input and a clear button, whose value marks that player's
+row in both tables. Theme is three `Button`s with `selected`, the navbar's own
+switch idiom. Both go through `SettingsContext`.
 
 `SettingsDialog.scss`: the column, its labels, and the well the field and its
 clear button share. The well takes the focus ring, not the input.

--- a/src/components/settings/SettingsDialog.scss
+++ b/src/components/settings/SettingsDialog.scss
@@ -71,8 +71,11 @@
     outline: none;
   }
 
+  // The quiet ink, not `--rak-unlit`. That token is a combobox cell that could
+  // light, deliberately faint at 1.31:1 on this well, and a hint a reader is
+  // meant to read is text rather than a shape. This clears 6:1 in both modes.
   &::placeholder {
-    color: var(--rak-unlit);
+    color: var(--rak-text-tertiary);
   }
 }
 

--- a/src/components/settings/SettingsDialog.scss
+++ b/src/components/settings/SettingsDialog.scss
@@ -3,11 +3,14 @@
 @use "../../styles/lcd" as *;
 
 // The dialog body owns the padding around this and the width it stands in, so this
-// is the column and the air between its sections and nothing else.
+// is the column, the air between its sections, and the room a focus ring needs.
+// That last is here rather than on the body: the body's own progress bar spans the
+// rule above it, and padding there would hold the bar off both ends of it.
 .settings {
   display: flex;
   flex-direction: column;
   gap: var(--rak-space-6);
+  padding-inline: $focus-ring-reach;
 }
 
 .settings__section {

--- a/src/components/settings/SettingsDialog.scss
+++ b/src/components/settings/SettingsDialog.scss
@@ -2,22 +2,12 @@
 @use "../../styles/label" as *;
 @use "../../styles/lcd" as *;
 
+// The dialog body owns the padding around this and the width it stands in, so this
+// is the column and the air between its sections and nothing else.
 .settings {
   display: flex;
   flex-direction: column;
-  width: min(340px, 100%);
-  padding: var(--rak-space-4);
   gap: var(--rak-space-6);
-}
-
-// The page's own name, since `PageLayout` hides its `<h1>` and this route draws no
-// table to say what it is. Set the way a dialog sets its title, which is the
-// only other heading the app draws.
-.settings__title {
-  margin: 0;
-  color: var(--rak-text);
-  font-size: var(--rak-text-lg);
-  font-weight: 700;
 }
 
 .settings__section {

--- a/src/components/settings/SettingsDialog.test.tsx
+++ b/src/components/settings/SettingsDialog.test.tsx
@@ -110,6 +110,18 @@ describe("SettingsDialog, the reader's own name", () => {
     expect(localStorage.getItem(PLAYER_NAME_KEY)).toBeNull();
   });
 
+  it("keeps the focus in the field it just emptied", async () => {
+    localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
+    const user = mountDialog();
+    await user.click(
+      screen.getByRole("button", { name: "Clear your player name" }),
+    );
+
+    // The button unmounts on the same click, so without this the focus lands on
+    // `<body>` and the next tab restarts from the top of the document.
+    expect(screen.getByLabelText("Your Player Name")).toHaveFocus();
+  });
+
   it("offers nothing to clear while the field is empty", () => {
     mountDialog();
 

--- a/src/components/settings/SettingsDialog.test.tsx
+++ b/src/components/settings/SettingsDialog.test.tsx
@@ -22,6 +22,15 @@ beforeEach(() => {
 });
 
 describe("SettingsDialog", () => {
+  it("asks for the name first, then the theme", () => {
+    mountDialog();
+    const headings = screen
+      .getAllByRole("heading", { level: 3 })
+      .map((heading) => heading.textContent);
+
+    expect(headings).toEqual(["Your Player Name", "Theme"]);
+  });
+
   it("closes from the shell's own close button", async () => {
     const onOpenChange = vi.fn();
     const user = mountDialog(onOpenChange);

--- a/src/components/settings/SettingsDialog.test.tsx
+++ b/src/components/settings/SettingsDialog.test.tsx
@@ -1,20 +1,17 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router";
 import { SettingsContextProvider } from "../../context/SettingsContext";
-import SettingsPage from "./SettingsPage";
+import SettingsDialog from "./SettingsDialog";
 
 const THEME_KEY = "rak-madness:settings:theme";
 const PLAYER_NAME_KEY = "rak-madness:settings:playerName";
 
-function mountPage() {
+function mountDialog(onOpenChange = () => undefined) {
   const user = userEvent.setup();
   render(
-    <MemoryRouter>
-      <SettingsContextProvider>
-        <SettingsPage />
-      </SettingsContextProvider>
-    </MemoryRouter>,
+    <SettingsContextProvider>
+      <SettingsDialog open onOpenChange={onOpenChange} />
+    </SettingsContextProvider>,
   );
   return user;
 }
@@ -24,36 +21,19 @@ beforeEach(() => {
   delete document.documentElement.dataset.theme;
 });
 
-describe("SettingsPage, the page itself", () => {
-  it("names itself above the settings", () => {
-    mountPage();
+describe("SettingsDialog", () => {
+  it("closes from the shell's own close button", async () => {
+    const onOpenChange = vi.fn();
+    const user = mountDialog(onOpenChange);
+    await user.click(screen.getByRole("button", { name: "Close" }));
 
-    expect(
-      screen.getByRole("heading", { level: 2, name: "Settings" }),
-    ).toBeInTheDocument();
-  });
-
-  it("leaves for the home page from the close button", async () => {
-    const user = userEvent.setup();
-    render(
-      <MemoryRouter initialEntries={["/settings"]}>
-        <SettingsContextProvider>
-          <Routes>
-            <Route path="/settings" element={<SettingsPage />} />
-            <Route path="/" element={<p>Home</p>} />
-          </Routes>
-        </SettingsContextProvider>
-      </MemoryRouter>,
-    );
-    await user.click(screen.getByRole("button", { name: "Close settings" }));
-
-    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });
 
-describe("SettingsPage, the theme", () => {
+describe("SettingsDialog, the theme", () => {
   it("offers auto, dark, and light, in that order", () => {
-    mountPage();
+    mountDialog();
     const labels = screen
       .getAllByRole("button")
       .filter((button) => button.classList.contains("settings__choice"))
@@ -63,7 +43,7 @@ describe("SettingsPage, the theme", () => {
   });
 
   it("starts on auto", () => {
-    mountPage();
+    mountDialog();
 
     expect(screen.getByRole("button", { name: "Auto" })).toHaveAttribute(
       "aria-pressed",
@@ -72,7 +52,7 @@ describe("SettingsPage, the theme", () => {
   });
 
   it("saves the theme that was clicked, and shows it as chosen", async () => {
-    const user = mountPage();
+    const user = mountDialog();
     await user.click(screen.getByRole("button", { name: "Dark" }));
 
     expect(screen.getByRole("button", { name: "Dark" })).toHaveAttribute(
@@ -87,9 +67,9 @@ describe("SettingsPage, the theme", () => {
   });
 });
 
-describe("SettingsPage, the reader's own name", () => {
+describe("SettingsDialog, the reader's own name", () => {
   it("saves what is typed", async () => {
-    const user = mountPage();
+    const user = mountDialog();
     await user.type(screen.getByLabelText("Your Player Name"), "Linebacher");
 
     expect(localStorage.getItem(PLAYER_NAME_KEY)).toBe("Linebacher");
@@ -97,14 +77,14 @@ describe("SettingsPage, the reader's own name", () => {
 
   it("shows the name already saved", () => {
     localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
-    mountPage();
+    mountDialog();
 
     expect(screen.getByLabelText("Your Player Name")).toHaveValue("Linebacher");
   });
 
   it("forgets the name once the field is cleared", async () => {
     localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
-    const user = mountPage();
+    const user = mountDialog();
     await user.clear(screen.getByLabelText("Your Player Name"));
 
     expect(localStorage.getItem(PLAYER_NAME_KEY)).toBeNull();
@@ -112,7 +92,7 @@ describe("SettingsPage, the reader's own name", () => {
 
   it("empties the field from the clear button", async () => {
     localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
-    const user = mountPage();
+    const user = mountDialog();
     await user.click(
       screen.getByRole("button", { name: "Clear your player name" }),
     );
@@ -122,7 +102,7 @@ describe("SettingsPage, the reader's own name", () => {
   });
 
   it("offers nothing to clear while the field is empty", () => {
-    mountPage();
+    mountDialog();
 
     expect(
       screen.queryByRole("button", { name: "Clear your player name" }),

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import { useId, useRef } from "react";
 import { Theme, useSettings } from "../../context/SettingsContext";
 import Button from "../button/Button";
 import DialogShell from "../dialog/DialogShell";
@@ -24,6 +24,7 @@ export default function SettingsDialog({
   const { theme, setTheme, playerName, setPlayerName } = useSettings();
   const themeLabelId = useId();
   const nameInputId = useId();
+  const nameInput = useRef<HTMLInputElement>(null);
 
   return (
     <DialogShell open={open} onOpenChange={onOpenChange} title="Settings">
@@ -37,6 +38,7 @@ export default function SettingsDialog({
               hold their chevron. */}
           <div className="settings__field">
             <input
+              ref={nameInput}
               id={nameInputId}
               className="settings__field-input"
               type="text"
@@ -47,13 +49,19 @@ export default function SettingsDialog({
               onChange={(event) => setPlayerName(event.target.value)}
             />
             {/* Nothing to clear while the field is empty, and a button that does
-                nothing is one more thing to tab past. */}
+                nothing is one more thing to tab past. Clearing therefore takes
+                this button off screen, so the focus on it has to go somewhere
+                first: left alone it falls to `<body>`, and the next tab restarts
+                from the top of the document with the dialog still open. */}
             {playerName !== "" && (
               <button
                 type="button"
                 className="settings__field-clear"
                 aria-label="Clear your player name"
-                onClick={() => setPlayerName("")}
+                onClick={() => {
+                  nameInput.current?.focus();
+                  setPlayerName("");
+                }}
               >
                 <CloseIcon />
               </button>

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -1,11 +1,9 @@
 import { useId } from "react";
-import { useNavigate } from "react-router";
 import { Theme, useSettings } from "../../context/SettingsContext";
 import Button from "../button/Button";
+import DialogShell from "../dialog/DialogShell";
 import { CloseIcon } from "../icon/Icon";
-import LogoButton, { APP_NAME } from "../navbar/LogoButton";
-import PageLayout from "../pageLayout/PageLayout";
-import "./SettingsPage.scss";
+import "./SettingsDialog.scss";
 
 // Alphabetical, so the row has an order a reader can predict rather than one that
 // ranks the choices.
@@ -15,31 +13,21 @@ const THEMES: Array<{ value: Theme; label: string }> = [
   { value: "light", label: "Light" },
 ];
 
-/** The `/settings` route: how the app looks, and who the reader is. */
-export default function SettingsPage() {
-  const navigate = useNavigate();
+/** How the app looks, and who the reader is. */
+export default function SettingsDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
   const { theme, setTheme, playerName, setPlayerName } = useSettings();
   const themeLabelId = useId();
   const nameInputId = useId();
 
   return (
-    <PageLayout
-      title={`${APP_NAME} Settings`}
-      navbarLeft={<LogoButton onClick={() => navigate("/")} />}
-      /* The way out. The logo goes home from every page, but nothing on this one
-         says so, and a page of preferences reads as something a reader closes. */
-      navbarRight={
-        <Button
-          iconOnly
-          ariaLabel="Close settings"
-          onClick={() => navigate("/")}
-        >
-          <CloseIcon />
-        </Button>
-      }
-    >
+    <DialogShell open={open} onOpenChange={onOpenChange} title="Settings">
       <div className="settings">
-        <h2 className="settings__title">Settings</h2>
         <section className="settings__section">
           <h3 className="settings__label" id={themeLabelId}>
             Theme
@@ -106,6 +94,6 @@ export default function SettingsPage() {
           </p>
         </section>
       </div>
-    </PageLayout>
+    </DialogShell>
   );
 }

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -29,36 +29,6 @@ export default function SettingsDialog({
     <DialogShell open={open} onOpenChange={onOpenChange} title="Settings">
       <div className="settings">
         <section className="settings__section">
-          <h3 className="settings__label" id={themeLabelId}>
-            Theme
-          </h3>
-          {/* Buttons that show which one is chosen, the same shape the navbar's
-              own view switch is. Not a `radiogroup`, which wants `aria-checked`
-              where `Button` gives `aria-pressed`. Named by the heading above it
-              rather than by a label of its own, which would say `Theme` twice. */}
-          <div
-            className="settings__choices"
-            role="group"
-            aria-labelledby={themeLabelId}
-          >
-            {THEMES.map(({ value, label }) => (
-              <Button
-                key={value}
-                compact
-                selected={theme === value}
-                onClick={() => setTheme(value)}
-                className="settings__choice"
-              >
-                {label}
-              </Button>
-            ))}
-          </div>
-          <p className="settings__hint">
-            Auto mode honors your device settings.
-          </p>
-        </section>
-
-        <section className="settings__section">
           <h3 className="settings__label">
             <label htmlFor={nameInputId}>Your Player Name</label>
           </h3>
@@ -91,6 +61,36 @@ export default function SettingsDialog({
           </div>
           <p className="settings__hint">
             Your row is marked in the scoreboard and picks tables.
+          </p>
+        </section>
+
+        <section className="settings__section">
+          <h3 className="settings__label" id={themeLabelId}>
+            Theme
+          </h3>
+          {/* Buttons that show which one is chosen, the same shape the navbar's
+              own view switch is. Not a `radiogroup`, which wants `aria-checked`
+              where `Button` gives `aria-pressed`. Named by the heading above it
+              rather than by a label of its own, which would say `Theme` twice. */}
+          <div
+            className="settings__choices"
+            role="group"
+            aria-labelledby={themeLabelId}
+          >
+            {THEMES.map(({ value, label }) => (
+              <Button
+                key={value}
+                compact
+                selected={theme === value}
+                onClick={() => setTheme(value)}
+                className="settings__choice"
+              >
+                {label}
+              </Button>
+            ))}
+          </div>
+          <p className="settings__hint">
+            Auto mode honors your device settings.
           </p>
         </section>
       </div>

--- a/src/components/settings/SettingsPage.scss
+++ b/src/components/settings/SettingsPage.scss
@@ -1,0 +1,59 @@
+@use "../../styles/focus" as *;
+@use "../../styles/label" as *;
+@use "../../styles/lcd" as *;
+
+.settings {
+  display: flex;
+  flex-direction: column;
+  width: min(340px, 100%);
+  padding: var(--rak-space-4);
+  gap: var(--rak-space-6);
+}
+
+.settings__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--rak-space-2);
+}
+
+.settings__label {
+  @include micro-label;
+
+  margin: 0;
+  font-size: var(--rak-text-sm);
+  color: var(--rak-text-secondary);
+}
+
+.settings__choices {
+  display: flex;
+  flex-direction: row;
+  gap: var(--rak-space-2);
+}
+
+.settings__choice {
+  // Even thirds, so which one is chosen is the only thing telling them apart.
+  flex: 1 1 0;
+}
+
+.settings__field {
+  @include lcd-field;
+  @include focus-ring;
+
+  min-height: var(--rak-touch-target);
+  padding-inline: var(--rak-space-3);
+  // The face the tables set a player's name in, so what is typed here looks like
+  // what it has to match.
+  font-family: var(--rak-font-mono);
+  font-size: var(--rak-text-md);
+  line-height: var(--rak-line-height);
+
+  &::placeholder {
+    color: var(--rak-unlit);
+  }
+}
+
+.settings__hint {
+  margin: 0;
+  font-size: var(--rak-text-sm);
+  color: var(--rak-text-tertiary);
+}

--- a/src/components/settings/SettingsPage.scss
+++ b/src/components/settings/SettingsPage.scss
@@ -10,8 +10,8 @@
   gap: var(--rak-space-6);
 }
 
-// The page's own name, since `PageLayout` hides its `<h1>` and every other route
-// says what it is with a table. Set the way a dialog sets its title, which is the
+// The page's own name, since `PageLayout` hides its `<h1>` and this route draws no
+// table to say what it is. Set the way a dialog sets its title, which is the
 // only other heading the app draws.
 .settings__title {
   margin: 0;

--- a/src/components/settings/SettingsPage.scss
+++ b/src/components/settings/SettingsPage.scss
@@ -10,6 +10,16 @@
   gap: var(--rak-space-6);
 }
 
+// The page's own name, since `PageLayout` hides its `<h1>` and every other route
+// says what it is with a table. Set the way a dialog sets its title, which is the
+// only other heading the app draws.
+.settings__title {
+  margin: 0;
+  color: var(--rak-text);
+  font-size: var(--rak-text-lg);
+  font-weight: 700;
+}
+
 .settings__section {
   display: flex;
   flex-direction: column;

--- a/src/components/settings/SettingsPage.scss
+++ b/src/components/settings/SettingsPage.scss
@@ -86,15 +86,16 @@
   }
 }
 
-// Lit chrome rather than muted UI, which is what the selects set their chevron in
-// too. Square and as tall as the well, so the whole bay is inside the hit area.
+// The bay the home page's selects give their chevron, down to the side padding
+// that sets the glyph off the edge of the glass. Lit chrome rather than muted UI,
+// and as tall as the well, so the whole bay is inside the hit area.
 .settings__field-clear {
   display: flex;
   align-items: center;
   justify-content: center;
   align-self: stretch;
-  aspect-ratio: 1;
-  padding: 0;
+  padding-block: 0;
+  padding-inline: var(--rak-space-2);
   border: none;
   background: none;
   color: var(--rak-on-solid);

--- a/src/components/settings/SettingsPage.scss
+++ b/src/components/settings/SettingsPage.scss
@@ -35,21 +35,60 @@
   flex: 1 1 0;
 }
 
+// The well the name is typed into. The shell rather than the input itself, so the
+// clear button stands inside it: `lcd-field` resets an `<input>` and a `<button>`
+// alike, and a ring around the shell is what the mixin's own `$on` is for.
 .settings__field {
   @include lcd-field;
-  @include focus-ring;
+  @include focus-ring(":focus-within");
 
+  display: flex;
+  align-items: center;
   min-height: var(--rak-touch-target);
-  padding-inline: var(--rak-space-3);
+  // None on the trailing edge: the clear button has a bay of its own there, the
+  // same shape the home page's selects give their chevron.
+  padding-inline: var(--rak-space-3) 0;
+}
+
+.settings__field-input {
+  flex: 1;
+  // Without this a long name widens the well past the column instead of scrolling
+  // inside it, since a flex item's floor is the content it holds.
+  min-width: 0;
+  align-self: stretch;
+  appearance: none;
+  border: none;
+  background: none;
+  color: inherit;
   // The face the tables set a player's name in, so what is typed here looks like
   // what it has to match.
   font-family: var(--rak-font-mono);
   font-size: var(--rak-text-md);
   line-height: var(--rak-line-height);
 
+  // The shell draws the one ring, so the input inside it draws none of its own.
+  &:focus {
+    outline: none;
+  }
+
   &::placeholder {
     color: var(--rak-unlit);
   }
+}
+
+// Lit chrome rather than muted UI, which is what the selects set their chevron in
+// too. Square and as tall as the well, so the whole bay is inside the hit area.
+.settings__field-clear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  aspect-ratio: 1;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--rak-on-solid);
+  cursor: pointer;
 }
 
 .settings__hint {

--- a/src/components/settings/SettingsPage.test.tsx
+++ b/src/components/settings/SettingsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { SettingsContextProvider } from "../../context/SettingsContext";
 import SettingsPage from "./SettingsPage";
 
@@ -24,14 +24,42 @@ beforeEach(() => {
   delete document.documentElement.dataset.theme;
 });
 
-describe("SettingsPage, the theme", () => {
-  it("offers a light, a dark, and an auto", () => {
+describe("SettingsPage, the page itself", () => {
+  it("names itself above the settings", () => {
     mountPage();
-    const themes = screen.getByRole("group", { name: "Theme" });
 
-    expect(themes).toHaveTextContent("Light");
-    expect(themes).toHaveTextContent("Dark");
-    expect(themes).toHaveTextContent("Auto");
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Settings" }),
+    ).toBeInTheDocument();
+  });
+
+  it("leaves for the home page from the close button", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/settings"]}>
+        <SettingsContextProvider>
+          <Routes>
+            <Route path="/settings" element={<SettingsPage />} />
+            <Route path="/" element={<p>Home</p>} />
+          </Routes>
+        </SettingsContextProvider>
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByRole("button", { name: "Close settings" }));
+
+    expect(screen.getByText("Home")).toBeInTheDocument();
+  });
+});
+
+describe("SettingsPage, the theme", () => {
+  it("offers auto, dark, and light, in that order", () => {
+    mountPage();
+    const labels = screen
+      .getAllByRole("button")
+      .filter((button) => button.classList.contains("settings__choice"))
+      .map((button) => button.textContent);
+
+    expect(labels).toEqual(["Auto", "Dark", "Light"]);
   });
 
   it("starts on auto", () => {

--- a/src/components/settings/SettingsPage.test.tsx
+++ b/src/components/settings/SettingsPage.test.tsx
@@ -62,7 +62,7 @@ describe("SettingsPage, the theme", () => {
 describe("SettingsPage, the reader's own name", () => {
   it("saves what is typed", async () => {
     const user = mountPage();
-    await user.type(screen.getByLabelText("Your name"), "Linebacher");
+    await user.type(screen.getByLabelText("Your Player Name"), "Linebacher");
 
     expect(localStorage.getItem(PLAYER_NAME_KEY)).toBe("Linebacher");
   });
@@ -71,14 +71,33 @@ describe("SettingsPage, the reader's own name", () => {
     localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
     mountPage();
 
-    expect(screen.getByLabelText("Your name")).toHaveValue("Linebacher");
+    expect(screen.getByLabelText("Your Player Name")).toHaveValue("Linebacher");
   });
 
   it("forgets the name once the field is cleared", async () => {
     localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
     const user = mountPage();
-    await user.clear(screen.getByLabelText("Your name"));
+    await user.clear(screen.getByLabelText("Your Player Name"));
 
     expect(localStorage.getItem(PLAYER_NAME_KEY)).toBeNull();
+  });
+
+  it("empties the field from the clear button", async () => {
+    localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
+    const user = mountPage();
+    await user.click(
+      screen.getByRole("button", { name: "Clear your player name" }),
+    );
+
+    expect(screen.getByLabelText("Your Player Name")).toHaveValue("");
+    expect(localStorage.getItem(PLAYER_NAME_KEY)).toBeNull();
+  });
+
+  it("offers nothing to clear while the field is empty", () => {
+    mountPage();
+
+    expect(
+      screen.queryByRole("button", { name: "Clear your player name" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/settings/SettingsPage.test.tsx
+++ b/src/components/settings/SettingsPage.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { SettingsContextProvider } from "../../context/SettingsContext";
+import SettingsPage from "./SettingsPage";
+
+const THEME_KEY = "rak-madness:settings:theme";
+const PLAYER_NAME_KEY = "rak-madness:settings:playerName";
+
+function mountPage() {
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <SettingsContextProvider>
+        <SettingsPage />
+      </SettingsContextProvider>
+    </MemoryRouter>,
+  );
+  return user;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  delete document.documentElement.dataset.theme;
+});
+
+describe("SettingsPage, the theme", () => {
+  it("offers a light, a dark, and an auto", () => {
+    mountPage();
+    const themes = screen.getByRole("group", { name: "Theme" });
+
+    expect(themes).toHaveTextContent("Light");
+    expect(themes).toHaveTextContent("Dark");
+    expect(themes).toHaveTextContent("Auto");
+  });
+
+  it("starts on auto", () => {
+    mountPage();
+
+    expect(screen.getByRole("button", { name: "Auto" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("saves the theme that was clicked, and shows it as chosen", async () => {
+    const user = mountPage();
+    await user.click(screen.getByRole("button", { name: "Dark" }));
+
+    expect(screen.getByRole("button", { name: "Dark" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Auto" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(localStorage.getItem(THEME_KEY)).toBe("dark");
+  });
+});
+
+describe("SettingsPage, the reader's own name", () => {
+  it("saves what is typed", async () => {
+    const user = mountPage();
+    await user.type(screen.getByLabelText("Your name"), "Linebacher");
+
+    expect(localStorage.getItem(PLAYER_NAME_KEY)).toBe("Linebacher");
+  });
+
+  it("shows the name already saved", () => {
+    localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
+    mountPage();
+
+    expect(screen.getByLabelText("Your name")).toHaveValue("Linebacher");
+  });
+
+  it("forgets the name once the field is cleared", async () => {
+    localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
+    const user = mountPage();
+    await user.clear(screen.getByLabelText("Your name"));
+
+    expect(localStorage.getItem(PLAYER_NAME_KEY)).toBeNull();
+  });
+});

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useId } from "react";
 import { useNavigate } from "react-router";
 import { Theme, useSettings } from "../../context/SettingsContext";
 import Button from "../button/Button";
+import { CloseIcon } from "../icon/Icon";
 import Footer from "../footer/Footer";
 import LogoButton, { APP_NAME } from "../navbar/LogoButton";
 import PageLayout from "../pageLayout/PageLayout";
@@ -17,6 +18,7 @@ const THEMES: Array<{ value: Theme; label: string }> = [
 export default function SettingsPage() {
   const navigate = useNavigate();
   const { theme, setTheme, playerName, setPlayerName } = useSettings();
+  const themeLabelId = useId();
   const nameInputId = useId();
 
   return (
@@ -26,11 +28,18 @@ export default function SettingsPage() {
     >
       <div className="settings">
         <section className="settings__section">
-          <h2 className="settings__label">Appearance</h2>
+          <h2 className="settings__label" id={themeLabelId}>
+            Theme
+          </h2>
           {/* Buttons that show which one is chosen, the same shape the navbar's
               own view switch is. Not a `radiogroup`, which wants `aria-checked`
-              where `Button` gives `aria-pressed`. */}
-          <div className="settings__choices" role="group" aria-label="Theme">
+              where `Button` gives `aria-pressed`. Named by the heading above it
+              rather than by a label of its own, which would say `Theme` twice. */}
+          <div
+            className="settings__choices"
+            role="group"
+            aria-labelledby={themeLabelId}
+          >
             {THEMES.map(({ value, label }) => (
               <Button
                 key={value}
@@ -50,18 +59,35 @@ export default function SettingsPage() {
 
         <section className="settings__section">
           <h2 className="settings__label">
-            <label htmlFor={nameInputId}>Your name</label>
+            <label htmlFor={nameInputId}>Your Player Name</label>
           </h2>
-          <input
-            id={nameInputId}
-            className="settings__field"
-            type="text"
-            autoComplete="off"
-            spellCheck={false}
-            placeholder="As it appears in the picks"
-            value={playerName}
-            onChange={(event) => setPlayerName(event.target.value)}
-          />
+          {/* The well is the shell rather than the input, so the clear button
+              sits inside it in a bay of its own, the way the home page's selects
+              hold their chevron. */}
+          <div className="settings__field">
+            <input
+              id={nameInputId}
+              className="settings__field-input"
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="As it appears in the picks"
+              value={playerName}
+              onChange={(event) => setPlayerName(event.target.value)}
+            />
+            {/* Nothing to clear while the field is empty, and a button that does
+                nothing is one more thing to tab past. */}
+            {playerName !== "" && (
+              <button
+                type="button"
+                className="settings__field-clear"
+                aria-label="Clear your player name"
+                onClick={() => setPlayerName("")}
+              >
+                <CloseIcon />
+              </button>
+            )}
+          </div>
           <p className="settings__hint">
             Your row is marked in the scoreboard and the picks. Leave this empty
             to mark nothing.

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router";
 import { Theme, useSettings } from "../../context/SettingsContext";
 import Button from "../button/Button";
 import { CloseIcon } from "../icon/Icon";
-import Footer from "../footer/Footer";
 import LogoButton, { APP_NAME } from "../navbar/LogoButton";
 import PageLayout from "../pageLayout/PageLayout";
 import "./SettingsPage.scss";
@@ -108,8 +107,6 @@ export default function SettingsPage() {
           </p>
         </section>
       </div>
-
-      <Footer />
     </PageLayout>
   );
 }

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -66,7 +66,7 @@ export default function SettingsPage() {
             ))}
           </div>
           <p className="settings__hint">
-            Auto follows whatever your device is set to.
+            Auto mode honors your device settings.
           </p>
         </section>
 

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -102,8 +102,7 @@ export default function SettingsPage() {
             )}
           </div>
           <p className="settings__hint">
-            Your row is marked in the scoreboard and the picks. Leave this empty
-            to mark nothing.
+            Your row is marked in the scoreboard and picks tables.
           </p>
         </section>
       </div>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -8,10 +8,12 @@ import LogoButton, { APP_NAME } from "../navbar/LogoButton";
 import PageLayout from "../pageLayout/PageLayout";
 import "./SettingsPage.scss";
 
+// Alphabetical, so the row has an order a reader can predict rather than one that
+// ranks the choices.
 const THEMES: Array<{ value: Theme; label: string }> = [
-  { value: "light", label: "Light" },
-  { value: "dark", label: "Dark" },
   { value: "auto", label: "Auto" },
+  { value: "dark", label: "Dark" },
+  { value: "light", label: "Light" },
 ];
 
 /** The `/settings` route: how the app looks, and who the reader is. */
@@ -25,12 +27,24 @@ export default function SettingsPage() {
     <PageLayout
       title={`${APP_NAME} Settings`}
       navbarLeft={<LogoButton onClick={() => navigate("/")} />}
+      /* The way out. The logo goes home from every page, but nothing on this one
+         says so, and a page of preferences reads as something a reader closes. */
+      navbarRight={
+        <Button
+          iconOnly
+          ariaLabel="Close settings"
+          onClick={() => navigate("/")}
+        >
+          <CloseIcon />
+        </Button>
+      }
     >
       <div className="settings">
+        <h2 className="settings__title">Settings</h2>
         <section className="settings__section">
-          <h2 className="settings__label" id={themeLabelId}>
+          <h3 className="settings__label" id={themeLabelId}>
             Theme
-          </h2>
+          </h3>
           {/* Buttons that show which one is chosen, the same shape the navbar's
               own view switch is. Not a `radiogroup`, which wants `aria-checked`
               where `Button` gives `aria-pressed`. Named by the heading above it
@@ -58,9 +72,9 @@ export default function SettingsPage() {
         </section>
 
         <section className="settings__section">
-          <h2 className="settings__label">
+          <h3 className="settings__label">
             <label htmlFor={nameInputId}>Your Player Name</label>
-          </h2>
+          </h3>
           {/* The well is the shell rather than the input, so the clear button
               sits inside it in a bay of its own, the way the home page's selects
               hold their chevron. */}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,0 +1,75 @@
+import { useId } from "react";
+import { useNavigate } from "react-router";
+import { Theme, useSettings } from "../../context/SettingsContext";
+import Button from "../button/Button";
+import Footer from "../footer/Footer";
+import LogoButton, { APP_NAME } from "../navbar/LogoButton";
+import PageLayout from "../pageLayout/PageLayout";
+import "./SettingsPage.scss";
+
+const THEMES: Array<{ value: Theme; label: string }> = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "auto", label: "Auto" },
+];
+
+/** The `/settings` route: how the app looks, and who the reader is. */
+export default function SettingsPage() {
+  const navigate = useNavigate();
+  const { theme, setTheme, playerName, setPlayerName } = useSettings();
+  const nameInputId = useId();
+
+  return (
+    <PageLayout
+      title={`${APP_NAME} Settings`}
+      navbarLeft={<LogoButton onClick={() => navigate("/")} />}
+    >
+      <div className="settings">
+        <section className="settings__section">
+          <h2 className="settings__label">Appearance</h2>
+          {/* Buttons that show which one is chosen, the same shape the navbar's
+              own view switch is. Not a `radiogroup`, which wants `aria-checked`
+              where `Button` gives `aria-pressed`. */}
+          <div className="settings__choices" role="group" aria-label="Theme">
+            {THEMES.map(({ value, label }) => (
+              <Button
+                key={value}
+                compact
+                selected={theme === value}
+                onClick={() => setTheme(value)}
+                className="settings__choice"
+              >
+                {label}
+              </Button>
+            ))}
+          </div>
+          <p className="settings__hint">
+            Auto follows whatever your device is set to.
+          </p>
+        </section>
+
+        <section className="settings__section">
+          <h2 className="settings__label">
+            <label htmlFor={nameInputId}>Your name</label>
+          </h2>
+          <input
+            id={nameInputId}
+            className="settings__field"
+            type="text"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="As it appears in the picks"
+            value={playerName}
+            onChange={(event) => setPlayerName(event.target.value)}
+          />
+          <p className="settings__hint">
+            Your row is marked in the scoreboard and the picks. Leave this empty
+            to mark nothing.
+          </p>
+        </section>
+      </div>
+
+      <Footer />
+    </PageLayout>
+  );
+}

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -274,25 +274,30 @@
         --rak-cell-base: var(--rak-knocked-out-300);
       }
 
-      // The reader's own row, marked down the leading edge of this column rather
-      // than filled: the fill already says whether they can still win, and the
-      // pick cells beside it say how their week went. Marked here rather than on
-      // the rank cell because this column is the one that sticks, so the mark
-      // survives the sideways pan the picks table is read with.
-      //
-      // Border and shadow both, because `.table__cell-wipe` is opaque and covers
-      // the padding box a refresh flashes this cell. The border sits outside it.
-      &.--mine {
-        border-left-color: var(--rak-my-row-accent);
-        box-shadow: inset 4px 0 0 var(--rak-my-row-accent);
-      }
-
       // The one change a name cell can show is a player just being knocked out,
       // so the wipe always draws the fill they held before that, not the one
       // inherited from the `<td>`'s own, already-updated class above.
       .table__cell-wipe {
         --rak-cell-base: var(--rak-in-contention-300);
       }
+    }
+
+    // The reader's own row, ruled above and below rather than filled: the fill
+    // already says whether they can still win, and the pick cells say how their
+    // week went, so a fill here would take a hue off one of them.
+    //
+    // Read off the name cell, which is the one thing that knows whose row this
+    // is, rather than off a class on the `<tr>`, which both tables would have to
+    // set. Drawn on every cell rather than on the row, because a row draws no
+    // background of its own for a border to sit against.
+    //
+    // Inset, so the rule is inside the cell's own edges and no row grows by it.
+    // `.table__cell-wipe` is opaque and covers the padding box a refresh flashes,
+    // so a wiping cell drops its share of the rule until the flash is over.
+    tr:has(> .table__player-col.--mine) > td {
+      box-shadow:
+        inset 0 var(--rak-border-width) 0 var(--rak-my-row-accent),
+        inset 0 calc(-1 * var(--rak-border-width)) 0 var(--rak-my-row-accent);
     }
 
     td {

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -274,6 +274,19 @@
         --rak-cell-base: var(--rak-knocked-out-300);
       }
 
+      // The reader's own row, marked down the leading edge of this column rather
+      // than filled: the fill already says whether they can still win, and the
+      // pick cells beside it say how their week went. Marked here rather than on
+      // the rank cell because this column is the one that sticks, so the mark
+      // survives the sideways pan the picks table is read with.
+      //
+      // Border and shadow both, because `.table__cell-wipe` is opaque and covers
+      // the padding box a refresh flashes this cell. The border sits outside it.
+      &.--mine {
+        border-left-color: var(--rak-my-row-accent);
+        box-shadow: inset 4px 0 0 var(--rak-my-row-accent);
+      }
+
       // The one change a name cell can show is a player just being knocked out,
       // so the wipe always draws the fill they held before that, not the one
       // inherited from the `<td>`'s own, already-updated class above.

--- a/src/components/table/picks/PicksTable.test.tsx
+++ b/src/components/table/picks/PicksTable.test.tsx
@@ -10,6 +10,7 @@ import {
 import { useScoreChanges } from "../../../context/AppDataContext";
 import { GameStatusContextProvider } from "../../../context/GameStatusContext";
 import { PlayerAnalysisContextProvider } from "../../../context/PlayerAnalysisContext";
+import { SettingsContextProvider } from "../../../context/SettingsContext";
 import { pickChangeKey } from "../../../utils/scoring/gameColumns";
 import PicksTable from "./PicksTable";
 
@@ -77,6 +78,7 @@ function renderPicks(showGameStatus = vi.fn()) {
 }
 
 beforeEach(() => {
+  localStorage.clear();
   mockScoreChanges.mockReturnValue({ picks: new Map(), players: new Map() });
 });
 
@@ -289,5 +291,34 @@ describe("PicksTable, a refresh's changes", () => {
 
     const cell = screen.getByText("Alice").closest("button");
     expect(cell?.querySelector(".table__cell-wipe")).toBeInTheDocument();
+  });
+});
+
+describe("PicksTable, the reader's own row", () => {
+  // The provider seeds itself from storage as it mounts, so a name written here
+  // is the reader's by the time the table renders.
+  function renderAs(name: string) {
+    localStorage.setItem("rak-madness:settings:playerName", name);
+    render(
+      <SettingsContextProvider>
+        <PicksTable scores={scores} />
+      </SettingsContextProvider>,
+    );
+  }
+
+  it("marks their name cell, whatever case they saved their name in", () => {
+    renderAs("  alice ");
+
+    expect(screen.getByText("Alice").closest("td")).toHaveClass("--mine");
+    expect(screen.getByText("Bob").closest("td")).not.toHaveClass("--mine");
+  });
+
+  it("leaves every pick cell's own status class alone", () => {
+    renderAs("Alice");
+
+    expect(screen.getByText("MICH").closest("td")).toHaveClass("--yes");
+    expect(screen.getByText("OSU").closest("td")).toHaveClass("--no");
+    expect(screen.getByText("KC").closest("td")).toHaveClass("--incomplete");
+    expect(screen.getByText("MIA").closest("td")).toHaveClass("--unscoreable");
   });
 });

--- a/src/components/table/playerName/CLAUDE.md
+++ b/src/components/table/playerName/CLAUDE.md
@@ -10,8 +10,8 @@ color.
 player analysis search renders it too, so the same player wears the same icon in
 both places.
 
-The reader's own row, by `useIsMyPlayer`, takes `--mine`: an accent down this
-column's leading edge, which sticks, so it survives a sideways pan.
+`--mine`, from `useIsMyPlayer`, marks the reader's own. `Table.scss` reads it
+off the row and rules every cell above and below.
 
 A player a refresh just knocked out renders a `.table__cell-wipe`, from
 `useScoreChanges()`, over the fill they held before that.

--- a/src/components/table/playerName/CLAUDE.md
+++ b/src/components/table/playerName/CLAUDE.md
@@ -10,5 +10,8 @@ color.
 player analysis search renders it too, so the same player wears the same icon in
 both places.
 
+The reader's own row, by `useIsMyPlayer`, takes `--mine`: an accent down this
+column's leading edge, which sticks, so it survives a sideways pan.
+
 A player a refresh just knocked out renders a `.table__cell-wipe`, from
 `useScoreChanges()`, over the fill they held before that.

--- a/src/components/table/playerName/PlayerName.scss
+++ b/src/components/table/playerName/PlayerName.scss
@@ -25,3 +25,9 @@
     white-space: nowrap;
   }
 }
+
+// Set heavier beside the accent down the cell's leading edge, so the reader's own
+// row is told from its neighbours by weight as well as by that mark.
+.--mine .player-name__name {
+  font-weight: var(--rak-weight-bold);
+}

--- a/src/components/table/playerName/PlayerName.scss
+++ b/src/components/table/playerName/PlayerName.scss
@@ -26,8 +26,8 @@
   }
 }
 
-// Set heavier beside the accent down the cell's leading edge, so the reader's own
-// row is told from its neighbours by weight as well as by that mark.
+// Set heavier inside the rules `Table.scss` draws above and below the row, so the
+// reader's own row is told from its neighbours by weight as well as by that mark.
 .--mine .player-name__name {
   font-weight: var(--rak-weight-bold);
 }

--- a/src/components/table/playerName/PlayerName.tsx
+++ b/src/components/table/playerName/PlayerName.tsx
@@ -3,6 +3,7 @@ import { useScoreChanges } from "../../../context/AppDataContext";
 import { PlayerScore } from "../../../types/RakMadnessScores";
 import getClasses from "../../../utils/getClasses";
 import { useShowPlayerAnalysis } from "../../../context/PlayerAnalysisContext";
+import { useIsMyPlayer } from "../../../context/SettingsContext";
 import { PLAYER_COL_CLASS } from "../TableShell";
 import PlayerStatusIcon from "./PlayerStatusIcon";
 import "./PlayerName.scss";
@@ -11,11 +12,13 @@ function PlayerName({ player }: { player: PlayerScore }) {
   const showPlayerAnalysis = useShowPlayerAnalysis();
   const { players: playerChanges } = useScoreChanges();
   const justKnockedOut = playerChanges.has(player.name);
+  const isMine = useIsMyPlayer(player.name);
 
   return (
     <td
       className={getClasses(PLAYER_COL_CLASS, {
         "--knocked-out": player.status.isKnockedOut,
+        "--mine": isMine,
       })}
     >
       <button
@@ -27,6 +30,7 @@ function PlayerName({ player }: { player: PlayerScore }) {
           <span className="player-name__name">{player.name}</span>
           <PlayerStatusIcon isKnockedOut={player.status.isKnockedOut} />
         </span>
+        {isMine && <span className="table__sr-only">Your row</span>}
         <span className="table__sr-only">
           {player.status.isKnockedOut ? "Knocked out" : "Still in contention"}
         </span>

--- a/src/components/table/scores/ScoresTable.test.tsx
+++ b/src/components/table/scores/ScoresTable.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { PlayerScore, RakMadnessScores } from "../../../types/RakMadnessScores";
 import { PlayerAnalysisContextProvider } from "../../../context/PlayerAnalysisContext";
+import { SettingsContextProvider } from "../../../context/SettingsContext";
 import ScoresTable from "./ScoresTable";
 
 const showPlayerAnalysis = vi.fn();
@@ -31,11 +32,23 @@ const knockedOutBob = player({
 
 function mountTable(scores?: RakMadnessScores) {
   return render(
-    <PlayerAnalysisContextProvider showPlayerAnalysis={showPlayerAnalysis}>
-      <ScoresTable scores={scores} />
-    </PlayerAnalysisContextProvider>,
+    <SettingsContextProvider>
+      <PlayerAnalysisContextProvider showPlayerAnalysis={showPlayerAnalysis}>
+        <ScoresTable scores={scores} />
+      </PlayerAnalysisContextProvider>
+    </SettingsContextProvider>,
   );
 }
+
+// The provider seeds itself from storage as it mounts, so a name written here is
+// the reader's by the time the table renders.
+function saveMyName(name: string) {
+  localStorage.setItem("rak-madness:settings:playerName", name);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
 
 const bothPlayers: RakMadnessScores = {
   tiebreaker: 41,
@@ -130,5 +143,29 @@ describe("ScoresTable", () => {
     const [alice, bob] = screen.getAllByRole("button");
     expect(alice).toHaveTextContent("Still in contention");
     expect(bob).toHaveTextContent("Knocked out");
+  });
+
+  it("marks the reader's own row, whatever case they saved their name in", () => {
+    saveMyName("  alice ");
+    mountTable(bothPlayers);
+    const [alice, bob] = screen.getAllByRole("button");
+    expect(alice.closest("td")?.className).toContain("--mine");
+    expect(alice.closest("td")?.className).not.toContain("--knocked-out");
+    expect(bob.closest("td")?.className).not.toContain("--mine");
+  });
+
+  it("marks nobody's row where no name is saved", () => {
+    mountTable(bothPlayers);
+    screen.getAllByRole("button").forEach((cellButton) => {
+      expect(cellButton.closest("td")?.className).not.toContain("--mine");
+    });
+  });
+
+  it("announces the reader's own row for a screen reader", () => {
+    saveMyName("Alice");
+    mountTable(bothPlayers);
+    const [alice, bob] = screen.getAllByRole("button");
+    expect(alice).toHaveTextContent("Your row");
+    expect(bob).not.toHaveTextContent("Your row");
   });
 });

--- a/src/context/CLAUDE.md
+++ b/src/context/CLAUDE.md
@@ -4,6 +4,8 @@
   routes, with the season and week derived from the pathname. Publishes
   `WeekDecidedContext` and `ScoreChangesContext` separately, the latter what a
   refresh just changed, for the tables to flash.
+- `SettingsContext`: the theme and the reader's own name, from `settingsStore`.
+  Writes `data-theme` for `index.scss`, and answers `useIsMyPlayer`.
 - `ToastContext`: the toast list, split from its actions.
 - `PlayerAnalysisContext`: how a player's name in a table opens the player analysis
   on them. One callback, a no-op with no provider above.

--- a/src/context/SettingsContext.test.tsx
+++ b/src/context/SettingsContext.test.tsx
@@ -28,6 +28,27 @@ function Probe({ candidate = "Linebacher" }: { candidate?: string }) {
   );
 }
 
+/** The `<meta>` `applyThemeColor` writes, which no test fixture puts in the DOM. */
+function mountThemeColorMeta(): HTMLMetaElement {
+  const meta = document.createElement("meta");
+  meta.name = "theme-color";
+  document.head.append(meta);
+  return meta;
+}
+
+/** Answers the dark query, which `setupTests` otherwise answers no to. */
+function stubPrefersDark(prefersDark: boolean) {
+  const original = window.matchMedia;
+  window.matchMedia = (media: string) =>
+    ({
+      ...original(media),
+      matches: media.includes("prefers-color-scheme: dark") && prefersDark,
+    }) as MediaQueryList;
+  return () => {
+    window.matchMedia = original;
+  };
+}
+
 function mountProbe(candidate?: string) {
   const user = userEvent.setup();
   render(
@@ -104,5 +125,46 @@ describe("SettingsContext, the reader's own name", () => {
     mountProbe("Barb Wire");
 
     expect(screen.getByTestId("isMine")).toHaveTextContent("false");
+  });
+});
+
+describe("SettingsContext, the browser's own chrome bar", () => {
+  // The default is `auto`, so this is what a reader who never opens the settings
+  // gets. Left on the dark value it stood a dark bar over the light navbar.
+  it("follows the operating system while the theme is auto", () => {
+    const meta = mountThemeColorMeta();
+    const restore = stubPrefersDark(false);
+    try {
+      mountProbe();
+      expect(meta.content).toBe("#eaeaea");
+    } finally {
+      restore();
+      meta.remove();
+    }
+  });
+
+  it("takes the dark value on a dark operating system", () => {
+    const meta = mountThemeColorMeta();
+    const restore = stubPrefersDark(true);
+    try {
+      mountProbe();
+      expect(meta.content).toBe("#4f4f4f");
+    } finally {
+      restore();
+      meta.remove();
+    }
+  });
+
+  it("takes the chosen theme over the operating system", async () => {
+    const meta = mountThemeColorMeta();
+    const restore = stubPrefersDark(true);
+    try {
+      const user = mountProbe();
+      await user.click(screen.getByRole("button", { name: "light" }));
+      expect(meta.content).toBe("#eaeaea");
+    } finally {
+      restore();
+      meta.remove();
+    }
   });
 });

--- a/src/context/SettingsContext.test.tsx
+++ b/src/context/SettingsContext.test.tsx
@@ -52,7 +52,7 @@ describe("SettingsContext, the theme", () => {
   });
 
   it("names the chosen theme on the document, for index.scss to select on", async () => {
-    const user = await mountProbe();
+    const user = mountProbe();
     await user.click(screen.getByRole("button", { name: "dark" }));
 
     expect(document.documentElement.dataset.theme).toBe("dark");
@@ -60,7 +60,7 @@ describe("SettingsContext, the theme", () => {
   });
 
   it("takes the name back off the document on the way to auto", async () => {
-    const user = await mountProbe();
+    const user = mountProbe();
     await user.click(screen.getByRole("button", { name: "dark" }));
     await user.click(screen.getByRole("button", { name: "auto" }));
 
@@ -79,7 +79,7 @@ describe("SettingsContext, the theme", () => {
 
 describe("SettingsContext, the reader's own name", () => {
   it("saves what was typed, as it was typed", async () => {
-    const user = await mountProbe();
+    const user = mountProbe();
     await user.click(screen.getByRole("button", { name: "name me" }));
 
     expect(screen.getByTestId("playerName")).toHaveTextContent("Linebacher");

--- a/src/context/SettingsContext.test.tsx
+++ b/src/context/SettingsContext.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import {
+  SettingsContextProvider,
+  Theme,
+  useIsMyPlayer,
+  useSettings,
+} from "./SettingsContext";
+
+const THEME_KEY = "rak-madness:settings:theme";
+const PLAYER_NAME_KEY = "rak-madness:settings:playerName";
+
+function Probe({ candidate = "Linebacher" }: { candidate?: string }) {
+  const { theme, setTheme, playerName, setPlayerName } = useSettings();
+  const isMine = useIsMyPlayer(candidate);
+  return (
+    <>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="playerName">{playerName}</span>
+      <span data-testid="isMine">{String(isMine)}</span>
+      {(["light", "dark", "auto"] as Array<Theme>).map((option) => (
+        <button key={option} onClick={() => setTheme(option)}>
+          {option}
+        </button>
+      ))}
+      <button onClick={() => setPlayerName("Linebacher")}>name me</button>
+    </>
+  );
+}
+
+function mountProbe(candidate?: string) {
+  const user = userEvent.setup();
+  render(
+    <SettingsContextProvider>
+      <Probe candidate={candidate} />
+    </SettingsContextProvider>,
+  );
+  return user;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  delete document.documentElement.dataset.theme;
+});
+
+describe("SettingsContext, the theme", () => {
+  it("follows the OS until told otherwise", () => {
+    mountProbe();
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("auto");
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+  });
+
+  it("names the chosen theme on the document, for index.scss to select on", async () => {
+    const user = await mountProbe();
+    await user.click(screen.getByRole("button", { name: "dark" }));
+
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(localStorage.getItem(THEME_KEY)).toBe("dark");
+  });
+
+  it("takes the name back off the document on the way to auto", async () => {
+    const user = await mountProbe();
+    await user.click(screen.getByRole("button", { name: "dark" }));
+    await user.click(screen.getByRole("button", { name: "auto" }));
+
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+    expect(localStorage.getItem(THEME_KEY)).toBeNull();
+  });
+
+  it("starts in the theme last chosen", () => {
+    localStorage.setItem(THEME_KEY, "light");
+    mountProbe();
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+});
+
+describe("SettingsContext, the reader's own name", () => {
+  it("saves what was typed, as it was typed", async () => {
+    const user = await mountProbe();
+    await user.click(screen.getByRole("button", { name: "name me" }));
+
+    expect(screen.getByTestId("playerName")).toHaveTextContent("Linebacher");
+    expect(localStorage.getItem(PLAYER_NAME_KEY)).toBe("Linebacher");
+  });
+
+  it("matches a player past case and surrounding space", () => {
+    localStorage.setItem(PLAYER_NAME_KEY, "  linebacher ");
+    mountProbe("Linebacher");
+
+    expect(screen.getByTestId("isMine")).toHaveTextContent("true");
+  });
+
+  it("matches nobody where no name is saved", () => {
+    mountProbe("Linebacher");
+
+    expect(screen.getByTestId("isMine")).toHaveTextContent("false");
+  });
+
+  it("matches nobody else", () => {
+    localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
+    mountProbe("Barb Wire");
+
+    expect(screen.getByTestId("isMine")).toHaveTextContent("false");
+  });
+});

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -20,8 +20,10 @@ const DEFAULT_THEME: Theme = "auto";
 /**
  * The navbar's own fill in each theme, for the browser chrome bar to match. Read
  * off `--rak-primary-500` in `index.scss`, whose light and dark values these are.
- * Written here rather than computed, because the bar has to be right on the first
- * paint, before any stylesheet has resolved a variable.
+ *
+ * Copied rather than read back off the document, because only one theme's value is
+ * resolved there at a time and this has to name the other one too. That makes them
+ * two literals to keep in step with the stylesheet by hand.
  */
 const THEME_COLOR: Record<"light" | "dark", string> = {
   light: "#eaeaea",

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,0 +1,133 @@
+import {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { readSetting, writeSetting } from "../utils/settingsStore";
+
+export type Theme = "light" | "dark" | "auto";
+
+const THEME_KEY = "theme";
+const PLAYER_NAME_KEY = "playerName";
+
+/** Follow the operating system, which is what the app did before it could be told. */
+const DEFAULT_THEME: Theme = "auto";
+
+/**
+ * The navbar's own fill in each theme, for the browser chrome bar to match. Read
+ * off `--rak-primary-500` in `index.scss`, whose light and dark values these are.
+ * Written here rather than computed, because the bar has to be right on the first
+ * paint, before any stylesheet has resolved a variable.
+ */
+const THEME_COLOR: Record<"light" | "dark", string> = {
+  light: "#eaeaea",
+  dark: "#4f4f4f",
+};
+
+type Settings = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  /**
+   * What the reader is called in the picks sheet, or the empty string for a reader
+   * who has not said. Kept as typed, since it is theirs to read back.
+   */
+  playerName: string;
+  setPlayerName: (name: string) => void;
+};
+
+const doNothing = () => undefined;
+
+// Defaults rather than a throw, following `PlayerAnalysisContext`: the tables read
+// this per row and both suites mount them on their own, with no provider above.
+const SettingsContext = createContext<Settings>({
+  theme: DEFAULT_THEME,
+  setTheme: doNothing,
+  playerName: "",
+  setPlayerName: doNothing,
+});
+
+function storedTheme(): Theme {
+  const saved = readSetting(THEME_KEY);
+  return saved === "light" || saved === "dark" ? saved : DEFAULT_THEME;
+}
+
+/**
+ * Which theme the document is in, as an attribute `index.scss` selects on, and as
+ * the color the browser paints its own chrome in.
+ *
+ * `auto` clears the attribute rather than resolving the OS preference here, so the
+ * media query stays the only thing reading that signal and a reader who changes it
+ * mid-session is followed without a listener.
+ */
+function applyTheme(theme: Theme): void {
+  const root = document.documentElement;
+  if (theme === "auto") {
+    delete root.dataset.theme;
+  } else {
+    root.dataset.theme = theme;
+  }
+
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (!(meta instanceof HTMLMetaElement)) return;
+  if (theme === "auto") {
+    // Back to the one value both schemes have always shared. A `media` attribute
+    // would say more, but only until an explicit choice contradicted it.
+    meta.content = THEME_COLOR.dark;
+  } else {
+    meta.content = THEME_COLOR[theme];
+  }
+}
+
+export function SettingsContextProvider({ children }: PropsWithChildren) {
+  const [theme, setThemeState] = useState<Theme>(storedTheme);
+  const [playerName, setPlayerNameState] = useState<string>(
+    () => readSetting(PLAYER_NAME_KEY) ?? "",
+  );
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+    writeSetting(THEME_KEY, next === DEFAULT_THEME ? "" : next);
+  }, []);
+
+  const setPlayerName = useCallback((next: string) => {
+    setPlayerNameState(next);
+    writeSetting(PLAYER_NAME_KEY, next);
+  }, []);
+
+  const value = useMemo(
+    () => ({ theme, setTheme, playerName, setPlayerName }),
+    [theme, setTheme, playerName, setPlayerName],
+  );
+
+  return (
+    <SettingsContext.Provider value={value}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings(): Settings {
+  return useContext(SettingsContext);
+}
+
+/**
+ * Whether a player in a table is the reader themselves.
+ *
+ * Trimmed and case-folded, which nothing else comparing these names is: they come
+ * out of the picks sheet as whoever typed them left them, and every other consumer
+ * matches one sheet value against another with `===`. This one matches a sheet
+ * value against something a reader typed from memory.
+ */
+export function useIsMyPlayer(name: string): boolean {
+  const { playerName } = useSettings();
+  const mine = playerName.trim().toLowerCase();
+  return mine !== "" && name.trim().toLowerCase() === mine;
+}

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import doNothing from "../utils/doNothing";
 import { readSetting, writeSetting } from "../utils/settingsStore";
 
 export type Theme = "light" | "dark" | "auto";
@@ -40,8 +41,6 @@ type Settings = {
   playerName: string;
   setPlayerName: (name: string) => void;
 };
-
-const doNothing = () => undefined;
 
 // Defaults rather than a throw, following `PlayerAnalysisContext`: the tables read
 // this per row and both suites mount them on their own, with no provider above.

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -57,9 +57,10 @@ function storedTheme(): Theme {
   return saved === "light" || saved === "dark" ? saved : DEFAULT_THEME;
 }
 
+const DARK_QUERY = "(prefers-color-scheme: dark)";
+
 /**
- * Which theme the document is in, as an attribute `index.scss` selects on, and as
- * the color the browser paints its own chrome in.
+ * Which theme the document is in, as an attribute `index.scss` selects on.
  *
  * `auto` clears the attribute rather than resolving the OS preference here, so the
  * media query stays the only thing reading that signal and a reader who changes it
@@ -72,16 +73,25 @@ function applyTheme(theme: Theme): void {
   } else {
     root.dataset.theme = theme;
   }
+}
 
+/**
+ * The color the browser paints its own chrome in, which no stylesheet can say.
+ *
+ * `auto` has to resolve the OS preference here, unlike the attribute above. The
+ * default is `auto`, so leaving this on the dark value stood a dark chrome bar over
+ * a light navbar for every reader who never opened the settings at all.
+ */
+function applyThemeColor(theme: Theme): void {
   const meta = document.querySelector('meta[name="theme-color"]');
   if (!(meta instanceof HTMLMetaElement)) return;
-  if (theme === "auto") {
-    // Back to the one value both schemes have always shared. A `media` attribute
-    // would say more, but only until an explicit choice contradicted it.
-    meta.content = THEME_COLOR.dark;
-  } else {
-    meta.content = THEME_COLOR[theme];
-  }
+  const resolved =
+    theme === "auto"
+      ? window.matchMedia(DARK_QUERY).matches
+        ? "dark"
+        : "light"
+      : theme;
+  meta.content = THEME_COLOR[resolved];
 }
 
 export function SettingsContextProvider({ children }: PropsWithChildren) {
@@ -92,6 +102,17 @@ export function SettingsContextProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     applyTheme(theme);
+  }, [theme]);
+
+  // Watched rather than read once, since on `auto` the answer changes with the OS
+  // and nothing else is reading that signal for the chrome bar.
+  useEffect(() => {
+    applyThemeColor(theme);
+    if (theme !== "auto") return;
+    const dark = window.matchMedia(DARK_QUERY);
+    const follow = () => applyThemeColor("auto");
+    dark.addEventListener("change", follow);
+    return () => dark.removeEventListener("change", follow);
   }, [theme]);
 
   const setTheme = useCallback((next: Theme) => {

--- a/src/context/createCallbackContext.ts
+++ b/src/context/createCallbackContext.ts
@@ -1,6 +1,5 @@
 import { createContext, useContext } from "react";
-
-const doNothing = () => undefined;
+import doNothing from "../utils/doNothing";
 
 /**
  * A context for a single callback, a no-op with no provider above so whatever

--- a/src/index.scss
+++ b/src/index.scss
@@ -222,6 +222,11 @@
   --rak-in-contention-300: #9edbfa;
   --rak-in-contention-on-light: #126287;
 
+  // The reader's own row, marked down the leading edge of the frozen player
+  // column. Gold because it is the one hue the tables do not already spend, so
+  // the mark cannot be mistaken for a pick result or a knockout.
+  --rak-my-row-accent: var(--rak-gold-500);
+
   --rak-surface: #fff;
   --rak-fill-subtle: #f3f3f3;
   --rak-fill-muted: #e5e5e5;
@@ -452,133 +457,150 @@ html {
   }
 }
 
-// The OS signal alone: no toggle, no stored override. The instrument-panel chrome
-// (navbar, keys, table header, the readout glass) is a light panel with dark ink
-// in light mode above, and this is where it becomes the dark device it was
-// before: every token that pairs with it inverts here too, so the panel and its
-// ink move together. Every value below was chosen to clear WCAG AA against the
-// surface it pairs with.
+// The dark half of the palette. The instrument-panel chrome (navbar, keys, table
+// header, the readout glass) is a light panel with dark ink in light mode above,
+// and this is where it becomes the dark device it was before: every token that
+// pairs with it inverts here too, so the panel and its ink move together. Every
+// value below was chosen to clear WCAG AA against the surface it pairs with.
+//
+// A mixin rather than a rule, because the two ways in need the same body: the OS
+// signal, and the reader's own choice saved in `settingsStore`. Written out twice
+// they would drift.
+@mixin dark-tokens {
+  color-scheme: dark;
+
+  // The primary ramp and its header divider, back to the dark, achromatic
+  // values the instrument-panel chrome this ramp draws always stood on in
+  // this mode.
+  --rak-primary-400: #5e5e5e;
+  --rak-primary-500: #4f4f4f;
+  --rak-primary-600: #404040;
+  --rak-primary-700: #333333;
+  --rak-primary-800: #262626;
+  // The combobox field, back to the same dark fill this step always stood on
+  // in this mode. The readout glass needs no override: `--rak-glass-fill`
+  // above is fixed to this same value in both modes already.
+  --rak-well-fill: #262626;
+  --rak-table-header-divider: #757575;
+  // The chrome's own ink, light again against the dark fill above.
+  --rak-on-solid: #fff;
+  // The stronger cut, for the dark fill the field sinks into here. Same as
+  // `--rak-glass-well` above, since the field's own fill now matches the
+  // glass's fixed one in this mode.
+  --rak-well: inset 0 1px 2px rgb(0 0 0 / 35%);
+  // Light again, against the dark fill it reads a cell of the field on here.
+  --rak-unlit: rgb(255 255 255 / 12%);
+
+  --rak-brand-light: #262626;
+
+  --rak-success-400: #4ade80;
+  --rak-danger-400: #f87171;
+  --rak-gold-700: #e8b84b;
+  --rak-knocked-out-on-light: #ffb069;
+  --rak-in-contention-on-light: #74c6f5;
+  // The brighter gold, since this one is read against a dark cell.
+  --rak-my-row-accent: var(--rak-gold-700);
+
+  --rak-surface: #191919;
+  --rak-fill-subtle: #212121;
+  --rak-fill-muted: #292929;
+  --rak-border: #747474;
+  --rak-panel-border: var(--rak-border);
+
+  --rak-text: #f6f6f6;
+  --rak-text-secondary: #d1d1d1;
+  --rak-text-tertiary: #a1a1a1;
+
+  --rak-disabled-bg: #262626;
+  --rak-disabled-text: #939393;
+  --rak-disabled-edge: #121212;
+
+  --rak-selected-fill: #383838;
+
+  // The colorful table cells: a player's status and a pick's outcome. Same hue
+  // as the light-mode pastel, taken darker and more saturated, so a chip built
+  // to sit on a white page does not glare against this one. `--rak-text-on-pale`
+  // inverts to light ink alongside them, below.
+  --rak-success-300: #1b5719;
+  --rak-danger-300: #571919;
+  --rak-knocked-out-300: #573619;
+  --rak-in-contention-300: #194257;
+  --rak-cell-unscoreable: #4e5719;
+  --rak-text-on-pale: var(--rak-text);
+
+  // The game dialog's marks, off the same darkened hues as the cells above:
+  // `--live` off the danger cell's red, `--invalid` off the unscoreable cell's
+  // yellow-green, `--final` off the success cell's green. `--upcoming` has no
+  // cell to match, so it takes the neutral panel fill already this dark.
+  --rak-mark-live-bg: var(--rak-danger-300);
+  --rak-mark-live-text: var(--rak-text);
+  --rak-mark-invalid-bg: var(--rak-cell-unscoreable);
+  --rak-mark-invalid-text: var(--rak-text);
+  --rak-mark-final-bg: var(--rak-success-300);
+  --rak-mark-final-text: var(--rak-text);
+  --rak-mark-upcoming-bg: var(--rak-fill-muted);
+  --rak-mark-upcoming-text: var(--rak-text);
+
+  // The toast's own darkened fills, off the same hues as their light
+  // pastel. `primary` and `neutral` are both grey chrome, so they take the
+  // selected-row and muted-panel fills already this dark; `success` and
+  // `danger` reuse the table cell's own darkened green/red. `warning` gets
+  // its own: its hue is the orange the rest of its ramp runs on, not the
+  // yellow-green `--rak-cell-unscoreable` took.
+  --rak-toast-primary-bg: var(--rak-selected-fill);
+  --rak-toast-neutral-bg: var(--rak-fill-muted);
+  --rak-toast-success-bg: var(--rak-success-300);
+  --rak-toast-warning-bg: #573a19;
+  --rak-toast-danger-bg: var(--rak-danger-300);
+  --rak-toast-primary-text: var(--rak-text);
+  --rak-toast-neutral-text: var(--rak-text);
+  --rak-toast-success-text: var(--rak-text);
+  --rak-toast-warning-text: var(--rak-text);
+  --rak-toast-danger-text: var(--rak-text);
+  // Told from the page regardless of its own colors, so a navy helmet on a navy
+  // background still has an edge against a page it did not draw itself for. The
+  // same boundary any control's own edge is told from its surface with. Four
+  // hard-edged shadows, one per side, rather than one soft `drop-shadow` blur:
+  // this follows the crest's own alpha channel like a blur would, but reads as
+  // a 1px line around the ink instead of a glow past it.
+  --rak-logo-outline: drop-shadow(1px 0 0 var(--rak-border))
+    drop-shadow(-1px 0 0 var(--rak-border))
+    drop-shadow(0 1px 0 var(--rak-border))
+    drop-shadow(0 -1px 0 var(--rak-border));
+  // An even row is mixed toward this. `--rak-primary-800` is nearly the fill's
+  // own darkness once the fill goes dark too, so mixing toward it stopped
+  // reading as a row apart from its neighbor. Light instead, the same distance
+  // the other way, so the two rows part again.
+  --rak-stripe-with: var(--rak-text);
+
+  // The dialog's busy sweep. Black-on-a-key reads against the light-mode
+  // `--rak-disabled-bg`, and blends into it once that token goes dark.
+  --rak-loading-sheen-on-light: rgb(255 255 255 / 10%);
+  // The dialog progress bar's own sweep, off the primary ramp's dark chrome
+  // step in light mode. That step stays dark in both modes, and the track it
+  // sweeps over (`--rak-fill-subtle`) goes dark too, so the sweep needs to
+  // lighten here instead.
+  --rak-progress-fill: var(--rak-border);
+
+  --rak-well-light: inset 0 1px 2px rgb(0 0 0 / 42%);
+  // The key's own moulding, back to the cut it always dished by against this
+  // mode's dark fills.
+  --rak-key-top: inset 0 1px 0 rgb(255 255 255 / 18%);
+  --rak-key-dish: inset 0 -2px 3px rgb(0 0 0 / 14%);
+  --rak-state-hover: rgb(255 255 255 / 8%);
+  --rak-state-press: rgb(255 255 255 / 16%);
+}
+
+// Auto, which is the default: the OS decides, unless the reader has asked for
+// light outright.
 @media (prefers-color-scheme: dark) {
-  :root {
-    color-scheme: dark;
-
-    // The primary ramp and its header divider, back to the dark, achromatic
-    // values the instrument-panel chrome this ramp draws always stood on in
-    // this mode.
-    --rak-primary-400: #5e5e5e;
-    --rak-primary-500: #4f4f4f;
-    --rak-primary-600: #404040;
-    --rak-primary-700: #333333;
-    --rak-primary-800: #262626;
-    // The combobox field, back to the same dark fill this step always stood on
-    // in this mode. The readout glass needs no override: `--rak-glass-fill`
-    // above is fixed to this same value in both modes already.
-    --rak-well-fill: #262626;
-    --rak-table-header-divider: #757575;
-    // The chrome's own ink, light again against the dark fill above.
-    --rak-on-solid: #fff;
-    // The stronger cut, for the dark fill the field sinks into here. Same as
-    // `--rak-glass-well` above, since the field's own fill now matches the
-    // glass's fixed one in this mode.
-    --rak-well: inset 0 1px 2px rgb(0 0 0 / 35%);
-    // Light again, against the dark fill it reads a cell of the field on here.
-    --rak-unlit: rgb(255 255 255 / 12%);
-
-    --rak-brand-light: #262626;
-
-    --rak-success-400: #4ade80;
-    --rak-danger-400: #f87171;
-    --rak-gold-700: #e8b84b;
-    --rak-knocked-out-on-light: #ffb069;
-    --rak-in-contention-on-light: #74c6f5;
-
-    --rak-surface: #191919;
-    --rak-fill-subtle: #212121;
-    --rak-fill-muted: #292929;
-    --rak-border: #747474;
-    --rak-panel-border: var(--rak-border);
-
-    --rak-text: #f6f6f6;
-    --rak-text-secondary: #d1d1d1;
-    --rak-text-tertiary: #a1a1a1;
-
-    --rak-disabled-bg: #262626;
-    --rak-disabled-text: #939393;
-    --rak-disabled-edge: #121212;
-
-    --rak-selected-fill: #383838;
-
-    // The colorful table cells: a player's status and a pick's outcome. Same hue
-    // as the light-mode pastel, taken darker and more saturated, so a chip built
-    // to sit on a white page does not glare against this one. `--rak-text-on-pale`
-    // inverts to light ink alongside them, below.
-    --rak-success-300: #1b5719;
-    --rak-danger-300: #571919;
-    --rak-knocked-out-300: #573619;
-    --rak-in-contention-300: #194257;
-    --rak-cell-unscoreable: #4e5719;
-    --rak-text-on-pale: var(--rak-text);
-
-    // The game dialog's marks, off the same darkened hues as the cells above:
-    // `--live` off the danger cell's red, `--invalid` off the unscoreable cell's
-    // yellow-green, `--final` off the success cell's green. `--upcoming` has no
-    // cell to match, so it takes the neutral panel fill already this dark.
-    --rak-mark-live-bg: var(--rak-danger-300);
-    --rak-mark-live-text: var(--rak-text);
-    --rak-mark-invalid-bg: var(--rak-cell-unscoreable);
-    --rak-mark-invalid-text: var(--rak-text);
-    --rak-mark-final-bg: var(--rak-success-300);
-    --rak-mark-final-text: var(--rak-text);
-    --rak-mark-upcoming-bg: var(--rak-fill-muted);
-    --rak-mark-upcoming-text: var(--rak-text);
-
-    // The toast's own darkened fills, off the same hues as their light
-    // pastel. `primary` and `neutral` are both grey chrome, so they take the
-    // selected-row and muted-panel fills already this dark; `success` and
-    // `danger` reuse the table cell's own darkened green/red. `warning` gets
-    // its own: its hue is the orange the rest of its ramp runs on, not the
-    // yellow-green `--rak-cell-unscoreable` took.
-    --rak-toast-primary-bg: var(--rak-selected-fill);
-    --rak-toast-neutral-bg: var(--rak-fill-muted);
-    --rak-toast-success-bg: var(--rak-success-300);
-    --rak-toast-warning-bg: #573a19;
-    --rak-toast-danger-bg: var(--rak-danger-300);
-    --rak-toast-primary-text: var(--rak-text);
-    --rak-toast-neutral-text: var(--rak-text);
-    --rak-toast-success-text: var(--rak-text);
-    --rak-toast-warning-text: var(--rak-text);
-    --rak-toast-danger-text: var(--rak-text);
-    // Told from the page regardless of its own colors, so a navy helmet on a navy
-    // background still has an edge against a page it did not draw itself for. The
-    // same boundary any control's own edge is told from its surface with. Four
-    // hard-edged shadows, one per side, rather than one soft `drop-shadow` blur:
-    // this follows the crest's own alpha channel like a blur would, but reads as
-    // a 1px line around the ink instead of a glow past it.
-    --rak-logo-outline: drop-shadow(1px 0 0 var(--rak-border))
-      drop-shadow(-1px 0 0 var(--rak-border))
-      drop-shadow(0 1px 0 var(--rak-border))
-      drop-shadow(0 -1px 0 var(--rak-border));
-    // An even row is mixed toward this. `--rak-primary-800` is nearly the fill's
-    // own darkness once the fill goes dark too, so mixing toward it stopped
-    // reading as a row apart from its neighbor. Light instead, the same distance
-    // the other way, so the two rows part again.
-    --rak-stripe-with: var(--rak-text);
-
-    // The dialog's busy sweep. Black-on-a-key reads against the light-mode
-    // `--rak-disabled-bg`, and blends into it once that token goes dark.
-    --rak-loading-sheen-on-light: rgb(255 255 255 / 10%);
-    // The dialog progress bar's own sweep, off the primary ramp's dark chrome
-    // step in light mode. That step stays dark in both modes, and the track it
-    // sweeps over (`--rak-fill-subtle`) goes dark too, so the sweep needs to
-    // lighten here instead.
-    --rak-progress-fill: var(--rak-border);
-
-    --rak-well-light: inset 0 1px 2px rgb(0 0 0 / 42%);
-    // The key's own moulding, back to the cut it always dished by against this
-    // mode's dark fills.
-    --rak-key-top: inset 0 1px 0 rgb(255 255 255 / 18%);
-    --rak-key-dish: inset 0 -2px 3px rgb(0 0 0 / 14%);
-    --rak-state-hover: rgb(255 255 255 / 8%);
-    --rak-state-press: rgb(255 255 255 / 16%);
+  :root:not([data-theme="light"]) {
+    @include dark-tokens;
   }
+}
+
+// A reader who chose dark, on any OS. After the query above rather than before it,
+// so it wins on source order as well as on specificity.
+:root[data-theme="dark"] {
+  @include dark-tokens;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -135,9 +135,10 @@
   // The page behind the tiled logo, and the largest surface on a phone.
   --rak-brand-light: #a4a4a4;
   // What the app is mounted in on a screen too wide for the tiles to be its
-  // ground. A shade over the frame around the table so that frame still has an
-  // edge to be read against, on the same grey ramp as the rest of the app now.
-  --rak-case: var(--rak-neutral-700);
+  // ground. A shade under the navbar it runs down from and a shade over the
+  // white column it frames, so the column keeps an edge without the case
+  // reading as a dark bezel around a light page.
+  --rak-case: #dcdcdc;
 
   // Primary scale: the navbar, table header, and key chrome. Light here, so that
   // chrome reads as a light panel with dark ink on it, the same as the rest of
@@ -228,6 +229,10 @@
   --rak-my-row-accent: var(--rak-gold-500);
 
   --rak-surface: #fff;
+  // What a dialog stands on, one plane above the page. The same white here,
+  // where the scrim already takes the page to grey under it. Dark mode has no
+  // such room and lifts the plane instead.
+  --rak-surface-raised: var(--rak-surface);
   --rak-fill-subtle: #f3f3f3;
   --rak-fill-muted: #e5e5e5;
   // A control's own boundary, which has to be told from the surface behind it.
@@ -241,6 +246,10 @@
   // both modes. Dark mode moves this to `--rak-border` below, against the dark
   // surface that step pairs with there.
   --rak-panel-border: #2e2e2e;
+  // A dialog's own edge, drawn only where the plane it stands on cannot carry
+  // the separation alone. Nothing here: the scrim under a white dialog is a
+  // 2.96:1 step already, and a dark outline around a modal reads as a mistake.
+  --rak-dialog-edge: transparent;
   // The rule between header cells. Not a step on the primary ramp: that ramp
   // is light here and dark in dark mode, and a line has to clear 3:1 against
   // both. Dark mode pins it to its own old value below, against the header's
@@ -492,6 +501,11 @@ html {
   --rak-unlit: rgb(255 255 255 / 12%);
 
   --rak-brand-light: #262626;
+  // Between the navbar above it and the surface it frames, the same place the
+  // light case sits. Stays where it was: a dark app in a dark case needs no
+  // moving, and the light one only moved to stop framing a light page in near
+  // black.
+  --rak-case: #373737;
 
   --rak-success-400: #4ade80;
   --rak-danger-400: #f87171;
@@ -502,10 +516,21 @@ html {
   --rak-my-row-accent: var(--rak-gold-700);
 
   --rak-surface: #191919;
+  // A dialog stands a plane above the page here, because neither thing that
+  // separates the two in light mode works at this end of the ramp.
+  // `--rak-scrim` is 45% of `--rak-shadow-color`, which is #151515: laid over
+  // this surface it lands on #171717, a 1.02 step. `--rak-shadow-modal` is the
+  // same near-black, so it draws nothing either. Lifting the fill is the only
+  // separation left, and it is a 1.23 step, which the edge below then makes
+  // measurable.
+  --rak-surface-raised: #292929;
   --rak-fill-subtle: #212121;
   --rak-fill-muted: #292929;
   --rak-border: #747474;
   --rak-panel-border: var(--rak-border);
+  // 3.11:1 against the raised fill, which two planes this dark can never reach
+  // against each other. The edge is what carries the requirement.
+  --rak-dialog-edge: var(--rak-panel-border);
 
   --rak-text: #f6f6f6;
   --rak-text-secondary: #d1d1d1;

--- a/src/index.scss
+++ b/src/index.scss
@@ -521,14 +521,14 @@ html {
   // `--rak-scrim` is 45% of `--rak-shadow-color`, which is #151515: laid over
   // this surface it lands on #171717, a 1.02 step. `--rak-shadow-modal` is the
   // same near-black, so it draws nothing either. Lifting the fill is the only
-  // separation left, and it is a 1.17 step, which the edge below then makes
+  // separation left, and it is a 1.11 step, which the edge below then makes
   // measurable.
-  --rak-surface-raised: #252525;
+  --rak-surface-raised: #212121;
   --rak-fill-subtle: #212121;
   --rak-fill-muted: #292929;
   --rak-border: #747474;
   --rak-panel-border: var(--rak-border);
-  // 3.28:1 against the raised fill, which two planes this dark can never reach
+  // 3.45:1 against the raised fill, which two planes this dark can never reach
   // against each other. The edge is what carries the requirement.
   --rak-dialog-edge: var(--rak-panel-border);
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -521,14 +521,14 @@ html {
   // `--rak-scrim` is 45% of `--rak-shadow-color`, which is #151515: laid over
   // this surface it lands on #171717, a 1.02 step. `--rak-shadow-modal` is the
   // same near-black, so it draws nothing either. Lifting the fill is the only
-  // separation left, and it is a 1.23 step, which the edge below then makes
+  // separation left, and it is a 1.17 step, which the edge below then makes
   // measurable.
-  --rak-surface-raised: #292929;
+  --rak-surface-raised: #252525;
   --rak-fill-subtle: #212121;
   --rak-fill-muted: #292929;
   --rak-border: #747474;
   --rak-panel-border: var(--rak-border);
-  // 3.11:1 against the raised fill, which two planes this dark can never reach
+  // 3.28:1 against the raised fill, which two planes this dark can never reach
   // against each other. The edge is what carries the requirement.
   --rak-dialog-edge: var(--rak-panel-border);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,6 +31,7 @@ import ibmPlexMono700Url from "@fontsource/ibm-plex-mono/files/ibm-plex-mono-lat
 import dseg14Url from "@fontsource/dseg14-classic/files/dseg14-classic-latin-700-normal.woff2?url";
 import dseg7Url from "@fontsource/dseg7-classic/files/dseg7-classic-latin-700-normal.woff2?url";
 import { AppDataContextProvider } from "./context/AppDataContext";
+import { SettingsContextProvider } from "./context/SettingsContext";
 import { ToastContextProvider } from "./context/ToastContext";
 import Toaster from "./components/toaster/Toaster";
 import prefetchLink from "./utils/prefetchLink";
@@ -81,12 +82,14 @@ const root = createRoot(container);
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <ToastContextProvider>
-        <AppDataContextProvider>
-          <App />
-        </AppDataContextProvider>
-        <Toaster />
-      </ToastContextProvider>
+      <SettingsContextProvider>
+        <ToastContextProvider>
+          <AppDataContextProvider>
+            <App />
+          </AppDataContextProvider>
+          <Toaster />
+        </ToastContextProvider>
+      </SettingsContextProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/src/styles/CLAUDE.md
+++ b/src/styles/CLAUDE.md
@@ -6,7 +6,8 @@ keyframes. Design tokens live in `src/index.scss` instead.
 
 - `_breakpoints.scss`: `roomy-screen`, `labelled-navbar`, `wide-screen`,
   `can-hover`, `phone-landscape`, `reduced-motion`
-- `_focus.scss`: `focus-ring`, the app's one focus ring
+- `_focus.scss`: `focus-ring`, the app's one focus ring, and `$focus-ring-reach`,
+  the room it needs outside a control a scrolling ancestor would clip it against
 - `_ink.scss`: `ink-height`, an icon drawn as tall as the text beside it
 - `_a11y.scss`: `visually-hidden`
 - `_label.scss`: `micro-label`, the tracked capitals every small label is set in

--- a/src/styles/_focus.scss
+++ b/src/styles/_focus.scss
@@ -1,5 +1,14 @@
-// The one focus ring. Mixins only, so this emits no CSS of its own however many
-// files pull it in.
+// The one focus ring. Mixins and a number, so this emits no CSS of its own however
+// many files pull it in.
+
+/**
+ * How far outside its box a ring reaches: the offset below, and then its width.
+ *
+ * What a control flush with the edge of a clipping ancestor has to be held off that
+ * edge by. Anything scrolling computes `overflow-x: auto` from its own `overflow-y`,
+ * so it clips sideways as well, and takes the ring with it.
+ */
+$focus-ring-reach: 4px;
 
 /**
  * Drawn in `--rak-focus-ring`, which every surface that is not the page sets for

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -12,6 +12,7 @@
 - `debugLog`: scoring traces, silent outside a dev server
 - `latestOnly`: drops an async result its effect outlived
 - `getClasses`: className join, fixed and conditional names
+- `doNothing`: the no-op a default prop or context stands in with
 - `plural`: a count and its noun, pluralized
 - `rangeWithPrefix`: labeled index arrays (C1, C2…)
 - `matching`: case-folded substring search, shared by both dialogs' item lists

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -7,6 +7,7 @@
 - `pickStatusFill`: pick colors for the export
 - `picksCache` / `espnCache`: an uploaded workbook, and ESPN's fixed answers,
   on `localStorageCache`, a capped store under one prefix
+- `settingsStore`: the reader's own preferences, kept whatever the caches drop
 - `loadStoredPicks`: a week's workbook from the API, or cache
 - `debugLog`: scoring traces, silent outside a dev server
 - `latestOnly`: drops an async result its effect outlived

--- a/src/utils/doNothing.ts
+++ b/src/utils/doNothing.ts
@@ -1,0 +1,10 @@
+/**
+ * The callback a default stands in with, for a prop or a context whose absence is
+ * ordinary rather than a mistake.
+ *
+ * One shared identity, so a default that reaches a dependency array or a memo
+ * comparison is the same reference on every render.
+ */
+export default function doNothing(): undefined {
+  return undefined;
+}

--- a/src/utils/pickStatusFill.test.ts
+++ b/src/utils/pickStatusFill.test.ts
@@ -12,11 +12,12 @@ const TOKEN_FOR_STATUS: Record<Status, string> = {
 
 function tokenValues(): Map<string, string> {
   const stylesheet = readFileSync("src/index.scss", "utf8");
-  // The export is a static file with no concept of the reader's system theme, so
-  // it has to match the light-mode base rather than any `@media` override of it.
-  // The light-mode base is everything before the first one, so a brace-matching
-  // regex isn't needed and can't be fooled by how deeply a future override nests.
-  const lightModeOnly = stylesheet.split("@media")[0];
+  // The export is a static file with no concept of the reader's theme, so it has
+  // to match the light-mode base rather than the dark override of it. The base is
+  // everything before the first `@media` or `@mixin`, the two shapes an override
+  // is written in, so a brace-matching regex isn't needed and can't be fooled by
+  // how deeply a future one nests.
+  const lightModeOnly = stylesheet.split(/@media|@mixin/)[0];
   return new Map(
     Array.from(
       lightModeOnly.matchAll(/(--rak-[a-z0-9-]+):\s*(#[0-9a-fA-F]{3,6})\s*;/g),

--- a/src/utils/pickStatusFill.test.ts
+++ b/src/utils/pickStatusFill.test.ts
@@ -10,14 +10,31 @@ const TOKEN_FOR_STATUS: Record<Status, string> = {
   incomplete: "--rak-surface",
 };
 
+/**
+ * The first `:root` block of a stylesheet, read to its own closing brace.
+ *
+ * Bounded by that brace rather than by the first `@media` or `@mixin`, which is
+ * where an override happens to start today. A mixin declared for anything else
+ * would silently cut the block short, and the tokens past the cut would read as
+ * undeclared.
+ */
+function lightModeRoot(stylesheet: string): string {
+  const start = stylesheet.indexOf(":root {");
+  let depth = 0;
+  for (let index = start; index < stylesheet.length; index++) {
+    if (stylesheet[index] === "{") depth++;
+    else if (stylesheet[index] === "}" && --depth === 0) {
+      return stylesheet.slice(start, index);
+    }
+  }
+  return stylesheet.slice(start);
+}
+
 function tokenValues(): Map<string, string> {
   const stylesheet = readFileSync("src/index.scss", "utf8");
   // The export is a static file with no concept of the reader's theme, so it has
-  // to match the light-mode base rather than the dark override of it. The base is
-  // everything before the first `@media` or `@mixin`, the two shapes an override
-  // is written in, so a brace-matching regex isn't needed and can't be fooled by
-  // how deeply a future one nests.
-  const lightModeOnly = stylesheet.split(/@media|@mixin/)[0];
+  // to match the light-mode base rather than the dark override of it.
+  const lightModeOnly = lightModeRoot(stylesheet);
   return new Map(
     Array.from(
       lightModeOnly.matchAll(/(--rak-[a-z0-9-]+):\s*(#[0-9a-fA-F]{3,6})\s*;/g),

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -18,5 +18,6 @@ The picks-to-scoreboard pipeline, sequenced by `getPlayerScores`.
 - `isWeekOver`: whether the week finished
 - `applyKnockouts`: who can still win, why not
 - `scoreChanges`: what a refresh changed
-- `getPlayerAnalysis`: what a player must do
+- `getPlayerAnalysis`: what a player must do, plus `getSettledAnalysis`,
+  the answers a week already holds, which the dialog asks before it waits
 - `leagueResultFixtures`: test game builders

--- a/src/utils/scoring/getPlayerAnalysis.test.ts
+++ b/src/utils/scoring/getPlayerAnalysis.test.ts
@@ -5,7 +5,7 @@ import {
   RakMadnessScores,
   Status,
 } from "../../types/RakMadnessScores";
-import getPlayerAnalysis from "./getPlayerAnalysis";
+import getPlayerAnalysis, { getSettledAnalysis } from "./getPlayerAnalysis";
 
 /** A game still to be played unless a status says otherwise. */
 function pick(text: string, status: Status = "incomplete"): PickResult {
@@ -165,6 +165,78 @@ describe("getPlayerAnalysis, whether there is anything to work out", () => {
       player: "Bob",
       explanation: "Knocked out on Total Score by Alice.",
     });
+  });
+});
+
+// What the dialog asks before it puts a progress bar up, so a week that needs no
+// search never stands one over an answer that is already there.
+describe("getSettledAnalysis, the answers that need no search", () => {
+  it("gives a knocked out player their reason", () => {
+    const scores = week([
+      player({ name: "Alice", total: 5 }),
+      player({ name: "Bob", total: 0, isKnockedOut: true }),
+    ]);
+    scores.scores[1].status.explanation =
+      "Knocked out on Total Score by Alice.";
+
+    expect(getSettledAnalysis(scores, "Bob")).toEqual({
+      kind: "knockedOut",
+      player: "Bob",
+      explanation: "Knocked out on Total Score by Alice.",
+    });
+  });
+
+  // The case that sent a reader here: a week whose games are all in, where the
+  // bar used to run over an answer the knockouts had already given.
+  it("clinches a week whose games are all played", () => {
+    const scores = week(
+      [
+        player({ name: "Alice", total: 5, pro: [pick("KC -3", "yes")] }),
+        player({ name: "Bob", total: 3, pro: [pick("DEN +3", "no")] }),
+      ],
+      41,
+    );
+
+    expect(getSettledAnalysis(scores, "Alice")).toEqual({
+      kind: "clinched",
+      player: "Alice",
+    });
+  });
+
+  it("clinches once every rival left is knocked out", () => {
+    const scores = week([
+      player({ name: "Alice", total: 5, pro: [pick("KC -3")] }),
+      player({
+        name: "Bob",
+        total: 0,
+        pro: [pick("DEN +3")],
+        isKnockedOut: true,
+      }),
+    ]);
+
+    expect(getSettledAnalysis(scores, "Alice")).toEqual({
+      kind: "clinched",
+      player: "Alice",
+    });
+  });
+
+  it("sends a week still open to the search", () => {
+    // Opposite picks on the one game left, so which of them takes it is exactly
+    // what the search is for.
+    const scores = week([
+      player({ name: "Alice", total: 3, pro: [pick("KC -3")] }),
+      player({ name: "Bob", total: 3, pro: [pick("DEN +3")] }),
+    ]);
+
+    expect(getSettledAnalysis(scores, "Alice")).toBeUndefined();
+    expect(getPlayerAnalysis(scores, "Alice")).toBeDefined();
+  });
+
+  it("sends a name the sheet does not hold to the search, which has no answer either", () => {
+    const scores = week([player({ name: "Alice" })]);
+
+    expect(getSettledAnalysis(scores, "Nobody")).toBeUndefined();
+    expect(getPlayerAnalysis(scores, "Nobody")).toBeUndefined();
   });
 });
 

--- a/src/utils/scoring/getPlayerAnalysis.ts
+++ b/src/utils/scoring/getPlayerAnalysis.ts
@@ -506,7 +506,19 @@ function reduceRoutes(
  * well as one being played. Undefined where the sheet holds nobody by that name,
  * which is the only way the question has no answer at all.
  */
-export default function getPlayerAnalysis(
+/**
+ * The answer where the week already holds one, and undefined where the search below
+ * is what has to find it.
+ *
+ * Split out so a caller can ask before it puts a progress bar up. Every branch here
+ * is a walk of the players, which is why `getPlayerAnalysis` opens with the same
+ * call rather than keeping two copies of them.
+ *
+ * A name the sheet does not hold answers undefined too. `getPlayerAnalysis` answers
+ * the same undefined for it, so a caller falling through to the search on this needs
+ * no third case.
+ */
+export function getSettledAnalysis(
   scores: RakMadnessScores,
   playerName: string,
 ): PlayerAnalysis | undefined {
@@ -529,12 +541,37 @@ export default function getPlayerAnalysis(
 
   // A knocked out player cannot take the week off anyone, so they are not measured
   // against. That is what keeps the search small late in a week.
-  const rivals = players
-    .map((it, index) => ({ player: it, index }))
-    .filter((it) => it.index !== playerIndex && !it.player.status.isKnockedOut);
+  const rivals = liveRivals(players, playerIndex);
   if (rivals.length === 0) {
     return { kind: "clinched", player: player.name };
   }
+
+  return undefined;
+}
+
+/** Everyone still able to take the week off this player. */
+function liveRivals(
+  players: RakMadnessScores["scores"],
+  playerIndex: number,
+): Array<{ player: RakMadnessScores["scores"][number]; index: number }> {
+  return players
+    .map((it, index) => ({ player: it, index }))
+    .filter((it) => it.index !== playerIndex && !it.player.status.isKnockedOut);
+}
+
+export default function getPlayerAnalysis(
+  scores: RakMadnessScores,
+  playerName: string,
+): PlayerAnalysis | undefined {
+  const settled = getSettledAnalysis(scores, playerName);
+  if (settled != null) return settled;
+
+  const players = scores.scores;
+  const playerIndex = players.findIndex((it) => it.name === playerName);
+  if (playerIndex < 0) return undefined;
+
+  const player = players[playerIndex];
+  const rivals = liveRivals(players, playerIndex);
 
   // A game every live player picked the same way moves all their scores together,
   // in the total and in both tiebreaker tiers, so it cannot change the order.

--- a/src/utils/settingsStore.test.ts
+++ b/src/utils/settingsStore.test.ts
@@ -1,0 +1,41 @@
+import { readSetting, writeSetting } from "./settingsStore";
+import { blockAllStorageMethods } from "./storageMockUtils";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("settingsStore", () => {
+  it("reads back what it wrote", () => {
+    writeSetting("playerName", "Linebacher");
+
+    expect(readSetting("playerName")).toBe("Linebacher");
+  });
+
+  it("has nothing for a name never set", () => {
+    expect(readSetting("theme")).toBeUndefined();
+  });
+
+  it("forgets a setting written empty", () => {
+    writeSetting("playerName", "Linebacher");
+    writeSetting("playerName", "");
+
+    expect(readSetting("playerName")).toBeUndefined();
+  });
+
+  it("leaves the settings beside the one it writes", () => {
+    writeSetting("theme", "dark");
+    writeSetting("playerName", "");
+
+    expect(readSetting("theme")).toBe("dark");
+  });
+
+  it("reads a miss rather than throwing where storage is blocked", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    blockAllStorageMethods();
+
+    expect(() => writeSetting("theme", "dark")).not.toThrow();
+    expect(readSetting("theme")).toBeUndefined();
+  });
+});

--- a/src/utils/settingsStore.ts
+++ b/src/utils/settingsStore.ts
@@ -1,0 +1,32 @@
+// The reader's own preferences, under one prefix of localStorage.
+//
+// Deliberately not `localStorageCache`, which every other store here is built on.
+// That one is capped and clears its whole prefix the moment a read or a write
+// fails, which is right for something a page load can refetch and wrong for a
+// value the reader typed. A failure here is a miss for that one name, and the
+// names beside it are left alone.
+
+const PREFIX = "rak-madness:settings:";
+
+/** The value saved under a name, or undefined for one never set. */
+export function readSetting(name: string): string | undefined {
+  try {
+    return localStorage.getItem(PREFIX + name) ?? undefined;
+  } catch (error) {
+    console.warn(`Could not read the ${name} setting`, error);
+    return undefined;
+  }
+}
+
+/** Saves a value, or forgets the setting when the value is empty. */
+export function writeSetting(name: string, value: string): void {
+  try {
+    if (value === "") {
+      localStorage.removeItem(PREFIX + name);
+    } else {
+      localStorage.setItem(PREFIX + name, value);
+    }
+  } catch (error) {
+    console.warn(`Could not save the ${name} setting`, error);
+  }
+}


### PR DESCRIPTION
## What

A settings dialog, opened from the home page footer, holding a theme choice and the reader's own player name. Both persist to localStorage.

<img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/settings-page/pr-settings-auto.png" width="300"> <img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/settings-page/pr-settings-dark.png" width="300">

A saved name rules that player's row above and below in both tables. The rule crosses the sticky player column, so a sideways pan keeps it on screen.

<img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/settings-page/pr-scoreboard-dark.png" width="300"> <img src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/settings-page/pr-picks-panned.png" width="300">

## Changes

- The rule is `--rak-gold-500`, never a fill, so every pick and status color keeps its meaning. Gold is the hue the tables do not spend.
- In dark mode a dialog and the page under it were both `--rak-surface`, and the scrim over #191919 lands on #171717. `--rak-surface-raised` lifts the dialog and a hairline carries the 3:1. `--rak-case` stops framing a light page in #373737.
- `index.html` reads the theme before the first paint, or a saved dark theme flashes light on load.
- Refresh leads the results bar. Trailing it, the button shoved the switch left every time a live week put it on screen.
- The settings reuse `DialogShell`. Its busy flag now carries its own label, so no dialog can draw an unnamed bar.
- The footer gives up the screen at 540px, not 528px: the 360px control stack, the 56px links, the 68px navbar, and 16px of clearance.

## Verification

- Two commits are unrelated. A team logo centered on three scoreline rows rather than on the name beside it. The player analysis stood a progress bar over a week that needs no search.
- Chose Dark on a light OS, reloaded, saw no flash.

🏍️ Exfiltrated by [Agent Carmen Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
