### PR TITLE
fix(dialog): open the list from a press anywhere on the search field

### DIFF
--- a/src/components/dialog/DialogCombobox.scss
+++ b/src/components/dialog/DialogCombobox.scss
@@ -21,9 +21,9 @@
   @include focus-ring(":focus-within");
 }
 
-// The whole field, under everything drawn on it. Positioned, so it paints over the
-// icon and the adornment, which are not, and a press on either reaches it. The input
-// is lifted back over it below.
+// Fills the field. Positioned, so it sits above the icon and the adornment,
+// neither of which is, and a press on either reaches it. The input is lifted
+// back above it below.
 .dialog__search-trigger {
   position: absolute;
   inset: 0;

--- a/src/components/dialog/DialogCombobox.scss
+++ b/src/components/dialog/DialogCombobox.scss
@@ -9,6 +9,8 @@
 .dialog__search {
   @include lcd-field;
 
+  // The box the trigger below is stretched over.
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--rak-space-2);
@@ -19,7 +21,21 @@
   @include focus-ring(":focus-within");
 }
 
+// The whole field, under everything drawn on it. Positioned, so it paints over the
+// icon and the adornment, which are not, and a press on either reaches it. The input
+// is lifted back over it below.
+.dialog__search-trigger {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
+
 .dialog__input {
+  // Over the trigger, since a press here is the input's own: it is what opens a
+  // phone's keyboard, and it places the caret.
+  position: relative;
   flex: 1;
   min-width: 0;
   padding: 3px 0;

--- a/src/components/dialog/DialogCombobox.tsx
+++ b/src/components/dialog/DialogCombobox.tsx
@@ -111,6 +111,23 @@ export default function DialogCombobox<T>({
       autoHighlight
     >
       <div className="dialog__search">
+        {/*
+          A press anywhere on the field opens the list, rather than only one landing
+          in the input. This fills the field and everything else in it draws over
+          it, so the icon, the adornment, and the padding around them all reach it.
+
+          The input alone sits above it and keeps its own press, which is what a
+          phone needs: the trigger raises no keyboard on a touch, and a search
+          opened without one cannot be typed into.
+
+          Out of a reader's way, which has the input's own `combobox` role for all
+          of this and would otherwise be offered a second, nameless control.
+        */}
+        <Combobox.Trigger
+          className="dialog__search-trigger"
+          aria-hidden="true"
+          tabIndex={-1}
+        />
         <Combobox.Input
           ref={inputRef}
           placeholder={placeholder}

--- a/src/components/gameStatus/GameStatusDialog.scss
+++ b/src/components/gameStatus/GameStatusDialog.scss
@@ -63,6 +63,9 @@ $check-icon-ratio: math.div(451, 333);
   display: flex;
   align-items: center;
   justify-content: center;
+  // Out of any selection dragged over the list. The four words are the mark's
+  // shape, not text worth copying, and highlighted they read as picked out.
+  user-select: none;
 
   &.--live {
     @include mark-pill(var(--rak-mark-live-bg), var(--rak-mark-live-text));

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
@@ -218,6 +218,21 @@ describe("PlayerAnalysisDialog", () => {
     // with the name rather than standing over an empty search.
     expect(document.querySelector(".player-analysis__input-status")).toBeNull();
 
+    // The press is the whole field, not the input alone. The trigger stretched
+    // over it is what the chevron, the mark, and the padding around them all
+    // reach, and it opens the list the same way a press on the input does.
+    await user.keyboard("{Escape}");
+    const field = document.querySelector<HTMLElement>(
+      ".dialog__search-trigger",
+    );
+    expect(field).not.toBeNull();
+    await user.click(field!);
+
+    expect(
+      (await screen.findAllByRole("option")).map((it) => it.textContent),
+    ).toEqual(["Alice", "Bob", "Bobby"]);
+    expect(screen.getByRole("combobox", { name: "Player" })).toHaveValue("");
+
     // Dismissing puts the chosen name back, since the answer below is still that
     // player's.
     await user.keyboard("{Escape}");


### PR DESCRIPTION
## What

A press anywhere on a dialog's search field opens its list. A game status mark no longer joins a selection dragged over the list.

## Why

Only the input opened the list. The chevron, the mark beside it, and the padding around them did nothing.

## Changes

- A `Combobox.Trigger` stretches over the whole field and takes every press the input does not.
- The input stays above the trigger. A touch on the input raises the phone keyboard, and a touch on the trigger does not.
- The trigger is `aria-hidden` and out of the tab order. The input already carries the `combobox` role.
- Base UI still anchors the list to the input, so the popup keeps its width and its place.

## Notes / Follow-ups

- The touch path comes from Base UI's own trigger code. I did not test it on a device.

💣 Neutralized by [Agent Juni Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
