### PR TITLE
fix(gameStatus): open on the game instead of a wireframe

### DIFF
--- a/src/components/gameStatus/CLAUDE.md
+++ b/src/components/gameStatus/CLAUDE.md
@@ -3,11 +3,11 @@
 How a game in the week is going, opened from a pick cell.
 
 - `GameStatusDialog`: `DialogShell` over a `DialogCombobox` of `scores.games`, in picks
-  table column order, which the query matches. `GameMark` says where a game stands;
+  table column order, which the query matches. `GameMark` says where a game stands.
   `useLiveGame` keeps the chosen one fresh.
 - `GameStatusSummary`: the pool's line, the game as ESPN's boxscore says it, its kickoff,
-  town and Gamecast link. The wireframe is that layout over the week's own copy, held
-  until both marks decode too, so neither pops in over it. `useScorelineFit`
-  takes the full names, then the marks, off one too narrow.
+  town and Gamecast link. The week's own copy is up from the first render, and a fetched
+  answer replaces it in place, so nothing waits. `useScorelineFit` takes the full names,
+  then the marks, off one too narrow.
 - `GameStatusSummary.scss`: both sides in one grid, the dash in a track between two
   equal ones, so neither side moves it. `--rak-score-size` sizes that row.

--- a/src/components/gameStatus/GameStatusDialog.test.tsx
+++ b/src/components/gameStatus/GameStatusDialog.test.tsx
@@ -15,6 +15,7 @@ import {
   upcomingGame as upcomingGameFixture,
 } from "../../utils/scoring/leagueResultFixtures";
 import { POLL_MS } from "../../hooks/useLiveGame";
+import { warmedImageUrls } from "../../utils/warmImage";
 
 vi.mock("../../utils/getLeagueResults");
 
