### PR TITLE
fix(pageLayout): fill the scrolling box with the header's own color

### DIFF
--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -93,7 +93,15 @@
     // the box, so nothing but that gap ever shows this. A roomier screen leaves
     // room beside the table, where it would show as a second dark band against the
     // header, so the surface every other page carries goes back below.
-    background-color: var(--rak-primary-600);
+    //
+    // The header's color rather than the frame's, because the header is what the
+    // gap opens over on nearly every fling. It pins to the top, so it is on screen
+    // whichever way the table is thrown. `.results-caption__text` pins too and
+    // stands on the frame's color instead, so the gap now shows over the caption
+    // where it did not before. That costs only a fling thrown sideways with the
+    // table already at the top, against a header that flashed on all of them.
+    // See SCROLL-FLASH.md.
+    background-color: var(--rak-primary-800);
 
     // Nothing of its own, so the tiled ground behind the page shows either side of
     // the table, which is what every other page stands on. The shadow goes with


### PR DESCRIPTION
## What

`.page__content.--scores` goes from `--rak-primary-600` to `--rak-primary-800`, the color the table header already carries.

## Why

Firefox on Android fills a region it has not rasterized yet with the scroll container's own color. A `position: sticky` element leaves such a region, so a fast fling flashes a flat band over the pinned header. The header is `--rak-primary-800` and the container was `--rak-primary-600`, so that band read as a lighter gray over a darker header. Matched, the band is invisible. `SCROLL-FLASH.md` records the mechanism.

## Changes

- The change is not free. `.results-caption__text` sticks too and stands on `--rak-primary-600`, so its band becomes visible where it was invisible. It only sticks left, and it scrolls away with the first rows, so it costs a sideways fling with the table already at the top. The header pinned to the viewport flashed on every fling.
- A roomy screen already resets this background to `transparent`, so nothing changes above the breakpoint.

## Verification

Fling a week's scoreboard on Android Firefox. Set `apz.record_checkerboarding` to `true` first, then read `about:checkerboard` for a severity rather than an impression.

## Notes / Follow-ups

This does nothing for the pinned player column, which is the other half of the flash. `debug-thead-sticky-only` is the throwaway branch that decides whether a structural fix for that column is worth building.

🧼 Sanitized by [Agent Juni Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
