### PR TITLE
chore(table): stick the header row alone to bisect the scroll flash

### DIFF
--- a/.claude/skills/record-demo/scripts/scenarios/header-pin-probe.js
+++ b/.claude/skills/record-demo/scripts/scenarios/header-pin-probe.js
@@ -8,9 +8,26 @@ const SEASON = 2024;
 const WEEK = 5;
 
 const NAMES = [
-  "Alice", "Bob", "Carol", "Dave", "Erin", "Frank", "Grace", "Heidi",
-  "Ivan", "Judy", "Mallory", "Niaj", "Olivia", "Peggy", "Rupert", "Sybil",
-  "Trent", "Victor", "Walter", "Wendy",
+  "Alice",
+  "Bob",
+  "Carol",
+  "Dave",
+  "Erin",
+  "Frank",
+  "Grace",
+  "Heidi",
+  "Ivan",
+  "Judy",
+  "Mallory",
+  "Niaj",
+  "Olivia",
+  "Peggy",
+  "Rupert",
+  "Sybil",
+  "Trent",
+  "Victor",
+  "Walter",
+  "Wendy",
 ];
 
 const PICK_SETS = [
@@ -51,7 +68,9 @@ export default async function run({ page, context, baseUrl }) {
   await page.waitForTimeout(800);
 
   const scroller = page.locator(".page__content");
-  const max = await scroller.evaluate((el) => el.scrollHeight - el.clientHeight);
+  const max = await scroller.evaluate(
+    (el) => el.scrollHeight - el.clientHeight,
+  );
   console.log("vertical scroll range:", max);
   await scroller.evaluate((el) => {
     el.scrollTop = Math.round((el.scrollHeight - el.clientHeight) / 2);

--- a/.claude/skills/record-demo/scripts/scenarios/header-pin-probe.js
+++ b/.claude/skills/record-demo/scripts/scenarios/header-pin-probe.js
@@ -1,0 +1,61 @@
+import {
+  buildPicksWorkbook,
+  makeGame,
+  registerAppMocks,
+} from "../lib/mocks.js";
+
+const SEASON = 2024;
+const WEEK = 5;
+
+const NAMES = [
+  "Alice", "Bob", "Carol", "Dave", "Erin", "Frank", "Grace", "Heidi",
+  "Ivan", "Judy", "Mallory", "Niaj", "Olivia", "Peggy", "Rupert", "Sybil",
+  "Trent", "Victor", "Walter", "Wendy",
+];
+
+const PICK_SETS = [
+  { P1: "KC", P2: "SF", P3: "MIA", P4: "GB", P5: "BAL", P6: "LAC" },
+  { P1: "BUF", P2: "DAL", P3: "NYJ", P4: "CHI", P5: "CIN", P6: "DEN" },
+  { P1: "KC", P2: "DAL", P3: "MIA", P4: "CHI", P5: "BAL", P6: "LAC" },
+];
+
+const ROWS = Array.from({ length: 60 }, (_, i) => ({
+  Name: `${NAMES[i % NAMES.length]} ${Math.floor(i / NAMES.length) + 1}`,
+  ...PICK_SETS[i % PICK_SETS.length],
+}));
+
+function events() {
+  return {
+    events: [
+      makeGame("P1EVT", "KC", "BUF", 24, 17, "3"),
+      makeGame("P2EVT", "SF", "DAL", 27, 20, "3"),
+      makeGame("P3EVT", "NYJ", "MIA", 16, 20, "3"),
+      makeGame("P4EVT", "CHI", "GB", 10, 24, "3"),
+      makeGame("P5EVT", "BAL", "CIN", 24, 17, "3"),
+      makeGame("P6EVT", "DEN", "LAC", 13, 27, "3"),
+    ],
+  };
+}
+
+/** Scrolls the scoreboard down, so a screenshot shows whether the header pins. */
+export default async function run({ page, context, baseUrl }) {
+  await registerAppMocks(context, {
+    season: SEASON,
+    week: WEEK,
+    xlsxBuffer: buildPicksWorkbook(ROWS),
+    events,
+  });
+
+  await page.goto(`${baseUrl}/${SEASON}/${WEEK}/scoreboard`);
+  await page.waitForSelector("td.table__player-col", { timeout: 20000 });
+  await page.waitForTimeout(800);
+
+  const scroller = page.locator(".page__content");
+  const max = await scroller.evaluate((el) => el.scrollHeight - el.clientHeight);
+  console.log("vertical scroll range:", max);
+  await scroller.evaluate((el) => {
+    el.scrollTop = Math.round((el.scrollHeight - el.clientHeight) / 2);
+    el.scrollLeft = el.scrollWidth - el.clientWidth;
+  });
+  await page.waitForTimeout(800);
+}

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -111,18 +111,18 @@
 
   .table__header {
     background-color: var(--rak-primary-800);
+    // THROWAWAY. One sticky element for the whole header, so the page carries two
+    // sticky elements in total. See SCROLL-FLASH.md.
+    position: sticky;
+    top: 0;
+    z-index: var(--rak-z-sticky-header);
 
     th {
       // The screen-printed label every heading in the app is set in.
       @include micro-label;
 
-      // Each cell sticks on its own rather than the row's section doing it for
-      // them. The player column sticks left, and a cell sticking inside a
-      // sticky <thead> is a case Firefox on Android hands back to the main
-      // thread, which lands it a frame or two behind a fling. What shows in the
-      // gap is the white underneath.
       z-index: var(--rak-z-sticky-header);
-      position: sticky;
+      position: static;
       top: 0;
       color: var(--rak-on-solid);
       background-color: var(--rak-primary-800);
@@ -231,7 +231,8 @@
   // positioned cell already draws over the static ones beside it, and the header
   // sets a `z-index` of its own to stay over this on the way past.
   .table__player-col {
-    position: sticky;
+    // THROWAWAY. Unpinned, so the header is the only thing sticking.
+    position: static;
     left: 0;
   }
 


### PR DESCRIPTION
## What

Throwaway branch. Do not merge. It exists for the Cloudflare preview deploy, so the flash can be flick-tested on a real Android phone.

## Why

`SCROLL-FLASH.md` records that `position: sticky` causes the flash, and that every sticky element leaves a region Firefox fills with a flat color. Two mechanisms in Gecko fit that symptom and they disagree. WebRender picture cache slice pressure scales with the number of sticky elements, and this table carries 69 of them on the scoreboard. The displayport clip in https://bugzilla.mozilla.org/show_bug.cgi?id=1424714 holes each sticky element whatever the count. This branch separates the two.

## Changes

- `position: sticky` moves onto `<thead>` as one element. Every `<th>` and the player column go static. The page is left with two sticky elements, the header row and the caption text.
- `SCROLL-FLASH.md` asks for a `debug-header-sticky-only` run. That branch left 8 to 24 sticky `<th>`, already past WebRender's slice budget, so its result could not separate the two mechanisms. This one can.

## Verification

Set `apz.record_checkerboarding` to `true`, fling a week's scoreboard, then read `about:checkerboard`.

If the header still flashes, the count is not the driver. The overlay fix is dead and recoloring the player column is the only lever left. If the header is clean, the count is the driver and the overlay is worth building.

## Notes / Follow-ups

Close this without merge once the number is recorded in `SCROLL-FLASH.md`. Delete `debug-no-sticky` and `debug-header-sticky-only` at the same time.

🕵️ Handled by [Agent Spy Fox](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