@@ -156,11 +157,7 @@ describe("GameStatusDialog", () => {
 
     // Every mark the week could draw, asked for before any game is opened, so a
     // scoreline never comes up and then fills in.
-    expect(
-      [
-        ...document.head.querySelectorAll('link[rel="prefetch"][as="image"]'),
-      ].map((link) => link.getAttribute("href")),
-    ).toEqual([
+    expect(warmedImageUrls()).toEqual([
       "https://espn.com/OSU.png",
       "https://espn.com/MICH.png",
       "https://espn.com/BUF.png",

--- a/src/components/gameStatus/GameStatusDialog.test.tsx
+++ b/src/components/gameStatus/GameStatusDialog.test.tsx
@@ -23,7 +23,6 @@ import {
   dialog,
   getGameResultMock,
   SEASON,
-  settleLogos,
   WEEK,
 } from "./gameStatusDialogTestSupport";
 
@@ -170,19 +169,16 @@ describe("GameStatusDialog", () => {
       "https://espn.com/DAL.png",
     ]);
 
-    // The game, not the column the cell that opened it was in, and a wireframe
-    // rather than the score the week was scored at.
+    // The game, not the column the cell that opened it was in, and the week's own
+    // copy of it already up rather than a wait for the fetch that is out.
     expect(screen.getByRole("combobox", { name: "Game" })).toHaveValue(
       "KC @ BUF",
     );
-    expect(screen.getByRole("status")).toHaveTextContent("Loading the game");
+    expect(screen.getByText("BUF Team")).toBeInTheDocument();
     // In words as well as in a dot, a red dot alone reading as a decoration.
     expect(screen.getByRole("img", { name: "Live" })).toHaveTextContent("LIVE");
 
-    // The score the fetch came back with, not the one the week was scored at. Waited
-    // on by the bar, since the wireframe carries the week's own copy of the game and
-    // so already reads the same in places.
-    settleLogos();
+    // The score the fetch came back with, in place of the one the week was scored at.
     await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"));
     expect(screen.getByText("8:42 - 3rd Quarter")).toBeInTheDocument();
     expect(screen.getByText("BUF Team")).toBeInTheDocument();
@@ -200,7 +196,7 @@ describe("GameStatusDialog", () => {
     expect(await screen.findByText("14")).toBeInTheDocument();
 
     // A poll says it is out the way a first fetch does, and the game already on
-    // screen stays up behind the bar rather than a wireframe standing in for it.
+    // screen stays up behind the bar.
     const held = deferred();
     getGameResultMock.mockReturnValue(held.promise);
     await vi.advanceTimersByTimeAsync(POLL_MS);
@@ -272,15 +268,15 @@ describe("GameStatusDialog", () => {
     expect(
       screen.getByRole("progressbar", { name: "Fetching the game" }),
     ).toBeInTheDocument();
+    // The game being switched to, from the week's own copy of it, rather than the
+    // live one whose result is still the last one fetched.
     expect(screen.queryByText("BUF Team")).toBeNull();
-    // The game being switched to, which has yet to kick off, rather than the live one
-    // whose result is still the last one fetched.
+    expect(screen.getByText("PHI Team")).toBeInTheDocument();
     expect(
       screen.getByRole("img", { name: "Yet to kick off" }),
     ).toBeInTheDocument();
 
     pending.settle(upcomingGame);
-    settleLogos();
     await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"));
     expect(screen.getByText("PHI Team")).toBeInTheDocument();
     // Not started, so the search says so rather than that there is something to watch.
@@ -292,7 +288,6 @@ describe("GameStatusDialog", () => {
     const askedBeforeFinal = getGameResultMock.mock.calls.length;
     await user.click(screen.getByRole("combobox", { name: "Game" }));
     await user.click(await screen.findByRole("option", { name: /MICH @ OSU/ }));
-    settleLogos();
     expect(screen.getByText("OSU Team")).toBeInTheDocument();
     expect(screen.queryByRole("progressbar")).toBeNull();
     expect(screen.getByRole("img", { name: "Final" })).toBeInTheDocument();

--- a/src/components/gameStatus/GameStatusDialog.tsx
+++ b/src/components/gameStatus/GameStatusDialog.tsx
@@ -6,7 +6,7 @@ import { WeekInfo } from "../../types/League";
 import { RakMadnessScores } from "../../types/RakMadnessScores";
 import { WeekGame } from "../../types/WeekGame";
 import matching from "../../utils/matching";
-import prefetchLink from "../../utils/prefetchLink";
+import warmImage from "../../utils/warmImage";
 import DialogCombobox from "../dialog/DialogCombobox";
 import DialogShell from "../dialog/DialogShell";
 import { CheckIcon, EventIcon, WarningIcon } from "../icon/Icon";
@@ -22,19 +22,6 @@ import "./GameStatusDialog.scss";
  */
 function gameSearchText(game: WeekGame): string {
   return `${game.label}  ${game.name}`;
-}
-
-/**
- * Every URL this session has already asked the browser to warm, so a week with
- * marks fetched twice, or a game reopened later, never asks for the same logo
- * twice.
- */
-const prefetchedLogoUrls = new Set<string>();
-
-function prefetchLogo(url: string) {
-  if (prefetchedLogoUrls.has(url)) return;
-  prefetchedLogoUrls.add(url);
-  prefetchLink(url, { as: "image" });
 }
 
 /** The games a query offers, in picks table column order. */
@@ -162,7 +149,7 @@ export default function GameStatusDialog({
   games.forEach((it) => {
     [it.result?.home.team.logoUrl, it.result?.away.team.logoUrl].forEach(
       (url) => {
-        if (url != null) prefetchLogo(url);
+        if (url != null) warmImage(url);
       },
     );
   });

--- a/src/components/gameStatus/GameStatusDialog.tsx
+++ b/src/components/gameStatus/GameStatusDialog.tsx
@@ -117,9 +117,11 @@ function GameMark({
  * How a game in the week on screen is going, opened from a pick cell in the picks
  * table.
  *
- * A game that has not finished is fetched again on the way in and every twenty seconds
- * after that, so a live game on screen is the game as it stands rather than as the
- * week was last scored. One already final is shown as the week scored it.
+ * The week's own copy of the game is on screen the moment the dialog opens. A game
+ * that has not finished is fetched again as it appears and every twenty seconds after
+ * that, and each answer replaces the score in place, so a live game catches up rather
+ * than making the reader wait. One already final is never fetched, because the week
+ * scored it at the only score it can have.
  */
 export default function GameStatusDialog({
   open,
@@ -172,7 +174,7 @@ export default function GameStatusDialog({
     setQuery(arrived?.name ?? label);
   });
 
-  const { shown, isLoading, isFetching } = useLiveGame({
+  const { shown, isFetching } = useLiveGame({
     open,
     game,
     games: scores?.games,
@@ -205,16 +207,13 @@ export default function GameStatusDialog({
           itemToStringLabel={(option) => option.name}
           itemKey={(option) => option.label}
           // The chosen game's own mark, on the freshest status rather than the one
-          // the week was scored at, so a game going final stops pulsing. While a
-          // fetch is out, `shown` is still the game before it, whose status is not
-          // this game's, so the week's own is what stands until the answer lands.
+          // the week was scored at, so a game going final stops pulsing. The week's
+          // own stands until the first answer lands.
           adornment={
             game != null && (
               <GameMark
                 game={game}
-                status={
-                  (isLoading ? undefined : shown?.status) ?? game.result?.status
-                }
+                status={shown?.status ?? game.result?.status}
               />
             )
           }
@@ -228,7 +227,7 @@ export default function GameStatusDialog({
         />
       }
     >
-      <GameStatusSummary game={game} result={shown} isLoading={isLoading} />
+      <GameStatusSummary game={game} result={shown} />
     </DialogShell>
   );
 }

--- a/src/components/gameStatus/GameStatusDialogOnGameFinal.test.tsx
+++ b/src/components/gameStatus/GameStatusDialogOnGameFinal.test.tsx
@@ -57,7 +57,7 @@ describe("GameStatusDialog onGameFinal", () => {
     vi.useRealTimers();
   });
 
-  it("does not call onGameFinal for a game already final when opened", async () => {
+  it("shows a game already final on the first render, without fetching it", async () => {
     vi.useFakeTimers();
     const onGameFinal = vi.fn();
     const settledGame: WeekGame = {
@@ -78,6 +78,12 @@ describe("GameStatusDialog onGameFinal", () => {
       dialog(undefined, false, settledScores, onGameFinal),
     );
     rerender(dialog("P1", true, settledScores, onGameFinal));
+
+    // Nothing about it can have changed, so the week's own copy is the answer and
+    // goes up on the render that opens the dialog. No wait, and nothing asked for.
+    expect(screen.getByText("24")).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+    expect(getGameResultMock).not.toHaveBeenCalled();
     expect(
       await screen.findByRole("img", { name: "Final" }),
     ).toBeInTheDocument();

--- a/src/components/gameStatus/GameStatusSummary.scss
+++ b/src/components/gameStatus/GameStatusSummary.scss
@@ -1,8 +1,6 @@
-@use "../../styles/a11y" as *;
 @use "../../styles/breakpoints" as *;
 @use "../../styles/label" as *;
 @use "../../styles/lcd" as *;
-@use "../../styles/skeleton" as *;
 
 // Which side a player had to pick to score the point, and which one cost them it,
 // in the two hues the picks table fills a cell with. The 400 step, which is the one
@@ -32,25 +30,6 @@
   font-family: var(--rak-font-segment);
   // The face ships in its bold cut alone, which `src/index.tsx` is what loads.
   font-weight: var(--rak-weight-bold);
-}
-
-// A bar over the words an element holds, one on each line of it, so a name that wraps
-// to two lines comes out as two bars rather than as one across both. The bar is as wide
-// as the box, which the scoreline's grid gives both sides equally, so the two sides of
-// a wireframe mirror each other whatever the teams are called.
-//
-// Drawn on the element itself rather than in a layer over it: a bar of its own would
-// have to be told where every line of a wrapping name is.
-@mixin wireframe-bar($height: 0.7rem) {
-  color: transparent;
-  opacity: var(--rak-loading-fill-opacity);
-  background-image: repeating-linear-gradient(
-    to bottom,
-    transparent 0 calc((1lh - #{$height}) / 2),
-    var(--rak-loading-fill) calc((1lh - #{$height}) / 2)
-      calc((1lh + #{$height}) / 2),
-    transparent calc((1lh + #{$height}) / 2) 1lh
-  );
 }
 
 // How big the scores, the dash between them and the possession marks are set. Named
@@ -85,78 +64,6 @@
     --rak-marker-size: 1rem;
     --rak-score-gap: var(--rak-space-2);
   }
-}
-
-// A game holds a dozen or so bars at once, never the hundreds a wireframe table
-// does, so each bar carries its own sheen rather than one sweep standing in for
-// all of them. That keeps the shine over a bar rather than crossing the gaps
-// between them, where the wait has nothing to show yet.
-//
-// Every word under here is the week's own copy of the game, laid out by the rules the
-// answer will be laid out by and taken down to a bar. What is left showing is those
-// bars, the marks' own circles, and the dash the two scores meet at, which is the same
-// dash either way.
-.game-status.--skeleton {
-  // Every word is still there, holding the room it will take, and none of it drawn.
-  color: transparent;
-
-  // A box of its own, so a bar over one of these is a whole line box tall like every
-  // other bar. Inline still, so the strip reads the way the answer's does.
-  .game-status__meta-group > span {
-    display: inline-block;
-  }
-
-  .game-status__meta-group > span,
-  .game-status__spread,
-  .game-status__side-label,
-  .game-status__team-name,
-  .game-status__record,
-  .game-status__detail,
-  .game-status__down,
-  .game-status__outcome {
-    @include wireframe-bar;
-    @include skeleton-sheen;
-  }
-
-  // Thicker, standing in for the one line here set big enough to carry its own weight.
-  .game-status__points {
-    @include wireframe-bar(1.25rem);
-    @include skeleton-sheen;
-
-    @include roomy-screen {
-      @include wireframe-bar(2.25rem);
-    }
-  }
-
-  // A wireframe knows no score, so it lights no cells and shows none waiting either.
-  // The bar over the number is what stands in for the whole readout.
-  .game-status__points-ghost {
-    display: none;
-  }
-
-  // The mark's own square, filled. Round, because a square block reads as a blot at
-  // that size.
-  .game-status__logo {
-    @include skeleton-surface;
-    @include skeleton-sheen;
-
-    border-radius: 50%;
-  }
-
-  // Who has the ball is a thing the wireframe cannot know, so it keeps the room and
-  // says nothing. Both sides go the same way, which is what keeps the two mirrored.
-  //
-  // The strip under the scoreline names its own color as well, and the dot it puts
-  // between two halves is drawn in it.
-  .game-status__marker,
-  .game-status__meta,
-  .game-status__spread-value {
-    color: transparent;
-  }
-}
-
-.game-status__sr-only {
-  @include visually-hidden;
 }
 
 // The pool's own line on the game, over the scoreline it decides. Always said, `None`
@@ -243,8 +150,7 @@
 //
 // Whether there is room for it at all is `useScorelineFit`'s to say, since what it costs
 // the name beside it is what that name is. The last thing that hook gives up, and only
-// where cutting the name to its abbreviation left the two still short. The wireframe
-// draws its circle by the same answer, so a wait is still the size of the answer.
+// where cutting the name to its abbreviation left the two still short.
 .game-status__logo {
   display: block;
   align-self: center;

--- a/src/components/gameStatus/GameStatusSummary.test.tsx
+++ b/src/components/gameStatus/GameStatusSummary.test.tsx
@@ -1,29 +1,9 @@
-import {
-  fireEvent,
-  render as rtlRender,
-  screen,
-  type RenderResult,
-} from "@testing-library/react";
-import { ReactElement } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { GameStatus, HomeAway } from "../../types/ESPN";
 import { LeagueResult } from "../../types/LeagueResult";
 import { League } from "../../types/League";
 import { WeekGame } from "../../types/WeekGame";
 import GameStatusSummary from "./GameStatusSummary";
-
-/**
- * jsdom never actually fetches an image, so the logos `GameStatusSummary` waits
- * on before it leaves its wireframe would sit forever unloaded. Settling every
- * one straight after render stands in for the common case the wait is for: the
- * browser's image cache already warm from the dialog's own prefetch.
- */
-function render(ui: ReactElement): RenderResult {
-  const view = rtlRender(ui);
-  document
-    .querySelectorAll<HTMLImageElement>("img[hidden]")
-    .forEach((img) => fireEvent.load(img));
-  return view;
-}
 
 const KICKOFF = new Date("2024-10-06T17:00:00Z");
 
@@ -84,17 +64,12 @@ function result(over: Partial<LeagueResult> = {}): LeagueResult {
 }
 
 /*
- * The wireframe and the teams' marks, neither of which any query reaches: every word
- * under a wireframe is drawn as a bar, and a mark is decorative beside the name it
- * stands next to.
+ * The scoreline and the teams' marks, neither of which any query reaches: a mark is
+ * decorative beside the name it stands next to, and the scoreline is read whole rather
+ * than a line at a time.
  */
-function wireframe(): Element | null {
-  return document.querySelector(".game-status.--skeleton");
-}
-
-function scoreline(selector: string): string | undefined {
-  return document.querySelector(`${selector} .game-status__scoreline`)
-    ?.textContent;
+function scoreline(): string | undefined {
+  return document.querySelector(".game-status__scoreline")?.textContent;
 }
 
 function logos(): Array<string | null> {
@@ -103,66 +78,61 @@ function logos(): Array<string | null> {
   );
 }
 
-describe("GameStatusSummary, before there is anything to show", () => {
+describe("GameStatusSummary, the game it is given", () => {
   it("draws nothing with no game chosen", () => {
     const { container } = render(<GameStatusSummary />);
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("stands a wireframe in until the game has been fetched", () => {
+  it("shows the week's own copy of the game with nothing fetched yet", () => {
     render(<GameStatusSummary game={game(result())} />);
-    expect(screen.getByRole("status")).toHaveTextContent("Loading the game");
-    expect(wireframe()).not.toBeNull();
+    // The game itself rather than a wait for it, marks and all.
+    expect(
+      litDigits(
+        document.querySelector(
+          ".game-status__score.--home .game-status__points",
+        ) as Element,
+      ),
+    ).toEqual("30");
+    expect(logos()).toHaveLength(2);
   });
 
-  it("stands a wireframe in over the game before it while one is fetched", () => {
-    render(
-      <GameStatusSummary game={game(result())} result={result()} isLoading />,
-    );
-    // The wireframe carries the week's own copy of the game, so it comes out the
-    // size the answer will be. What is on screen is still only the wireframe.
-    expect(document.querySelector(".game-status:not(.--skeleton)")).toBeNull();
-    expect(wireframe()).not.toBeNull();
-  });
-
-  it("lays the wireframe out as the game it stands in for", () => {
-    const final = result();
-    const { unmount } = render(
-      <GameStatusSummary game={game(final)} result={final} />,
-    );
-    const shown = scoreline(".game-status:not(.--skeleton)");
+  it("lays the week's own copy out as the answer that replaces it", () => {
+    const week = result();
+    const { unmount } = render(<GameStatusSummary game={game(week)} />);
+    const before = scoreline();
     unmount();
 
-    // The same lines, in the same places, drawn from the week's own copy of the
-    // game, so nothing under the dialog moves when the answer lands.
-    render(<GameStatusSummary game={game(final)} />);
-    expect(scoreline(".game-status.--skeleton")).toEqual(shown);
+    // The same lines, in the same places, so nothing under the dialog moves when
+    // the answer lands on a game that has not moved either.
+    render(<GameStatusSummary game={game(week)} result={week} />);
+    expect(scoreline()).toEqual(before);
   });
 
-  it("holds the wireframe until both marks have loaded, even once the game has", () => {
-    // `rtlRender` rather than this file's own settling `render`, since this is
-    // what that settling stands in for.
-    rtlRender(<GameStatusSummary game={game(result())} result={result()} />);
-    expect(document.querySelector(".game-status:not(.--skeleton)")).toBeNull();
+  it("puts a fetched score up in place of the week's own", () => {
+    const home = (): string =>
+      litDigits(
+        document.querySelector(
+          ".game-status__score.--home .game-status__points",
+        ) as Element,
+      );
+    const week = result({
+      status: GameStatus.LIVE,
+      home: { ...result().home, score: 7 },
+    });
+    const { rerender } = render(<GameStatusSummary game={game(week)} />);
+    expect(home()).toEqual("7");
 
-    const [away, home] = document.querySelectorAll("img[hidden]");
-    fireEvent.load(away);
-    // One of the two loaded is not both of them.
-    expect(document.querySelector(".game-status:not(.--skeleton)")).toBeNull();
-
-    fireEvent.load(home);
-    expect(
-      document.querySelector(".game-status:not(.--skeleton)"),
-    ).not.toBeNull();
+    // The same game, one poll later. The score moves and nothing else does.
+    rerender(<GameStatusSummary game={game(week)} result={result()} />);
+    expect(home()).toEqual("30");
   });
 
-  it("shows the game without its marks rather than wait on one that never loads", () => {
-    rtlRender(<GameStatusSummary game={game(result())} result={result()} />);
-    fireEvent.error(document.querySelectorAll("img[hidden]")[0]);
+  it("shows the game without its marks rather than one that never loads", () => {
+    render(<GameStatusSummary game={game(result())} result={result()} />);
+    fireEvent.error(document.querySelectorAll("img")[0]);
 
-    expect(
-      document.querySelector(".game-status:not(.--skeleton)"),
-    ).not.toBeNull();
+    expect(document.querySelector(".game-status")).not.toBeNull();
     expect(logos()).toEqual([]);
   });
 
@@ -171,7 +141,7 @@ describe("GameStatusSummary, before there is anything to show", () => {
     expect(screen.getByText(/No game was found for P1/)).toHaveTextContent(
       "KC / BUF",
     );
-    expect(wireframe()).toBeNull();
+    expect(document.querySelector(".game-status")).toBeNull();
   });
 });
 

--- a/src/components/gameStatus/GameStatusSummary.tsx
+++ b/src/components/gameStatus/GameStatusSummary.tsx
@@ -321,8 +321,8 @@ function Score({
         "--missed": outcome === "missed",
       })}
     >
-      {/* Held apart from the marker beside it so the wireframe can draw a bar over
-          the number alone, and so a number of one digit takes the room two do. */}
+      {/* Held apart from the marker beside it so a number of one digit takes the
+          room two do. */}
       <span className="game-status__points">
         {/* Both cells, lit or not, so a score in single figures shows the one it is
             not using rather than a zero standing in it. The face is monospaced, so
@@ -458,14 +458,6 @@ function hasLogos(result: LeagueResult): boolean {
   return result.home.team.logoUrl != null && result.away.team.logoUrl != null;
 }
 
-/** Both logo URLs a result wears, away first as the scoreline shows them, or none
- *  where either side has none. */
-function logoUrlsOf(result: LeagueResult): Array<string> {
-  return hasLogos(result)
-    ? [result.away.team.logoUrl as string, result.home.team.logoUrl as string]
-    : [];
-}
-
 /**
  * The lines either side of the scores, each of which is one word on one line.
  *
@@ -583,11 +575,11 @@ function useScorelineFit(
 
 /**
  * The game, laid out the same way whether it is the one just fetched or the week's own
- * copy of it standing in under a wireframe.
+ * copy of it standing in until that answer lands.
  *
- * One layout for both is what keeps a wait the size of the answer: a game the week had
- * live carries a down and a link out, one it had finished carries neither, and the
- * wireframe is built from the same branches rather than from a guess at them.
+ * One layout for both is what lets an answer replace the copy in place: a game the week
+ * had live carries a down and a link out, one it had finished carries neither, and each
+ * of those is read off the game on screen rather than guessed at.
  */
 function Game({
   result,
@@ -599,11 +591,8 @@ function Game({
   spread?: GameSpread;
   /** What a side wears beside its name, or nothing where the marks are dropped. */
   logo?: (side: GameSide) => ReactNode;
-  /**
-   * ESPN's page for the game. Left off the wireframe, which is hidden from a screen
-   * reader and would otherwise hold a link that can be tabbed to but not seen.
-   */
-  gamecastHref?: string;
+  /** ESPN's page for the game. */
+  gamecastHref: string;
 }) {
   const [scoreline, fit] = useScorelineFit(result.id);
   // The link rides with the place rather than the kickoff, so it ends the strip at
@@ -611,16 +600,17 @@ function Game({
   // own, so a game ESPN sent no address for still carries the link.
   const placeParts = [
     result.venue,
-    gamecastHref != null && (
-      <a
-        className="game-status__gamecast"
-        href={gamecastHref}
-        target="_blank"
-        rel="noreferrer"
-      >
-        {GAMECAST_LABEL}
-      </a>
-    ),
+    <a
+      // `MetaGroup` keys each part by where it sits, so this one is only here
+      // because a bare element in an array literal is a lint error without it.
+      key="gamecast"
+      className="game-status__gamecast"
+      href={gamecastHref}
+      target="_blank"
+      rel="noreferrer"
+    >
+      {GAMECAST_LABEL}
+    </a>,
   ].filter(Boolean);
   // Only once the game is over, which is when the sentence under the scores says the
   // same thing. A side ahead at half time has won nothing yet.
@@ -668,70 +658,8 @@ function Game({
           opened for, and when and where it is played is the footnote. */}
       <div className="game-status__meta">
         <MetaGroup parts={kickoffParts(result.date)} />
-        {placeParts.length > 0 && <MetaGroup parts={placeParts} />}
+        <MetaGroup parts={placeParts} />
       </div>
-    </>
-  );
-}
-
-/**
- * The game before it has been fetched, drawn from the week's own copy of it.
- *
- * The same layout as the answer, with every word left in place and taken down to a bar
- * over it, so the wait is the size the answer will be: the same lines, in the same
- * rows, at the same widths, down to a name that takes two lines and a venue that takes
- * its own. Nothing under the dialog moves when the answer lands. What is on the way is
- * the same game, so the only thing the week's copy of it can be wrong about is a score
- * or a clock.
- *
- * Crossed by the one sheen the tables' wireframe uses, so a wait looks the same
- * wherever the app is waiting.
- */
-function Wireframe({
-  result,
-  spread,
-  pendingLogoUrls,
-  onLogoLoad,
-  onLogoError,
-}: {
-  result: LeagueResult;
-  spread?: GameSpread;
-  /** Every logo this game wears, decoded off screen so none of them pop in
-   *  once the wireframe gives way to the game itself. */
-  pendingLogoUrls: Array<string>;
-  onLogoLoad: (url: string) => void;
-  onLogoError: () => void;
-}) {
-  return (
-    <>
-      {/* Nothing below is worth reading out, so this says what it stands in for. */}
-      <span className="game-status__sr-only" role="status">
-        Loading the game
-      </span>
-      <div aria-hidden="true" className="game-status --skeleton">
-        <Game
-          result={result}
-          spread={spread}
-          // A block of its own rather than the mark itself: an image cannot carry the
-          // bar the rest of the wireframe is drawn with, and the real one is not
-          // fetched for a game nobody is looking at yet.
-          logo={
-            hasLogos(result)
-              ? () => <span className="game-status__logo" />
-              : undefined
-          }
-        />
-      </div>
-      {pendingLogoUrls.map((url) => (
-        <img
-          key={url}
-          src={url}
-          alt=""
-          hidden
-          onLoad={() => onLogoLoad(url)}
-          onError={onLogoError}
-        />
-      ))}
     </>
   );
 }
@@ -741,26 +669,21 @@ function Wireframe({
  * scores meeting at a dash between them, with where the game is up to over those scores
  * and what the offense or the pool has to say under them.
  *
- * `result` is the game as it was last fetched, and `isLoading` says it is not yet the
- * game `game` names. A wireframe stands in until it is, so a live game is never shown
- * at the score the week was last worked out at, nor at another game's.
+ * `result` is the game as it was last fetched. There is none until the first answer
+ * lands, and the week's own copy of the same game stands in meanwhile, so the dialog
+ * opens on the game rather than on a wait for it.
  */
 export default function GameStatusSummary({
   game,
   result,
-  isLoading = false,
 }: {
   game?: WeekGame;
+  /** The game as last fetched, where a fresher one than the week's has arrived. */
   result?: LeagueResult;
-  /** Set while the chosen game is being fetched for the first time. */
-  isLoading?: boolean;
 }) {
   // Which game's marks failed to load, rather than a flag, so moving to another
   // game asks about its marks instead of inheriting a verdict on the last one's.
   const [logolessId, setLogolessId] = useState<string>();
-  // Every URL that has already loaded, so a team seen once does not ask to be
-  // waited on again on a later game or a poll of this one.
-  const [loadedLogoUrls, setLoadedLogoUrls] = useState<Set<string>>(new Set());
 
   if (game == null) {
     return null;
@@ -774,39 +697,18 @@ export default function GameStatusSummary({
     );
   }
 
-  // `GameStatusDialog` has already asked the browser to warm every logo the week
-  // could show, so decoding these here is almost always a cache hit rather than
-  // a fetch, and the wireframe below holds only as long as that hit takes.
-  const chosenId = game.result.id;
-  const pendingLogoUrls = logoUrlsOf(game.result);
-  const logosDone =
-    logolessId === chosenId ||
-    pendingLogoUrls.every((url) => loadedLogoUrls.has(url));
-
-  // The wireframe rather than the game before it, so what is on screen is always
-  // the game the search names, and never a mark still popping in over it.
-  if (isLoading || result == null || !logosDone) {
-    return (
-      <Wireframe
-        result={game.result}
-        spread={game.spread}
-        pendingLogoUrls={pendingLogoUrls}
-        onLogoLoad={(url) =>
-          setLoadedLogoUrls((loaded) => new Set(loaded).add(url))
-        }
-        onLogoError={() => setLogolessId(chosenId)}
-      />
-    );
-  }
-
-  const logos = hasLogos(result) && logolessId !== result.id;
+  // The game as last fetched, or the week's own copy until the first answer lands.
+  // Both are the same game, so the only thing the week's copy can be behind on is a
+  // score or a clock, and a live one is replaced in place a moment later.
+  const shown = result ?? game.result;
+  const logos = hasLogos(shown) && logolessId !== shown.id;
 
   return (
     <div className="game-status">
       <Game
-        result={result}
+        result={shown}
         spread={game.spread}
-        gamecastHref={gamecastUrl(game.league, result.id)}
+        gamecastHref={gamecastUrl(game.league, shown.id)}
         logo={
           logos
             ? (side) => (
@@ -816,7 +718,12 @@ export default function GameStatusSummary({
                   // The team's name is beside it, so the mark says nothing a
                   // reader of the page in words is missing.
                   alt=""
-                  onError={() => setLogolessId(result.id)}
+                  // `GameStatusDialog` has already asked the browser to warm every
+                  // logo the week could show, so this is normally a cache hit, and
+                  // decoding it before the frame goes up puts the mark on screen
+                  // with the name beside it rather than a frame behind it.
+                  decoding="sync"
+                  onError={() => setLogolessId(shown.id)}
                 />
               )
             : undefined

--- a/src/components/gameStatus/GameStatusSummary.tsx
+++ b/src/components/gameStatus/GameStatusSummary.tsx
@@ -718,10 +718,10 @@ export default function GameStatusSummary({
                   // The team's name is beside it, so the mark says nothing a
                   // reader of the page in words is missing.
                   alt=""
-                  // `GameStatusDialog` has already asked the browser to warm every
-                  // logo the week could show, so this is normally a cache hit, and
-                  // decoding it before the frame goes up puts the mark on screen
-                  // with the name beside it rather than a frame behind it.
+                  // `GameStatusDialog` has already warmed every logo the week could
+                  // show, so this is normally a cache hit, and decoding it before
+                  // the frame goes up puts the mark on screen with the name beside
+                  // it rather than a frame behind it.
                   decoding="sync"
                   onError={() => setLogolessId(shown.id)}
                 />

--- a/src/components/gameStatus/gameStatusDialogTestSupport.tsx
+++ b/src/components/gameStatus/gameStatusDialogTestSupport.tsx
@@ -1,4 +1,3 @@
-import { fireEvent } from "@testing-library/react";
 import { MockedFunction } from "vitest";
 import { WeekInfo } from "../../types/League";
 import { RakMadnessScores } from "../../types/RakMadnessScores";
@@ -27,18 +26,6 @@ export const WEEK: WeekInfo = {
   endDate: new Date("2024-10-08T00:00:00Z"),
 };
 export const SEASON = 2024;
-
-/**
- * jsdom never actually fetches an image, so a game's marks would sit forever
- * unloaded behind `GameStatusSummary`'s own wireframe. Settles them for the game
- * on screen, standing in for the common case the wait is for: the browser's
- * image cache already warm from the dialog's own prefetch.
- */
-export function settleLogos() {
-  document
-    .querySelectorAll<HTMLImageElement>("img[hidden]")
-    .forEach((img) => fireEvent.load(img));
-}
 
 export function dialog(
   gameLabel: string | undefined,

--- a/src/hooks/useLiveGame.ts
+++ b/src/hooks/useLiveGame.ts
@@ -13,14 +13,16 @@ export const POLL_MS = 20_000;
  * One game, kept up to date for as long as it is being looked at.
  *
  * The week's scores carry the game as it stood when they were worked out, which is
- * stale the moment a live game moves, so a game is fetched again before it is
- * shown and then on `POLL_MS` until it is final. A game already final when it is
- * opened is shown as the scoring pass left it, because nothing about it can differ.
+ * stale the moment a live game moves, so a game is fetched again as it is shown and
+ * then on `POLL_MS` until it is final. A game already final when it is opened is
+ * never fetched at all, because nothing about it can differ.
  *
- * The game already on screen stays there while the next one is fetched, the way the
- * player analysis holds the last answer up behind its progress bar. `games` is the
- * scoring pass it belongs to: a rescore replaces every game, so it takes the one on
- * screen away with it.
+ * `shown` is the fresher answer alone. Nothing is returned until one lands, and the
+ * caller shows the week's own copy of the game meanwhile, so a reader never waits
+ * behind a fetch for a game they can already see.
+ *
+ * `games` is the scoring pass the answer belongs to. A rescore replaces every game,
+ * so it takes the fetched one with it.
  */
 export default function useLiveGame({
   open,
@@ -41,7 +43,7 @@ export default function useLiveGame({
    * before the next scheduled refresh would have.
    */
   onGameFinal?: () => void;
-}): { shown?: LeagueResult; isLoading: boolean; isFetching: boolean } {
+}): { shown?: LeagueResult; isFetching: boolean } {
   const [found, setFound] = useState<{
     games: Array<WeekGame>;
     label: string;
@@ -99,15 +101,12 @@ export default function useLiveGame({
     };
   }, [open, games, label, league, eventId, settled, week, season, onGameFinal]);
 
+  // Stamped with the game it was fetched for as well as the scoring pass, so an
+  // answer that landed for the game before this one is never handed back for it.
   const shown =
     settled ??
-    (found != null && found.games === games ? found.result : undefined);
-  const isLoading =
-    game != null &&
-    eventId != null &&
-    settled == null &&
-    (shown == null || found?.label !== label);
-  // `isLoading` is the wait with nothing to show behind it, and `isFetching` every
-  // wait, a poll of a game already on screen included.
-  return { shown, isLoading, isFetching: fetching };
+    (found != null && found.games === games && found.label === label
+      ? found.result
+      : undefined);
+  return { shown, isFetching: fetching };
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -521,14 +521,14 @@ html {
   // `--rak-scrim` is 45% of `--rak-shadow-color`, which is #151515: laid over
   // this surface it lands on #171717, a 1.02 step. `--rak-shadow-modal` is the
   // same near-black, so it draws nothing either. Lifting the fill is the only
-  // separation left, and it is a 1.11 step, which the edge below then makes
-  // measurable.
-  --rak-surface-raised: #212121;
+  // separation left, and it is a 1.04 step. Too small to read on its own, so the
+  // edge below is what actually separates the two planes.
+  --rak-surface-raised: #1d1d1d;
   --rak-fill-subtle: #212121;
   --rak-fill-muted: #292929;
   --rak-border: #747474;
   --rak-panel-border: var(--rak-border);
-  // 3.45:1 against the raised fill, which two planes this dark can never reach
+  // 3.61:1 against the raised fill, which two planes this dark can never reach
   // against each other. The edge is what carries the requirement.
   --rak-dialog-edge: var(--rak-panel-border);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,9 +57,8 @@ for (const href of PREFETCH_FONT_URLS) {
   });
 }
 // A cache warm alone still shows the fallback face until something decodes the
-// font outright. Weights below are all ones a route paints immediately, before
-// a reader has clicked anything, so each is asked for here rather than left to
-// arrive after that first paint has already committed to the fallback.
+// font outright. Every weight below is decoded up front rather than left to
+// arrive after the paint that needs it has already committed to the fallback.
 const FIRST_PAINT_FONTS = [
   ["400", "Chakra Petch"], // body copy
   ["600", "Chakra Petch"], // buttons, e.g. the home page's own
@@ -68,6 +67,11 @@ const FIRST_PAINT_FONTS = [
   ["600", "IBM Plex Mono"], // the home page's selected season row
   ["700", "IBM Plex Mono"], // a table's bold rank column
   ["700", "DSEG14 Classic"], // the navbar logo's name, on every route
+  // The scoreline's readout. Nothing paints it until the game status dialog
+  // opens, so a decode left until then swaps the face under a dialog already on
+  // screen. `useScorelineFit` measures that dialog, and it measures the fallback
+  // when the swap has yet to land.
+  ["700", "DSEG7 Classic"],
 ];
 for (const [weight, family] of FIRST_PAINT_FONTS) {
   document.fonts.load(`${weight} 1em "${family}"`).catch(() => {});

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -18,6 +18,7 @@
 - `matching`: case-folded substring search, shared by both dialogs' item lists
 - `readFileToBuffer`: an upload's bytes
 - `prefetchLink`: prefetch, no unused-preload console warning
+- `warmImage`: an image into the browser's cache, once, where prefetch does not reach
 
 ## Subdirectories
 

--- a/src/utils/warmImage.ts
+++ b/src/utils/warmImage.ts
@@ -1,0 +1,23 @@
+const warmed = new Map<string, HTMLImageElement>();
+
+export function warmedImageUrls(): Array<string> {
+  return [...warmed.keys()];
+}
+
+/**
+ * Fetches an image into the browser's own image cache, where an `<img>` drawn later
+ * with the same `src` finds it already there rather than going back out for it.
+ *
+ * A `<link rel=prefetch>` is the cheaper-looking way to do this and does not hold
+ * up. It is a hint the browser may defer or drop, and Safari does not implement it
+ * at all. Neither way warns about an unused resource, which is what rules out
+ * `rel=preload`.
+ *
+ * Each image is kept, because a collected one can take its cache entry with it.
+ */
+export default function warmImage(url: string) {
+  if (warmed.has(url)) return;
+  const image = new Image();
+  image.src = url;
+  warmed.set(url, image);
+}


### PR DESCRIPTION
## What

Delete the game status dialog's loading wireframe. The dialog opens straight onto the game.

## Why

The wireframe covered every game, one that finished weeks ago included. The less obvious gate: `GameStatusSummary` held it until both team logos decoded, in component state Base UI drops on close, so the gate fired again on every open.

## Changes

- `useLiveGame` returns the fresher answer alone. `shown` stays undefined until a fetch lands, and the caller falls back to the week's own copy of the same game.
- `shown` gains a label guard. `isLoading` used to cover the case where an answer landed for the game before this one.
- A game the week scored `FINAL` still never reaches the network. That gate is unchanged.
- The logos warm through `new Image()` rather than `rel=prefetch`. A prefetch is a hint the browser may defer, and Safari does not implement it. Opening the dialog under it fired 13 logo requests against the dev server. It now fires none.
- DSEG7 was warmed but never decoded, so the scoreline painted in the fallback face and `useScorelineFit` measured the wrong widths.
- Dark mode's dialog fill drops to `#1d1d1d`. The step over the page is now too small to read, so the edge separates them alone, and gains contrast doing it.

## Verification

- Chromium, with the picks API and ESPN mocked. A finished week opens each game with its full scoreline on the frame the dialog paints, both marks already `complete`. A `MutationObserver` saw no `.game-status.--skeleton` and no progress bar.

🔍 Investigated by [Agent Carmen Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
