### PR TITLE
feat(results): pull down to refresh a live week on a phone

### DIFF
--- a/.claude/skills/record-demo/SKILL.md
+++ b/.claude/skills/record-demo/SKILL.md
@@ -23,7 +23,8 @@ node .claude/skills/record-demo/scripts/record.js \
 
 Drop `--mp4` to keep the raw `.webm`. Add `--base-url` for a non-default dev
 server port, `--viewport WxH` for a different size (default `430x900`, this
-app's own phone-first default).
+app's own phone-first default), and `--touch` for a scenario driving a touch
+gesture, which also turns off every `can-hover` rule.
 
 ## Take a screenshot instead
 
@@ -44,6 +45,9 @@ instead of recording the whole run.
   dialog theme switch, the reader's own row, and the home page's two colored
   keys, in both themes. Writes its crops to `$LED_SHOT_DIR`, so `--out` is a
   throwaway.
+- `scenarios/pull-to-refresh.js` — pulls down from the top of the scoreboard on
+  a phone, where the navbar's refresh button is read and not drawn. Needs
+  `--touch`.
 - `scenarios/live-refresh.js` — opens the Game Status dialog on a live pick,
   waits out its real poll interval, and shows the table update on its own
   once the mocked game goes final.

--- a/.claude/skills/record-demo/SKILL.md
+++ b/.claude/skills/record-demo/SKILL.md
@@ -48,6 +48,10 @@ instead of recording the whole run.
 - `scenarios/pull-to-refresh.js` — pulls down from the top of the scoreboard on
   a phone, where the navbar's refresh button is read and not drawn. Needs
   `--touch`.
+- `scenarios/pull-close-variants.js` — the same pull twice, once at real speed
+  and once stretched, with a candidate close animation injected from
+  `$CLOSE_CSS` and `$CLOSE_CSS_SLOW`. Needs `--touch`. For comparing curves
+  against one build instead of rebuilding per candidate.
 - `scenarios/live-refresh.js` — opens the Game Status dialog on a live pick,
   waits out its real poll interval, and shows the table update on its own
   once the mocked game goes final.

--- a/.claude/skills/record-demo/scripts/lib/browser.js
+++ b/.claude/skills/record-demo/scripts/lib/browser.js
@@ -14,6 +14,7 @@ import path from "node:path";
  *   outPath: string,
  *   screenshot?: boolean,
  *   viewport?: { width: number, height: number },
+ *   touch?: boolean,
  *   mp4?: boolean,
  * }} options
  */
@@ -21,6 +22,7 @@ export async function launchDemo({
   outPath,
   screenshot = false,
   viewport = { width: 430, height: 900 },
+  touch = false,
   mp4 = false,
 }) {
   const browser = await chromium.launch({ headless: true });
@@ -29,6 +31,12 @@ export async function launchDemo({
     : await mkdtemp(path.join(tmpdir(), "record-demo-"));
   const context = await browser.newContext({
     viewport,
+    // A phone rather than a narrow desktop window. Off by default, because it
+    // also turns off every `can-hover` rule, which is what the other scenarios
+    // are capturing. Without it Chromium reports `hover: hover` and
+    // `pointer: fine`, so a scenario driving a touch gets no phone-only rules.
+    hasTouch: touch,
+    isMobile: touch,
     recordVideo: videoDir ? { dir: videoDir, size: viewport } : undefined,
   });
   const page = await context.newPage();

--- a/.claude/skills/record-demo/scripts/record.js
+++ b/.claude/skills/record-demo/scripts/record.js
@@ -9,6 +9,7 @@ function parseArgs(argv) {
     viewportWidth: 430,
     viewportHeight: 900,
     screenshot: false,
+    touch: false,
     mp4: false,
   };
   for (let i = 0; i < argv.length; i++) {
@@ -32,6 +33,9 @@ function parseArgs(argv) {
       case "--screenshot":
         args.screenshot = true;
         break;
+      case "--touch":
+        args.touch = true;
+        break;
       case "--mp4":
         args.mp4 = true;
         break;
@@ -41,7 +45,7 @@ function parseArgs(argv) {
   }
   if (!args.scenario || !args.out) {
     throw new Error(
-      "Usage: record.js --scenario <path> --out <file> [--screenshot] [--base-url <url>] [--viewport WxH] [--mp4]",
+      "Usage: record.js --scenario <path> --out <file> [--screenshot] [--base-url <url>] [--viewport WxH] [--touch] [--mp4]",
     );
   }
   return args;
@@ -56,6 +60,7 @@ async function main() {
     outPath: path.resolve(process.cwd(), args.out),
     screenshot: args.screenshot,
     viewport: { width: args.viewportWidth, height: args.viewportHeight },
+    touch: args.touch,
     mp4: args.mp4,
   });
 

--- a/.claude/skills/record-demo/scripts/scenarios/pull-close-variants.js
+++ b/.claude/skills/record-demo/scripts/scenarios/pull-close-variants.js
@@ -1,0 +1,92 @@
+import {
+  buildPicksWorkbook,
+  makeGame,
+  registerAppMocks,
+} from "../lib/mocks.js";
+
+const SEASON = 2024;
+const WEEK = 5;
+
+const PULL_DISTANCE_PX = 150;
+const PULL_STEPS = 26;
+
+const ROWS = [
+  { Name: "Alice", P1: "KC", P2: "SF", P3: "MIA", P4: "GB", P5: "BAL" },
+  { Name: "Bob", P1: "BUF", P2: "DAL", P3: "NYJ", P4: "CHI", P5: "CIN" },
+  { Name: "Carol", P1: "KC", P2: "DAL", P3: "MIA", P4: "CHI", P5: "BAL" },
+  { Name: "Dave", P1: "BUF", P2: "SF", P3: "NYJ", P4: "GB", P5: "CIN" },
+  { Name: "Erin", P1: "KC", P2: "SF", P3: "NYJ", P4: "GB", P5: "BAL" },
+  { Name: "Frank", P1: "BUF", P2: "DAL", P3: "MIA", P4: "CHI", P5: "CIN" },
+  { Name: "Grace", P1: "KC", P2: "SF", P3: "MIA", P4: "", P5: "BAL" },
+  { Name: "Heidi", P1: "BUF", P2: "DAL", P3: "NYJ", P4: "CHI", P5: "BAL" },
+];
+
+const events = {
+  events: [
+    makeGame("P1EVT", "KC", "BUF", 7, 3, "2"),
+    makeGame("P2EVT", "SF", "DAL", 27, 20, "3"),
+    makeGame("P3EVT", "NYJ", "MIA", 16, 20, "3"),
+    makeGame("P4EVT", "CHI", "GB", 10, 24, "3"),
+    makeGame("P5EVT", "BAL", "CIN", 24, 17, "3"),
+  ],
+};
+
+async function pull({ cdp, page, distance, steps }) {
+  const box = await page.locator("main#main").boundingBox();
+  const x = Math.round(box.x + box.width / 2);
+  const y = Math.round(box.y + 40);
+  const at = (step) => [{ x, y: Math.round(y + (distance * step) / steps) }];
+
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: at(0),
+  });
+  for (let step = 1; step <= steps; step += 1) {
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: at(step),
+    });
+    await page.waitForTimeout(16);
+  }
+  await page.waitForTimeout(250);
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchEnd",
+    touchPoints: [],
+  });
+}
+
+/**
+ * One candidate close animation, pulled twice: once at its real duration, once
+ * with every duration in it multiplied so the curve itself can be read.
+ *
+ * The candidate is CSS injected over the running app, read from `$CLOSE_CSS` and
+ * `$CLOSE_CSS_SLOW`, so every variant runs against one unmodified build. The slow
+ * pass stretches the CSS rather than the clock, because the timer that drops
+ * `data-pull` is JavaScript and would cut a stretched transition off mid-flight.
+ */
+export default async function run({ page, context, baseUrl }) {
+  await registerAppMocks(context, {
+    season: SEASON,
+    week: WEEK,
+    xlsxBuffer: buildPicksWorkbook(ROWS),
+    events: () => events,
+  });
+
+  await page.goto(`${baseUrl}/${SEASON}/${WEEK}/scoreboard`);
+  await page.waitForSelector("td.table__player-col", { timeout: 20000 });
+
+  const cdp = await context.newCDPSession(page);
+  const css = process.env.CLOSE_CSS ?? "";
+  if (css) await page.addStyleTag({ content: css });
+  await page.waitForTimeout(700);
+
+  await pull({ cdp, page, distance: PULL_DISTANCE_PX, steps: PULL_STEPS });
+  await page.waitForTimeout(2000);
+
+  const slow = process.env.CLOSE_CSS_SLOW ?? "";
+  if (slow) await page.addStyleTag({ content: slow });
+  await page.waitForTimeout(400);
+
+  await pull({ cdp, page, distance: PULL_DISTANCE_PX, steps: PULL_STEPS });
+  await page.waitForTimeout(4500);
+}

--- a/.claude/skills/record-demo/scripts/scenarios/pull-to-refresh.js
+++ b/.claude/skills/record-demo/scripts/scenarios/pull-to-refresh.js
@@ -1,0 +1,92 @@
+import {
+  buildPicksWorkbook,
+  makeGame,
+  registerAppMocks,
+} from "../lib/mocks.js";
+
+const SEASON = 2024;
+const WEEK = 5;
+
+// Far enough past `PULL_TRIGGER_PX` in `src/hooks/usePullToRefresh.ts` that the
+// resistance past it is on screen too.
+const PULL_DISTANCE_PX = 150;
+const PULL_STEPS = 26;
+
+const ROWS = [
+  { Name: "Alice", P1: "KC", P2: "SF", P3: "MIA", P4: "GB", P5: "BAL" },
+  { Name: "Bob", P1: "BUF", P2: "DAL", P3: "NYJ", P4: "CHI", P5: "CIN" },
+  { Name: "Carol", P1: "KC", P2: "DAL", P3: "MIA", P4: "CHI", P5: "BAL" },
+  { Name: "Dave", P1: "BUF", P2: "SF", P3: "NYJ", P4: "GB", P5: "CIN" },
+  { Name: "Erin", P1: "KC", P2: "SF", P3: "NYJ", P4: "GB", P5: "BAL" },
+  { Name: "Frank", P1: "BUF", P2: "DAL", P3: "MIA", P4: "CHI", P5: "CIN" },
+  { Name: "Grace", P1: "KC", P2: "SF", P3: "MIA", P4: "", P5: "BAL" },
+  { Name: "Heidi", P1: "BUF", P2: "DAL", P3: "NYJ", P4: "CHI", P5: "BAL" },
+];
+
+// One game still to play, which is what keeps the week live and the refresh on
+// offer at all.
+const events = {
+  events: [
+    makeGame("P1EVT", "KC", "BUF", 7, 3, "2"),
+    makeGame("P2EVT", "SF", "DAL", 27, 20, "3"),
+    makeGame("P3EVT", "NYJ", "MIA", 16, 20, "3"),
+    makeGame("P4EVT", "CHI", "GB", 10, 24, "3"),
+    makeGame("P5EVT", "BAL", "CIN", 24, 17, "3"),
+  ],
+};
+
+/**
+ * Drags one finger down the table and lets go.
+ *
+ * Chrome DevTools Protocol rather than `page.dispatchEvent`, which builds a
+ * `Touch` the page can read but the compositor never sees, so `preventDefault`
+ * and the scroller do not actually contend. This is a real touch.
+ */
+async function pull({ page, context, distance, steps }) {
+  const cdp = await context.newCDPSession(page);
+  const box = await page.locator("main#main").boundingBox();
+  const x = Math.round(box.x + box.width / 2);
+  const y = Math.round(box.y + 40);
+  const at = (step) => [{ x, y: Math.round(y + (distance * step) / steps) }];
+
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: at(0),
+  });
+  for (let step = 1; step <= steps; step += 1) {
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: at(step),
+    });
+    await page.waitForTimeout(16);
+  }
+  await page.waitForTimeout(250);
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchEnd",
+    touchPoints: [],
+  });
+}
+
+/**
+ * Needs `--touch`, without which Chromium reports a mouse and the gesture is off.
+ *
+ * Pulls down from the top of the scoreboard on a phone-sized touch screen, where
+ * the navbar's refresh button is read and not drawn. Shows the puck coming out
+ * from under the bar, the table following the finger, the rescore, and the spring
+ * back with the toast that says it happened.
+ */
+export default async function run({ page, context, baseUrl }) {
+  await registerAppMocks(context, {
+    season: SEASON,
+    week: WEEK,
+    xlsxBuffer: buildPicksWorkbook(ROWS),
+    events: () => events,
+  });
+
+  await page.goto(`${baseUrl}/${SEASON}/${WEEK}/scoreboard`);
+  await page.waitForSelector("td.table__player-col", { timeout: 20000 });
+  await page.waitForTimeout(700);
+
+  await pull({ page, context, distance: PULL_DISTANCE_PX, steps: PULL_STEPS });
+  await page.waitForTimeout(2500);
+}

--- a/src/App.results.test.tsx
+++ b/src/App.results.test.tsx
@@ -96,11 +96,11 @@ describe("the app, results views", () => {
     await user.click(screen.getByRole("button", { name: "Refresh" }));
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Results successfully updated"),
-      ).toBeInTheDocument();
+      expect(getPlayerScoresMock).toHaveBeenCalledTimes(2);
     });
-    expect(getPlayerScoresMock).toHaveBeenCalledTimes(2);
+    // A refresh that worked says nothing. The rescored table is the whole of the
+    // answer, so a toast over it would only repeat what it shows.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 
   it("reports a scoring failure instead of crashing", async () => {

--- a/src/components/navbar/ScoresNavbar.scss
+++ b/src/components/navbar/ScoresNavbar.scss
@@ -1,3 +1,4 @@
+@use "../../styles/a11y" as *;
 @use "../../styles/breakpoints" as *;
 
 // One flex child of the navbar's right side, so it carries the gap between its
@@ -49,5 +50,15 @@
 
   &.--collapsed {
     opacity: 0;
+  }
+}
+
+// Where a pull on the table takes its place. Read and not drawn, rather than
+// gone: a screen reader owns every swipe, so its reader cannot perform the
+// gesture, and `display: none` would leave them no way to refresh a live week at
+// all. On the wrapper, so the divider goes with it.
+@include phone-touch {
+  .scores-nav__live {
+    @include visually-hidden;
   }
 }

--- a/src/components/navbar/ScoresNavbar.scss
+++ b/src/components/navbar/ScoresNavbar.scss
@@ -57,8 +57,13 @@
 // gone: a screen reader owns every swipe, so its reader cannot perform the
 // gesture, and `display: none` would leave them no way to refresh a live week at
 // all. On the wrapper, so the divider goes with it.
+//
+// Back on the bar the moment it is tabbed to, the way `.page__skip-link` comes
+// back. Clipped to a pixel it is still in the tab order, so a keyboard on a phone
+// would otherwise land focus on something nobody can see. The bar shifts when it
+// returns, which is the whole of what a reader tabbing to it is asking for.
 @include phone-touch {
-  .scores-nav__live {
+  .scores-nav__live:not(:focus-within) {
     @include visually-hidden;
   }
 }

--- a/src/components/pageLayout/CLAUDE.md
+++ b/src/components/pageLayout/CLAUDE.md
@@ -1,6 +1,8 @@
 # pageLayout
 
 `PageLayout`: the chrome every page shares, documented on the component itself.
+Its `pull` prop arms `usePullToRefresh` on the scrolling area and draws
+`PullIndicator`, the puck a pull brings out from under the navbar.
 
 It also holds the note that covers a phone turned on its side, on every page: a
 week's table cannot be read across the 500px of height `phone-landscape` allows

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -124,15 +124,17 @@
   will-change: transform;
 }
 
-// From wherever the finger left it to where the puck rests, and back again after.
-// `--rak-ease-key` is the app's own curve for something that starts fast and
-// settles, which is what a spring back is.
+// From wherever the finger left it to where the puck rests. Under the finger's
+// own curve, since the content is still being handled at that point.
 :root[data-pull="refreshing"] .page__content {
   transition: transform var(--rak-duration-fast) var(--rak-ease-key);
 }
 
-:root[data-pull="settling"] .page__content {
-  transition: transform var(--rak-duration-slow) var(--rak-ease-key);
+// And home again after, off a stop it has been sitting at for the length of the
+// rescore. `--rak-ease-return` is what leaves that stop gently.
+:root[data-pull="settling"] .page__content,
+:root[data-pull="closing"] .page__content {
+  transition: transform var(--rak-duration-slow) var(--rak-ease-return);
 }
 
 /** Straight to the results, past a navbar that is the same on every page. */

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -22,34 +22,8 @@
   flex-direction: column;
   align-items: center;
   overflow: hidden;
-  // Makes this a stacking context, so the fill below sits above this element's
-  // own background and under everything the page lays out.
+  // Makes this a stacking context, so nothing the page raises can rise past it.
   isolation: isolate;
-
-  // What a pull opens a gap onto. Only while one is running, so the case is what
-  // frames the content column at every other moment, and only where the gesture
-  // is armed at all.
-  //
-  // Held off the safe-area row above the navbar, which is the one strip of this
-  // element a phone leaves bare. `inset: 0` is the padding box, which takes that
-  // row in, and flipping it for the length of a pull is a flash at the notch.
-  @include phone-touch {
-    &::before {
-      content: "";
-      position: absolute;
-      top: env(safe-area-inset-top, 0px);
-      right: 0;
-      bottom: 0;
-      left: 0;
-      z-index: var(--rak-z-below);
-      display: none;
-      background-color: var(--rak-pull-ground);
-    }
-  }
-}
-
-:root[data-pull] .page::before {
-  display: block;
 }
 
 .page__content {

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -134,7 +134,7 @@
 // rescore. `--rak-ease-return` is what leaves that stop gently.
 :root[data-pull="settling"] .page__content,
 :root[data-pull="closing"] .page__content {
-  transition: transform var(--rak-duration-slow) var(--rak-ease-return);
+  transition: transform var(--rak-duration-medium) var(--rak-ease-return);
 }
 
 /** Straight to the results, past a navbar that is the same on every page. */

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -74,6 +74,10 @@
   justify-content: safe center;
   box-shadow: var(--rak-shadow-overlay);
   overflow: auto;
+  // A fling in the table stops at the table. It never chained anywhere worth
+  // going, since `<html>` does not scroll, and on a phone it is what the pull
+  // below competes with.
+  overscroll-behavior: contain;
   // The room a scrollbar needs, held whether or not there is one, so a week long
   // enough to scroll is not narrower than the wireframe that stood in for it.
   scrollbar-gutter: stable;
@@ -129,6 +133,35 @@
       overflow-x: hidden;
     }
   }
+}
+
+// Where the pull is drawn, this box gives up its own bounce as well. At the top
+// of a table the rubber-band and the gesture answer the same finger, and the one
+// the app draws has to win. `index.scss` gave the same thing up document-wide.
+@include phone-touch {
+  .page__content {
+    overscroll-behavior-y: none;
+  }
+}
+
+// Only while a pull is running. Written unconditionally this would make the box a
+// stacking context on every page, trapping the table's sticky header and the
+// wireframe's sheen inside it for the sake of translating by nothing. Here it is
+// what is wanted: the header rides down with the box it sticks in.
+:root[data-pull] .page__content {
+  transform: translate3d(0, var(--rak-pull-offset, 0px), 0);
+  will-change: transform;
+}
+
+// From wherever the finger left it to where the puck rests, and back again after.
+// `--rak-ease-key` is the app's own curve for something that starts fast and
+// settles, which is what a spring back is.
+:root[data-pull="refreshing"] .page__content {
+  transition: transform var(--rak-duration-fast) var(--rak-ease-key);
+}
+
+:root[data-pull="settling"] .page__content {
+  transition: transform var(--rak-duration-slow) var(--rak-ease-key);
 }
 
 /** Straight to the results, past a navbar that is the same on every page. */

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -9,7 +9,9 @@
   // showing. `100vh` is the tall viewport, which would put the table's last rows
   // and the safe-area row below it out of reach until the URL bar collapsed.
   height: 100dvh;
-  background-color: var(--rak-brand-light);
+  // What the app is mounted in, at every width. The pages stand on it as panels,
+  // and it is what a pull to refresh draws the content off.
+  background-color: var(--rak-case);
   // index.html asks for viewport-fit=cover so the table below the scores can
   // size itself from the bottom inset. That lets the whole app draw into the
   // unsafe areas, so the other three sides are held back here.
@@ -20,39 +22,8 @@
   flex-direction: column;
   align-items: center;
   overflow: hidden;
-  // Makes this a stacking context, which is what lets the tiles below sit above
-  // this element's own background and below everything on the page.
+  // Makes this a stacking context, so nothing the page raises can rise past it.
   isolation: isolate;
-
-  // The tiled logo. Drawn here rather than on `.page` itself so it can be faded
-  // in: a background image cannot be, and the tiles arriving at full strength
-  // all at once is disorienting.
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    z-index: var(--rak-z-below);
-    background-image: var(--rak-background-tile);
-    opacity: 0;
-    transition: opacity var(--rak-duration-slow) ease-in;
-  }
-
-  &.--tiles-loaded::before {
-    opacity: 1;
-  }
-
-  // A phone only. The tiles are the whole surface behind a page held in one hand,
-  // and past that they are two strips either side of a content column 1024px wide,
-  // which reads as wallpaper the app forgot to finish rather than as its ground.
-  // The case the app is mounted in takes over there, since with the tiles gone the
-  // brand fill is a field of color rather than the ground under a pattern.
-  @include roomy-screen {
-    background-color: var(--rak-case);
-
-    &::before {
-      display: none;
-    }
-  }
 }
 
 .page__content {
@@ -99,11 +70,11 @@
     // header, so the surface every other page carries goes back below.
     background-color: var(--rak-primary-600);
 
-    // Nothing of its own, so the tiled ground behind the page shows either side of
-    // the table, which is what every other page stands on. The shadow goes with
-    // it: it is what lifts a panel off that ground, and with the fill gone there is
-    // no panel here to lift. `ResultsFrame.scss` puts it on the table, which is
-    // what stands on that ground instead.
+    // Nothing of its own, so the case behind the page shows either side of the
+    // table, which is what every other page stands on. The shadow goes with it: it
+    // is what lifts a panel off that ground, and with the fill gone there is no
+    // panel here to lift. `ResultsFrame.scss` puts it on the table, which is what
+    // stands on that ground instead.
     @include roomy-screen {
       background-color: transparent;
       box-shadow: none;
@@ -213,7 +184,7 @@
     justify-content: center;
     gap: var(--rak-space-2);
     padding: var(--rak-space-6);
-    background-color: var(--rak-brand-light);
+    background-color: var(--rak-case);
     text-align: center;
   }
 

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -22,8 +22,34 @@
   flex-direction: column;
   align-items: center;
   overflow: hidden;
-  // Makes this a stacking context, so nothing the page raises can rise past it.
+  // Makes this a stacking context, so the fill below sits above this element's
+  // own background and under everything the page lays out.
   isolation: isolate;
+
+  // What a pull opens a gap onto. Only while one is running, so the case is what
+  // frames the content column at every other moment, and only where the gesture
+  // is armed at all.
+  //
+  // Held off the safe-area row above the navbar, which is the one strip of this
+  // element a phone leaves bare. `inset: 0` is the padding box, which takes that
+  // row in, and flipping it for the length of a pull is a flash at the notch.
+  @include phone-touch {
+    &::before {
+      content: "";
+      position: absolute;
+      top: env(safe-area-inset-top, 0px);
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: var(--rak-z-below);
+      display: none;
+      background-color: var(--rak-pull-ground);
+    }
+  }
+}
+
+:root[data-pull] .page::before {
+  display: block;
 }
 
 .page__content {

--- a/src/components/pageLayout/PageLayout.tsx
+++ b/src/components/pageLayout/PageLayout.tsx
@@ -3,11 +3,14 @@ import {
   PropsWithChildren,
   ReactNode,
   useEffect,
+  useRef,
   useState,
 } from "react";
+import usePullToRefresh, { Pull } from "../../hooks/usePullToRefresh";
 import getClasses from "../../utils/getClasses";
 import { ScreenRotationIcon } from "../icon/Icon";
 import Navbar from "../navbar/Navbar";
+import PullIndicator from "./PullIndicator";
 import "./PageLayout.scss";
 
 const BACKGROUND_TILE = "/logo512.png";
@@ -87,6 +90,7 @@ export default function PageLayout({
   navbarRight,
   showingScores = false,
   scrollable = true,
+  pull,
   children,
 }: PropsWithChildren<{
   /**
@@ -103,8 +107,16 @@ export default function PageLayout({
    * clicked. The content keeps whatever scrollbars it asks for either way.
    */
   scrollable?: boolean;
+  /**
+   * The refresh a pull on the content offers, which is a phone's replacement for
+   * the refresh button. Left out by a page with nothing to refetch, and by one
+   * with nothing on it to pull yet.
+   */
+  pull?: Pull;
 }>) {
   const areTilesLoaded = useTileLoaded(BACKGROUND_TILE);
+  const contentRef = useRef<HTMLElement>(null);
+  const isPullArmed = usePullToRefresh({ scrollRef: contentRef, pull });
 
   return (
     <div
@@ -115,8 +127,10 @@ export default function PageLayout({
         Skip to results
       </a>
       <Navbar left={navbarLeft} right={navbarRight} />
+      {isPullArmed && <PullIndicator />}
       <main
         id="main"
+        ref={contentRef}
         className={getClasses("page__content", {
           "--scores": showingScores,
           "--frozen": !scrollable,

--- a/src/components/pageLayout/PageLayout.tsx
+++ b/src/components/pageLayout/PageLayout.tsx
@@ -1,11 +1,4 @@
-import {
-  CSSProperties,
-  PropsWithChildren,
-  ReactNode,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { PropsWithChildren, ReactNode, useRef } from "react";
 import usePullToRefresh, { Pull } from "../../hooks/usePullToRefresh";
 import getClasses from "../../utils/getClasses";
 import { ScreenRotationIcon } from "../icon/Icon";
@@ -13,77 +6,7 @@ import Navbar from "../navbar/Navbar";
 import PullIndicator from "./PullIndicator";
 import "./PageLayout.scss";
 
-const BACKGROUND_TILE = "/logo512.png";
-
-// Read by `PageLayout.scss`, so the file that loads the tile is also the one that
-// names it. The color behind the tiles is a token there, not here: it is the
-// largest surface in the app and does not belong in a style object.
-const BACKGROUND_STYLE = {
-  "--rak-background-tile": `url(${BACKGROUND_TILE})`,
-} as CSSProperties;
-
-/**
- * Sources that have finished loading once. Every route renders its own layout, so
- * without this the fade would start over on each move between pages.
- */
-const loadedSources = new Set<string>();
-
-/**
- * The width the stylesheet stops drawing the tiles at, asked as a query. Read from
- * the token `index.scss` exports rather than written again here, so the fetch and
- * the paint cannot disagree about where a phone ends.
- *
- * Negated rather than turned into a `max-width`, which would take in the breakpoint
- * itself: the stylesheet's own query is `min-width`, and this has to be exactly the
- * width it does not cover.
- */
-function tilesDrawnQuery(): string {
-  const width = getComputedStyle(document.documentElement)
-    .getPropertyValue("--rak-breakpoint-roomy")
-    .trim();
-  return `not all and (min-width: ${width})`;
-}
-
-/**
- * Whether the browser holds the tile, so a background drawn from it can be faded in
- * rather than appear all at once. True from the first render once the image has been
- * through here before, which is what keeps the fade to the first page.
- *
- * Asked for only where the stylesheet draws it. Above that width the tiles are
- * `display: none`, so the browser never fetches them for the page itself and this
- * was the only thing pulling them down. Watched rather than read once, because a
- * window dragged narrow crosses the same line without a reload.
- */
-function useTileLoaded(source: string): boolean {
-  const [isLoaded, setIsLoaded] = useState(() => loadedSources.has(source));
-
-  useEffect(() => {
-    if (loadedSources.has(source)) return;
-    const drawn = window.matchMedia(tilesDrawnQuery());
-    let image: HTMLImageElement | undefined;
-    const fetchOnce = () => {
-      if (image || !drawn.matches) return;
-      image = new Image();
-      // Listen before asking, because an image already in the cache still fires
-      // `load`, and it can fire as soon as the source is set.
-      image.onload = () => {
-        loadedSources.add(source);
-        setIsLoaded(true);
-      };
-      image.src = source;
-    };
-    fetchOnce();
-    drawn.addEventListener("change", fetchOnce);
-    return () => {
-      drawn.removeEventListener("change", fetchOnce);
-      if (image) image.onload = null;
-    };
-  }, [source]);
-
-  return isLoaded;
-}
-
-/** The chrome every page shares: the background, the navbar, and the main area. */
+/** The chrome every page shares: the navbar and the main area. */
 export default function PageLayout({
   title,
   navbarLeft,
@@ -114,15 +37,11 @@ export default function PageLayout({
    */
   pull?: Pull;
 }>) {
-  const areTilesLoaded = useTileLoaded(BACKGROUND_TILE);
   const contentRef = useRef<HTMLElement>(null);
   const isPullArmed = usePullToRefresh({ scrollRef: contentRef, pull });
 
   return (
-    <div
-      className={getClasses("page", { "--tiles-loaded": areTilesLoaded })}
-      style={BACKGROUND_STYLE}
-    >
+    <div className="page">
       <a className="page__skip-link" href="#main">
         Skip to results
       </a>

--- a/src/components/pageLayout/PullIndicator.scss
+++ b/src/components/pageLayout/PullIndicator.scss
@@ -1,0 +1,66 @@
+@use "../../styles/skeleton" as *;
+
+/**
+ * A strip of no height between the navbar and the content, so it takes no room in
+ * the page's column and needs to know nothing about the bar above it. The gap the
+ * translated content opens below is the whole of what it draws into.
+ */
+.page__pull {
+  position: relative;
+  align-self: stretch;
+  flex: 0 0 0;
+  height: 0;
+  // Over the table's sticky header and the wireframe's sheen, under the navbar,
+  // so the puck comes out from beneath the bar rather than over it.
+  z-index: var(--rak-z-pull);
+}
+
+.page__pull-puck {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--rak-touch-target);
+  height: var(--rak-touch-target);
+  border-radius: 50%;
+  background-color: var(--rak-primary-500);
+  box-shadow: var(--rak-shadow-raised);
+  // Centered in the gap below, which is `--rak-pull-offset` tall. Half of nothing
+  // is nothing, so at rest the puck is centered on the navbar's lower edge and
+  // covered by it.
+  transform: translate(-50%, calc(var(--rak-pull-offset, 0px) / 2 - 50%));
+  // Faded in by the pull itself rather than by a duration of its own, so it
+  // arrives at the speed the finger moves.
+  opacity: var(--rak-pull-progress, 0);
+
+  > svg {
+    fill: var(--rak-on-solid);
+  }
+}
+
+// Far enough that letting go would refresh. The app's own key, lit.
+:root[data-pull="armed"] .page__pull-puck,
+:root[data-pull="refreshing"] .page__pull-puck {
+  background-color: var(--rak-primary-400);
+}
+
+// The one way the app says it is still working, which is a sheen and never a
+// spin. `_skeleton.scss` states that, and the puck is no exception.
+:root[data-pull="refreshing"] .page__pull-puck {
+  @include skeleton-sheen;
+
+  // The mixin makes what it is on the containing block it clips the sheen
+  // against, and its `relative` would drop the puck back into the strip's flow.
+  // Said again after it, because absolute is a containing block too.
+  position: absolute;
+}
+
+// The finger is off it, so the puck rides the content back up rather than
+// tracking a position nothing is moving to any more.
+:root[data-pull="settling"] .page__pull-puck {
+  transition:
+    transform var(--rak-duration-slow) var(--rak-ease-key),
+    opacity var(--rak-duration-slow) var(--rak-ease-key);
+}

--- a/src/components/pageLayout/PullIndicator.scss
+++ b/src/components/pageLayout/PullIndicator.scss
@@ -84,8 +84,8 @@
 :root[data-pull="settling"] .page__pull-puck,
 :root[data-pull="closing"] .page__pull-puck {
   transition:
-    transform var(--rak-duration-slow) var(--rak-ease-return),
+    transform var(--rak-duration-medium) var(--rak-ease-return),
     opacity var(--rak-duration-fast) linear
-      calc(var(--rak-duration-slow) - var(--rak-duration-fast)),
-    background-color var(--rak-duration-slow) linear;
+      calc(var(--rak-duration-medium) - var(--rak-duration-fast)),
+    background-color var(--rak-duration-medium) linear;
 }

--- a/src/components/pageLayout/PullIndicator.scss
+++ b/src/components/pageLayout/PullIndicator.scss
@@ -26,6 +26,10 @@
   height: var(--rak-touch-target);
   border-radius: 50%;
   background-color: var(--rak-primary-500);
+  // Lit and unlit over a beat rather than in one frame. The unlighting lands on
+  // the close, where the puck starts moving in the same frame, and a fill
+  // snapping back there is read as part of the movement going wrong.
+  transition: background-color var(--rak-duration-fast) linear;
   box-shadow: var(--rak-shadow-raised);
   // Out from under the navbar, and back under it on the way home. At rest the
   // whole puck is above the strip's top edge, which is the bar's lower one, so
@@ -56,7 +60,12 @@
 
 // The one way the app says it is still working, which is a sheen and never a
 // spin. `_skeleton.scss` states that, and the puck is no exception.
-:root[data-pull="refreshing"] .page__pull-puck {
+//
+// Carried through the close as well, so the sweep ends when the puck is back
+// under the bar rather than being cut at the first frame of its retreat. Only
+// that close: `settling` is a pull that stopped short and did no work.
+:root[data-pull="refreshing"] .page__pull-puck,
+:root[data-pull="closing"] .page__pull-puck {
   @include skeleton-sheen;
 
   // The mixin makes what it is on the containing block it clips the sheen
@@ -67,8 +76,16 @@
 
 // The finger is off it, so the puck rides the content back up rather than
 // tracking a position nothing is moving to any more.
-:root[data-pull="settling"] .page__pull-puck {
+//
+// It goes home solid and is put out at the end, over the last fast beat of the
+// slow one. Fading it across the whole retreat emptied it in mid air, well
+// before it reached the bar, which read as the puck giving up rather than as the
+// bar taking it back.
+:root[data-pull="settling"] .page__pull-puck,
+:root[data-pull="closing"] .page__pull-puck {
   transition:
-    transform var(--rak-duration-slow) var(--rak-ease-key),
-    opacity var(--rak-duration-slow) var(--rak-ease-key);
+    transform var(--rak-duration-slow) var(--rak-ease-return),
+    opacity var(--rak-duration-fast) linear
+      calc(var(--rak-duration-slow) - var(--rak-duration-fast)),
+    background-color var(--rak-duration-slow) linear;
 }

--- a/src/components/pageLayout/PullIndicator.scss
+++ b/src/components/pageLayout/PullIndicator.scss
@@ -27,10 +27,18 @@
   border-radius: 50%;
   background-color: var(--rak-primary-500);
   box-shadow: var(--rak-shadow-raised);
-  // Centered in the gap below, which is `--rak-pull-offset` tall. Half of nothing
-  // is nothing, so at rest the puck is centered on the navbar's lower edge and
-  // covered by it.
-  transform: translate(-50%, calc(var(--rak-pull-offset, 0px) / 2 - 50%));
+  // Out from under the navbar, and back under it on the way home. At rest the
+  // whole puck is above the strip's top edge, which is the bar's lower one, so
+  // the bar covers it: `-100%` puts its own bottom on that line. The progress
+  // term gives that back as the pull runs, and by the time the pull is armed the
+  // two cancel to `-50%`, which is the middle of the gap. Centered in the gap
+  // from there on, however much further the finger goes.
+  transform: translate(
+    -50%,
+    calc(
+      var(--rak-pull-offset, 0px) / 2 - 100% + var(--rak-pull-progress, 0) * 50%
+    )
+  );
   // Faded in by the pull itself rather than by a duration of its own, so it
   // arrives at the speed the finger moves.
   opacity: var(--rak-pull-progress, 0);

--- a/src/components/pageLayout/PullIndicator.tsx
+++ b/src/components/pageLayout/PullIndicator.tsx
@@ -1,0 +1,20 @@
+import { UpdateIcon } from "../icon/Icon";
+import "./PullIndicator.scss";
+
+/**
+ * What a pull on the content below drags out from under the navbar.
+ *
+ * No props and no state: everything it draws comes off the root element, which is
+ * where `usePullToRefresh` writes the pull rather than re-rendering the table
+ * under it. Hidden from a screen reader, which has the refresh button instead and
+ * is told the outcome by the toast either way.
+ */
+export default function PullIndicator() {
+  return (
+    <div className="page__pull" aria-hidden="true">
+      <span className="page__pull-puck">
+        <UpdateIcon />
+      </span>
+    </div>
+  );
+}

--- a/src/components/results/CLAUDE.md
+++ b/src/components/results/CLAUDE.md
@@ -11,7 +11,8 @@ week worth showing.
 - `ScoreboardRoute` and `PicksRoute`: one table each, from context.
 - `ResultsFrame`: the page and wireframe both `ResultsLayout` and
   `CurrentWeekRedirect` render into. Holds the app's `PlayerAnalysisDialog` and
-  `GameStatusDialog` and both providers around the tables, and reads
-  `useIsWinnerDecided` for `ScoresNavbar`'s `isWeekLive`.
+  `GameStatusDialog` and both providers around the tables. Its
+  `useIsWinnerDecided` arms `ScoresNavbar`'s `isWeekLive` and `PageLayout`'s
+  `pull` together.
 - `ResultsFrame.scss`: the column the table and the wireframe are laid in, and the
   caption naming the week over both.

--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -113,8 +113,8 @@
 }
 
 // Room enough that the table does not fill the width, so the frame is cut to the
-// table and what is left either side is the page's own tiled ground, the same
-// background the home page stands on.
+// table and what is left either side is the case, the same ground the home page
+// stands on.
 @include roomy-screen {
   .results-scores {
     width: max-content;

--- a/src/components/results/ResultsFrame.tsx
+++ b/src/components/results/ResultsFrame.tsx
@@ -98,9 +98,11 @@ export default function ResultsFrame({
       // in for, so it wants the same content area.
       showingScores
       scrollable={isReady}
-      // TEMPORARY, do not commit: the live-week gate is off so a finished week
-      // can be pulled on for device testing. Restore `isReady && !isWinnerDecided`.
-      pull={isReady ? { onRefresh, isRefreshing } : undefined}
+      // Exact parity with the refresh button beside it: the same live week, and
+      // only once there is a table to pull on.
+      pull={
+        isReady && !isWinnerDecided ? { onRefresh, isRefreshing } : undefined
+      }
       navbarLeft={<LogoButton onClick={() => navigate("/")} />}
       navbarRight={
         // Rendered while the week loads, so the navbar does not change shape

--- a/src/components/results/ResultsFrame.tsx
+++ b/src/components/results/ResultsFrame.tsx
@@ -98,11 +98,9 @@ export default function ResultsFrame({
       // in for, so it wants the same content area.
       showingScores
       scrollable={isReady}
-      // Exact parity with the refresh button beside it: the same live week, and
-      // only once there is a table to pull on.
-      pull={
-        isReady && !isWinnerDecided ? { onRefresh, isRefreshing } : undefined
-      }
+      // TEMPORARY, do not commit: the live-week gate is off so a finished week
+      // can be pulled on for device testing. Restore `isReady && !isWinnerDecided`.
+      pull={isReady ? { onRefresh, isRefreshing } : undefined}
       navbarLeft={<LogoButton onClick={() => navigate("/")} />}
       navbarRight={
         // Rendered while the week loads, so the navbar does not change shape

--- a/src/components/results/ResultsFrame.tsx
+++ b/src/components/results/ResultsFrame.tsx
@@ -98,6 +98,11 @@ export default function ResultsFrame({
       // in for, so it wants the same content area.
       showingScores
       scrollable={isReady}
+      // Exact parity with the refresh button beside it: the same live week, and
+      // only once there is a table to pull on.
+      pull={
+        isReady && !isWinnerDecided ? { onRefresh, isRefreshing } : undefined
+      }
       navbarLeft={<LogoButton onClick={() => navigate("/")} />}
       navbarRight={
         // Rendered while the week loads, so the navbar does not change shape

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -12,7 +12,12 @@ import { v4 as uuidv4 } from "uuid";
 import doNothing from "../utils/doNothing";
 
 export const MAX_VISIBLE_TOASTS = 3;
-export const TOAST_LIFETIME_MS = 5000;
+/**
+ * How long a toast that closes itself stays up. Long enough to read one line of
+ * confirmation, and no longer: the only toasts on this clock say something
+ * worked, and the reader is already looking at what it did.
+ */
+export const TOAST_LIFETIME_MS = 3000;
 
 /** Each value has a matching ramp in `index.scss`. */
 export type ToastType =

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -17,7 +17,7 @@ export const MAX_VISIBLE_TOASTS = 3;
  * confirmation, and no longer: the only toasts on this clock say something
  * worked, and the reader is already looking at what it did.
  */
-export const TOAST_LIFETIME_MS = 3000;
+export const TOAST_LIFETIME_MS = 2000;
 
 /** Each value has a matching ramp in `index.scss`. */
 export type ToastType =

--- a/src/hooks/CLAUDE.md
+++ b/src/hooks/CLAUDE.md
@@ -10,6 +10,8 @@ The data layer, plus the two page measurements. The first four mount once in
   the throttle
 - `useLiveGame`: one game, refetched every twenty seconds
 - `useArrival`: an outside value, taken as it arrives
+- `useMediaQuery`: whether a media query holds, kept in step
+- `usePullToRefresh`: a phone's pull on a scrolling box, written to the root
 - `useExportScores`: the scores, as a workbook
 - `useWeekRouteGuard`: whether a `/:season/:week` URL has anything to show
 - `useFillerRows`: the empty rows carrying a table to the viewport bottom

--- a/src/hooks/useMediaQuery.test.ts
+++ b/src/hooks/useMediaQuery.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook } from "@testing-library/react";
+import useMediaQuery from "./useMediaQuery";
+
+const QUERY = "(max-width: 480px)";
+
+/** A `matchMedia` whose answer the test can change, which jsdom's stub cannot. */
+function stubMatchMedia(matches: boolean) {
+  const listeners = new Set<() => void>();
+  const list = {
+    matches,
+    addEventListener: (_: string, listener: () => void) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_: string, listener: () => void) => {
+      listeners.delete(listener);
+    },
+  };
+  window.matchMedia = (() => list) as unknown as typeof window.matchMedia;
+  return {
+    listeners,
+    answer(next: boolean) {
+      list.matches = next;
+      listeners.forEach((listener) => listener());
+    },
+  };
+}
+
+describe("useMediaQuery", () => {
+  const realMatchMedia = window.matchMedia;
+  afterEach(() => {
+    window.matchMedia = realMatchMedia;
+  });
+
+  it("reports the answer the browser gives now", () => {
+    stubMatchMedia(true);
+
+    expect(renderHook(() => useMediaQuery(QUERY)).result.current).toBe(true);
+  });
+
+  it("reports it again when the answer changes", () => {
+    const media = stubMatchMedia(false);
+    const { result } = renderHook(() => useMediaQuery(QUERY));
+
+    act(() => media.answer(true));
+
+    expect(result.current).toBe(true);
+  });
+
+  it("stops listening once it is gone", () => {
+    const media = stubMatchMedia(false);
+
+    renderHook(() => useMediaQuery(QUERY)).unmount();
+
+    expect(media.listeners.size).toBe(0);
+  });
+});

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,19 @@
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+
+/**
+ * Whether the browser answers yes to a media query, kept in step as it changes.
+ *
+ * jsdom lays nothing out and answers no to every query, which is what puts a test
+ * on the widest screen. `setupTests.ts` says so where it stubs `matchMedia`.
+ */
+export default function useMediaQuery(query: string): boolean {
+  const list = useMemo(() => window.matchMedia(query), [query]);
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      list.addEventListener("change", onChange);
+      return () => list.removeEventListener("change", onChange);
+    },
+    [list],
+  );
+  return useSyncExternalStore(subscribe, () => list.matches);
+}

--- a/src/hooks/usePlayerScores.ts
+++ b/src/hooks/usePlayerScores.ts
@@ -218,12 +218,15 @@ export default function usePlayerScores(
           // Refreshing rescores the workbook already in memory, so there is no
           // separate way for loading it to fail.
           const failure = scoringFailed(selectedWeek.value);
+          // Nothing said on success. The scores are on screen and the numbers
+          // that moved are marked, so a toast over them repeats what the table
+          // already shows and covers part of it to do so. A failure still speaks,
+          // since the table looks the same either way when one happens.
           try {
             await attemptScoring({
               loadPicks: async () => picksBuffer,
               onLoadFailure: failure,
               onScoreFailure: failure,
-              onSuccess: successToast("Results successfully updated"),
               keepScoresOnFailure: true,
             });
           } finally {

--- a/src/hooks/usePullToRefresh.test.ts
+++ b/src/hooks/usePullToRefresh.test.ts
@@ -5,6 +5,7 @@ import usePullToRefresh, {
   Pull,
   PULL_PHASE_ATTR,
   PULL_MAX_PX,
+  PULL_MIN_HOLD_MS,
   PULL_SLOP_PX,
   PULL_TRIGGER_PX,
   pullOffset,
@@ -129,6 +130,33 @@ describe("usePullToRefresh", () => {
     expect(document.documentElement.getAttribute(PULL_PHASE_ATTR)).toBe(
       "settling",
     );
+  });
+
+  it("closes a refresh apart from a pull that stopped short", async () => {
+    vi.useFakeTimers();
+    try {
+      const { box, view } = mount({ onRefresh: vi.fn(), isRefreshing: false });
+
+      act(() => {
+        box.dispatchEvent(touch("touchstart", 100, 100));
+        box.dispatchEvent(touch("touchmove", 100, 140));
+        box.dispatchEvent(touch("touchmove", 100, 100 + PULL_TRIGGER_PX + 10));
+        box.dispatchEvent(touch("touchend", 0, 0));
+      });
+      view.rerender({ pull: { onRefresh: vi.fn(), isRefreshing: true } });
+      view.rerender({ pull: { onRefresh: vi.fn(), isRefreshing: false } });
+
+      // The two closes are told apart so only the one that did work carries its
+      // sheen home. `settling` is what the case above writes.
+      act(() => {
+        vi.advanceTimersByTime(PULL_MIN_HOLD_MS);
+      });
+      expect(document.documentElement.getAttribute(PULL_PHASE_ATTR)).toBe(
+        "closing",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("leaves a sideways pan to the table, and takes a pull off it", () => {

--- a/src/hooks/usePullToRefresh.test.ts
+++ b/src/hooks/usePullToRefresh.test.ts
@@ -1,0 +1,166 @@
+import { act, renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import usePullToRefresh, {
+  lockAxis,
+  Pull,
+  PULL_PHASE_ATTR,
+  PULL_MAX_PX,
+  PULL_SLOP_PX,
+  PULL_TRIGGER_PX,
+  pullOffset,
+} from "./usePullToRefresh";
+
+describe("lockAxis", () => {
+  it("says nothing until the finger has left the slop", () => {
+    expect(lockAxis(PULL_SLOP_PX - 1, PULL_SLOP_PX - 1)).toBe("undecided");
+  });
+
+  it("takes a move straight down as the pull", () => {
+    expect(lockAxis(0, 20)).toBe("pull");
+  });
+
+  it("gives a sideways pan to the table, which is wider than the phone", () => {
+    expect(lockAxis(20, 0)).toBe("abandoned");
+  });
+
+  it("gives a diagonal to the table as well", () => {
+    expect(lockAxis(15, 20)).toBe("abandoned");
+  });
+
+  it("never arms on a flick upwards", () => {
+    expect(lockAxis(0, -20)).toBe("abandoned");
+  });
+});
+
+describe("pullOffset", () => {
+  it("moves nothing for a finger that has not moved down", () => {
+    expect(pullOffset(0)).toBe(0);
+    expect(pullOffset(-40)).toBe(0);
+  });
+
+  it("tracks the finger one to one up to the trigger", () => {
+    expect(pullOffset(40)).toBe(40);
+    expect(pullOffset(PULL_TRIGGER_PX)).toBe(PULL_TRIGGER_PX);
+  });
+
+  it("resists past the trigger without ever reaching the maximum", () => {
+    expect(pullOffset(200)).toBeGreaterThan(PULL_TRIGGER_PX);
+    expect(pullOffset(200)).toBeLessThan(PULL_MAX_PX);
+    expect(pullOffset(100_000)).toBeLessThan(PULL_MAX_PX);
+  });
+
+  it("only ever grows", () => {
+    for (let distance = 0; distance < 400; distance += 7) {
+      expect(pullOffset(distance + 7)).toBeGreaterThan(pullOffset(distance));
+    }
+  });
+});
+
+/**
+ * jsdom ships no `TouchEvent` constructor and lays nothing out, so the touches and
+ * the box's scroll position are both stood up by hand.
+ */
+function touch(type: string, x: number, y: number): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  return Object.assign(event, {
+    touches: type === "touchend" ? [] : [{ clientX: x, clientY: y }],
+  });
+}
+
+function mount(pull: Pull) {
+  const box = document.createElement("div");
+  document.body.append(box);
+  Object.defineProperty(box, "scrollTop", { value: 0, writable: true });
+  const view = renderHook(
+    (props: { pull: Pull }) => {
+      const ref = useRef(box);
+      return usePullToRefresh({ scrollRef: ref, pull: props.pull });
+    },
+    { initialProps: { pull } },
+  );
+  return { box, view };
+}
+
+describe("usePullToRefresh", () => {
+  const realMatchMedia = window.matchMedia;
+  beforeEach(() => {
+    // The gesture is a phone's, and jsdom answers no to every query by default.
+    window.matchMedia = ((media: string) => ({
+      media,
+      matches: true,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    })) as unknown as typeof window.matchMedia;
+  });
+  afterEach(() => {
+    window.matchMedia = realMatchMedia;
+    document.documentElement.removeAttribute(PULL_PHASE_ATTR);
+    document.body.replaceChildren();
+  });
+
+  it("refreshes on a pull past the trigger", () => {
+    const onRefresh = vi.fn();
+    const { box } = mount({ onRefresh, isRefreshing: false });
+
+    act(() => {
+      box.dispatchEvent(touch("touchstart", 100, 100));
+      box.dispatchEvent(touch("touchmove", 100, 140));
+      box.dispatchEvent(touch("touchmove", 100, 100 + PULL_TRIGGER_PX + 10));
+      box.dispatchEvent(touch("touchend", 0, 0));
+    });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(document.documentElement.getAttribute(PULL_PHASE_ATTR)).toBe(
+      "refreshing",
+    );
+  });
+
+  it("springs back from a pull that stopped short", () => {
+    const onRefresh = vi.fn();
+    const { box } = mount({ onRefresh, isRefreshing: false });
+
+    act(() => {
+      box.dispatchEvent(touch("touchstart", 100, 100));
+      box.dispatchEvent(touch("touchmove", 100, 130));
+      box.dispatchEvent(touch("touchend", 0, 0));
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(document.documentElement.getAttribute(PULL_PHASE_ATTR)).toBe(
+      "settling",
+    );
+  });
+
+  it("leaves a sideways pan to the table, and takes a pull off it", () => {
+    const { box } = mount({ onRefresh: vi.fn(), isRefreshing: false });
+
+    const pan = touch("touchmove", 160, 102);
+    const pull = touch("touchmove", 100, 160);
+    act(() => {
+      box.dispatchEvent(touch("touchstart", 100, 100));
+      box.dispatchEvent(pan);
+    });
+    act(() => {
+      box.dispatchEvent(touch("touchend", 0, 0));
+      box.dispatchEvent(touch("touchstart", 100, 100));
+      box.dispatchEvent(pull);
+    });
+
+    expect(pan.defaultPrevented).toBe(false);
+    expect(pull.defaultPrevented).toBe(true);
+  });
+
+  it("ignores a touch that starts partway down the table", () => {
+    const onRefresh = vi.fn();
+    const { box } = mount({ onRefresh, isRefreshing: false });
+    (box as unknown as { scrollTop: number }).scrollTop = 200;
+
+    act(() => {
+      box.dispatchEvent(touch("touchstart", 100, 100));
+      box.dispatchEvent(touch("touchmove", 100, 300));
+      box.dispatchEvent(touch("touchend", 0, 0));
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -20,11 +20,11 @@ export const PULL_TRIGGER_PX = 72;
 export const PULL_MAX_PX = 112;
 
 /**
- * How long the spring back takes. Matches `--rak-duration-slow`, which the
+ * How long the spring back takes. Matches `--rak-duration-medium`, which the
  * stylesheet times the transition to, so the transform is dropped in the frame it
  * reaches zero rather than before.
  */
-export const PULL_SETTLE_MS = 300;
+export const PULL_SETTLE_MS = 200;
 
 /**
  * The least time the puck stays open once the finger is off it.

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,238 @@
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
+import useMediaQuery from "./useMediaQuery";
+
+/** How far the content has moved, for the stylesheet to translate the box by. */
+export const PULL_OFFSET_VAR = "--rak-pull-offset";
+
+/** How far along the pull is, out of one, which is what fades the puck in. */
+export const PULL_PROGRESS_VAR = "--rak-pull-progress";
+
+/** Where the pull has got to. Absent when there is no pull to draw. */
+export const PULL_PHASE_ATTR = "data-pull";
+
+/** How far a finger moves before it has said which way it is going. */
+export const PULL_SLOP_PX = 8;
+
+/** How far the content moves before letting go refreshes rather than springs back. */
+export const PULL_TRIGGER_PX = 72;
+
+/** The furthest the content moves, however far the finger goes. */
+export const PULL_MAX_PX = 112;
+
+/**
+ * How long the spring back takes. Matches `--rak-duration-slow`, which the
+ * stylesheet times the transition to, so the transform is dropped in the frame it
+ * reaches zero rather than before.
+ */
+export const PULL_SETTLE_MS = 300;
+
+/**
+ * The least time the puck stays open once the finger is off it.
+ *
+ * A rescore off a warm cache finishes inside a frame, and a call the throttle
+ * drops never starts at all. Without a floor both read as the gesture having
+ * failed. Under the 500ms throttle window, so a second pull cannot arrive before
+ * the first has visibly finished.
+ */
+export const PULL_MIN_HOLD_MS = 400;
+
+export type PullAxis = "undecided" | "pull" | "abandoned";
+
+/**
+ * Which way a drag went, from how far it has come.
+ *
+ * Biased against the pull on purpose. A picks table is wider than the phone, so
+ * panning it sideways is the common motion, and a diagonal drag belongs to that
+ * rather than to a refresh.
+ */
+export function lockAxis(dx: number, dy: number): PullAxis {
+  if (Math.abs(dx) < PULL_SLOP_PX && Math.abs(dy) < PULL_SLOP_PX) {
+    return "undecided";
+  }
+  return dy > 0 && dy > Math.abs(dx) * 1.5 ? "pull" : "abandoned";
+}
+
+/**
+ * How far the content travels for a finger this far down the screen.
+ *
+ * One to one up to the trigger, so up to the point it matters the content is
+ * under the finger rather than lagging it. Past that it resists, and approaches
+ * `PULL_MAX_PX` without reaching it: a hard stop reads as the gesture having
+ * broken, where getting heavier reads as the end of it.
+ */
+export function pullOffset(distance: number): number {
+  if (distance <= 0) return 0;
+  if (distance <= PULL_TRIGGER_PX) return distance;
+  const slack = PULL_MAX_PX - PULL_TRIGGER_PX;
+  const past = distance - PULL_TRIGGER_PX;
+  return PULL_TRIGGER_PX + (slack * past) / (past + slack);
+}
+
+/** The refresh a pull offers, or nothing where a pull refreshes nothing. */
+export type Pull = { onRefresh: () => void; isRefreshing: boolean };
+
+/** The query `phone-touch` guards, which `index.scss` exports for this to read. */
+function phoneTouchQuery(): string {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue("--rak-phone-touch")
+    .trim()
+    .replace(/^"|"$/g, "");
+}
+
+/**
+ * Pull down from the top of the scrolling box to refresh what is in it.
+ *
+ * A phone's replacement for the refresh button, which `phone-touch` takes off the
+ * bar at the same width. Not the browser's own pull-to-refresh, which `index.scss`
+ * turns off: that reloads the document, and the scores are rescored from a
+ * workbook held in memory, which a reload would throw away.
+ *
+ * Writes where the pull has got to onto the root element rather than into state,
+ * the way `useViewportInsets` does, so a finger moving over a table of a thousand
+ * cells does not re-render one of them. What comes back is whether the gesture is
+ * attached at all, which is what says to draw the puck.
+ */
+export default function usePullToRefresh({
+  scrollRef,
+  pull,
+}: {
+  /** The box that scrolls, which the listeners go on. */
+  scrollRef: RefObject<HTMLElement | null>;
+  /** Left out by a page with nothing to refetch, which disarms the gesture. */
+  pull?: Pull;
+}): boolean {
+  const [query] = useState(phoneTouchQuery);
+  const isPhone = useMediaQuery(query);
+  const isArmed = isPhone && pull != null;
+
+  // Held open from the finger coming off until the refresh has been seen to run.
+  const [isHolding, setHolding] = useState(false);
+  // The gesture's own bookkeeping, which no render reads.
+  const drag = useRef({ x: 0, y: 0, offset: 0, axis: "abandoned" as PullAxis });
+  const releasedAt = useRef(0);
+  const clearTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // Read by listeners attached once, which outlive the render that made them.
+  const onRefresh = useRef(pull?.onRefresh);
+  useEffect(() => {
+    onRefresh.current = pull?.onRefresh;
+  });
+
+  const write = useCallback((offset: number, phase: string) => {
+    const root = document.documentElement;
+    drag.current.offset = offset;
+    root.style.setProperty(PULL_OFFSET_VAR, `${offset}px`);
+    root.style.setProperty(
+      PULL_PROGRESS_VAR,
+      `${Math.min(offset / PULL_TRIGGER_PX, 1)}`,
+    );
+    root.setAttribute(PULL_PHASE_ATTR, phase);
+  }, []);
+
+  const clear = useCallback(() => {
+    const root = document.documentElement;
+    drag.current.offset = 0;
+    root.style.removeProperty(PULL_OFFSET_VAR);
+    root.style.removeProperty(PULL_PROGRESS_VAR);
+    root.removeAttribute(PULL_PHASE_ATTR);
+  }, []);
+
+  // Back to nothing, over the length of the transition the stylesheet runs on
+  // `settling`, and the transform is given up in the frame it reaches zero.
+  const settle = useCallback(() => {
+    write(0, "settling");
+    clearTimeout(clearTimer.current);
+    clearTimer.current = setTimeout(clear, PULL_SETTLE_MS);
+  }, [write, clear]);
+
+  useEffect(() => {
+    const box = scrollRef.current;
+    if (!isArmed || box == null) return;
+
+    const start = (event: TouchEvent) => {
+      // A second finger, or a box already scrolled down. Abandoned for the whole
+      // of that touch, so its momentum and this gesture are never both running.
+      if (event.touches.length !== 1 || box.scrollTop > 0) {
+        drag.current.axis = "abandoned";
+        return;
+      }
+      const touch = event.touches[0];
+      drag.current = {
+        x: touch.clientX,
+        y: touch.clientY,
+        offset: 0,
+        axis: "undecided",
+      };
+    };
+
+    const move = (event: TouchEvent) => {
+      const { axis, x, y } = drag.current;
+      if (axis === "abandoned") return;
+      const touch = event.touches[0];
+      if (touch == null) return;
+      const dx = touch.clientX - x;
+      const dy = touch.clientY - y;
+      if (axis === "undecided") {
+        const decided = lockAxis(dx, dy);
+        if (decided === "undecided") return;
+        drag.current.axis = decided;
+        if (decided === "abandoned") return;
+      }
+      // Only once the pull has won, so the moves that turn out to be a sideways
+      // pan still scroll. This works at all because the listener below is the
+      // non-passive one: React's own are passive, and there this does nothing.
+      event.preventDefault();
+      const offset = pullOffset(dy);
+      write(offset, offset >= PULL_TRIGGER_PX ? "armed" : "pulling");
+    };
+
+    const end = () => {
+      const { axis, offset } = drag.current;
+      drag.current.axis = "abandoned";
+      if (axis !== "pull") return;
+      if (offset < PULL_TRIGGER_PX) {
+        settle();
+        return;
+      }
+      // Pinned where the puck rests while the week is rescored.
+      write(PULL_TRIGGER_PX, "refreshing");
+      releasedAt.current = performance.now();
+      setHolding(true);
+      onRefresh.current?.();
+    };
+
+    box.addEventListener("touchstart", start, { passive: true });
+    box.addEventListener("touchmove", move, { passive: false });
+    box.addEventListener("touchend", end, { passive: true });
+    box.addEventListener("touchcancel", end, { passive: true });
+    return () => {
+      box.removeEventListener("touchstart", start);
+      box.removeEventListener("touchmove", move);
+      box.removeEventListener("touchend", end);
+      box.removeEventListener("touchcancel", end);
+      // Nothing left to pull on, so whatever is open goes with it.
+      clearTimeout(clearTimer.current);
+      clear();
+    };
+  }, [isArmed, scrollRef, write, settle, clear]);
+
+  // What holds the puck open, and what closes it. `isRefreshing` rather than the
+  // promise `onRefresh` returns, which resolves at once when the throttle drops
+  // the call and would close the puck on a refresh that never ran.
+  const isRefreshing = pull?.isRefreshing ?? false;
+  useEffect(() => {
+    if (!isArmed || !isHolding || isRefreshing) return;
+    const left = PULL_MIN_HOLD_MS - (performance.now() - releasedAt.current);
+    const timer = setTimeout(
+      () => {
+        settle();
+        setHolding(false);
+      },
+      Math.max(left, 0),
+    );
+    return () => clearTimeout(timer);
+  }, [isArmed, isHolding, isRefreshing, settle]);
+
+  useEffect(() => () => clearTimeout(clearTimer.current), []);
+
+  return isArmed;
+}

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -136,13 +136,24 @@ export default function usePullToRefresh({
     root.removeAttribute(PULL_PHASE_ATTR);
   }, []);
 
-  // Back to nothing, over the length of the transition the stylesheet runs on
-  // `settling`, and the transform is given up in the frame it reaches zero.
-  const settle = useCallback(() => {
-    write(0, "settling");
-    clearTimeout(clearTimer.current);
-    clearTimer.current = setTimeout(clear, PULL_SETTLE_MS);
-  }, [write, clear]);
+  /**
+   * Back to nothing, over the length of the transition the stylesheet runs on
+   * both closing phases, and the transform is given up in the frame it reaches
+   * zero.
+   *
+   * The two are told apart because only one of them was working. `closing`
+   * carries the sheen the whole way home rather than cutting it at the first
+   * frame of the retreat, and `settling` is the pull that stopped short, which
+   * has nothing to say it was doing anything.
+   */
+  const settle = useCallback(
+    (phase: "settling" | "closing") => {
+      write(0, phase);
+      clearTimeout(clearTimer.current);
+      clearTimer.current = setTimeout(clear, PULL_SETTLE_MS);
+    },
+    [write, clear],
+  );
 
   useEffect(() => {
     const box = scrollRef.current;
@@ -190,7 +201,7 @@ export default function usePullToRefresh({
       drag.current.axis = "abandoned";
       if (axis !== "pull") return;
       if (offset < PULL_TRIGGER_PX) {
-        settle();
+        settle("settling");
         return;
       }
       // Pinned where the puck rests while the week is rescored.
@@ -224,7 +235,7 @@ export default function usePullToRefresh({
     const left = PULL_MIN_HOLD_MS - (performance.now() - releasedAt.current);
     const timer = setTimeout(
       () => {
-        settle();
+        settle("closing");
         setHolding(false);
       },
       Math.max(left, 0),

--- a/src/index.scss
+++ b/src/index.scss
@@ -117,6 +117,10 @@
   // A key's travel. Out fast and settling, the way a moulded key answers a
   // finger, rather than the symmetric curve every other transition uses.
   --rak-ease-key: cubic-bezier(0.2, 0.8, 0.3, 1);
+  // Something going home under nothing but its own weight, which starts from a
+  // standstill and lands soft. The key's curve is the wrong way round for that:
+  // it opens at full speed, which off a dead stop is read as a jolt.
+  --rak-ease-return: cubic-bezier(0.4, 0, 0.2, 1);
 
   // Stacking, one step per layer the page stacks, so what sits above what is
   // decided in one place. A z-index outside this list orders an element against

--- a/src/index.scss
+++ b/src/index.scss
@@ -121,6 +121,9 @@
   // Stacking, one step per layer the page stacks, so what sits above what is
   // decided in one place. A z-index outside this list orders an element against
   // its own siblings and nothing else.
+  // Behind everything the page lays out and in front of the page's own fill,
+  // which is the one layer under the content rather than over it.
+  --rak-z-below: -1;
   --rak-z-sticky-header: 20;
   // The header cell of the column that also sticks left. Above the header cells
   // after it in the table, which pass under it as the table scrolls sideways.
@@ -141,6 +144,10 @@
   // frames, so the column keeps an edge without the case reading as a dark bezel
   // around a light page.
   --rak-case: #dcdcdc;
+  // What a pull to refresh draws the content off. Taken to the end of the ramp
+  // rather than to the case, so the gap the finger opens reads as a hole behind
+  // the page and not as more of the same grey the page is framed in.
+  --rak-pull-ground: #fff;
 
   // Primary scale: the navbar, table header, and key chrome. Light here, so that
   // chrome reads as a light panel with dark ink on it, the same as the rest of
@@ -602,6 +609,7 @@ html {
   // moving, and the light one only moved to stop framing a light page in near
   // black.
   --rak-case: #373737;
+  --rak-pull-ground: #000;
 
   --rak-success-400: #4ade80;
   --rak-danger-400: #f87171;

--- a/src/index.scss
+++ b/src/index.scss
@@ -57,11 +57,16 @@
   --rak-line-height: 1.5;
   --rak-line-height-tight: 1.1;
 
-  // The width the tiled logo stops being drawn at, which `PageLayout.tsx` reads so
-  // it can stop fetching the tile there too. The breakpoints themselves are Sass,
-  // because a media query cannot read a custom property, and this is the one place
-  // outside a stylesheet that has to ask a breakpoint's question.
+  // The two questions asked outside a stylesheet as well as inside one. The
+  // breakpoints themselves stay Sass, because a media query cannot read a custom
+  // property, so what crosses over is written here for `matchMedia` to ask.
+  //
+  // `--rak-breakpoint-roomy` is the width the tiled logo stops being drawn at,
+  // which `PageLayout.tsx` reads so it can stop fetching the tile there too.
+  // `--rak-phone-touch` is the whole query `phone-touch` guards, quoted because a
+  // custom property holding a bare media query is not a valid declaration.
   --rak-breakpoint-roomy: #{$breakpoint-roomy};
+  --rak-phone-touch: "#{$phone-touch-query}";
 
   // What a label set in capitals is opened up by. Capitals are drawn on one
   // height and run together without it, and every small label in the app is set
@@ -126,6 +131,9 @@
   // after it in the table, which pass under it as the table scrolls sideways.
   --rak-z-sticky-corner: 25;
   --rak-z-skeleton: 30;
+  // The pull-to-refresh puck, over the table it is dragged off and under the bar
+  // it is dragged out from beneath.
+  --rak-z-pull: 40;
   --rak-z-navbar: 100;
   --rak-z-overlay: 200;
   --rak-z-toast: 400;

--- a/src/index.scss
+++ b/src/index.scss
@@ -109,8 +109,12 @@
   --rak-text-ink: 0.92em;
   --rak-caps-ink: 0.7em;
 
-  // Motion. Three durations cover every transition and the one loop.
+  // Motion. Three durations cover every transition, plus the one loop.
   --rak-duration-fast: 120ms;
+  // The travel too far to take at the fast one and too short to be given the
+  // slow. Only the pull's own close, which is a dismissal: the work is done and
+  // the reader is waiting on the page rather than watching it.
+  --rak-duration-medium: 200ms;
   --rak-duration-slow: 300ms;
   --rak-duration-loop: 2000ms;
   --rak-ease-standard: ease;

--- a/src/index.scss
+++ b/src/index.scss
@@ -57,15 +57,11 @@
   --rak-line-height: 1.5;
   --rak-line-height-tight: 1.1;
 
-  // The two questions asked outside a stylesheet as well as inside one. The
+  // The one question asked outside a stylesheet as well as inside one. The
   // breakpoints themselves stay Sass, because a media query cannot read a custom
-  // property, so what crosses over is written here for `matchMedia` to ask.
-  //
-  // `--rak-breakpoint-roomy` is the width the tiled logo stops being drawn at,
-  // which `PageLayout.tsx` reads so it can stop fetching the tile there too.
-  // `--rak-phone-touch` is the whole query `phone-touch` guards, quoted because a
-  // custom property holding a bare media query is not a valid declaration.
-  --rak-breakpoint-roomy: #{$breakpoint-roomy};
+  // property, so what crosses over is written here for `matchMedia` to ask. It is
+  // the whole query `phone-touch` guards, quoted because a custom property holding
+  // a bare media query is not a valid declaration.
   --rak-phone-touch: "#{$phone-touch-query}";
 
   // What a label set in capitals is opened up by. Capitals are drawn on one
@@ -125,7 +121,6 @@
   // Stacking, one step per layer the page stacks, so what sits above what is
   // decided in one place. A z-index outside this list orders an element against
   // its own siblings and nothing else.
-  --rak-z-below: -1;
   --rak-z-sticky-header: 20;
   // The header cell of the column that also sticks left. Above the header cells
   // after it in the table, which pass under it as the table scrolls sideways.
@@ -141,12 +136,10 @@
   // over it are the popup and the list it opens, taken from this with `calc`.
   --rak-z-modal: 1000;
 
-  // The page behind the tiled logo, and the largest surface on a phone.
-  --rak-brand-light: #a4a4a4;
-  // What the app is mounted in on a screen too wide for the tiles to be its
-  // ground. A shade under the navbar it runs down from and a shade over the
-  // white column it frames, so the column keeps an edge without the case
-  // reading as a dark bezel around a light page.
+  // What the app is mounted in, and the ground every page stands on. A shade
+  // under the navbar it runs down from and a shade over the white column it
+  // frames, so the column keeps an edge without the case reading as a dark bezel
+  // around a light page.
   --rak-case: #dcdcdc;
 
   // Primary scale: the navbar, table header, and key chrome. Light here, so that
@@ -604,7 +597,6 @@ html {
   // Light again, against the dark fill it reads a cell of the field on here.
   --rak-unlit: rgb(255 255 255 / 12%);
 
-  --rak-brand-light: #262626;
   // Between the navbar above it and the surface it frames, the same place the
   // light case sits. Stays where it was: a dark app in a dark case needs no
   // moving, and the light one only moved to stop framing a light page in near

--- a/src/index.scss
+++ b/src/index.scss
@@ -121,9 +121,6 @@
   // Stacking, one step per layer the page stacks, so what sits above what is
   // decided in one place. A z-index outside this list orders an element against
   // its own siblings and nothing else.
-  // Behind everything the page lays out and in front of the page's own fill,
-  // which is the one layer under the content rather than over it.
-  --rak-z-below: -1;
   --rak-z-sticky-header: 20;
   // The header cell of the column that also sticks left. Above the header cells
   // after it in the table, which pass under it as the table scrolls sideways.
@@ -144,10 +141,6 @@
   // frames, so the column keeps an edge without the case reading as a dark bezel
   // around a light page.
   --rak-case: #dcdcdc;
-  // What a pull to refresh draws the content off. Taken to the end of the ramp
-  // rather than to the case, so the gap the finger opens reads as a hole behind
-  // the page and not as more of the same grey the page is framed in.
-  --rak-pull-ground: #fff;
 
   // Primary scale: the navbar, table header, and key chrome. Light here, so that
   // chrome reads as a light panel with dark ink on it, the same as the rest of
@@ -609,7 +602,6 @@ html {
   // moving, and the light one only moved to stop framing a light page in near
   // black.
   --rak-case: #373737;
-  --rak-pull-ground: #000;
 
   --rak-success-400: #4ade80;
   --rak-danger-400: #f87171;

--- a/src/styles/CLAUDE.md
+++ b/src/styles/CLAUDE.md
@@ -5,10 +5,11 @@ files `@use` it. `_skeleton.scss` is the one exception, and says so: it holds
 keyframes. Design tokens live in `src/index.scss` instead.
 
 - `_breakpoints.scss`: `roomy-screen`, `labelled-navbar`, `wide-screen`,
-  `can-hover`, `phone-landscape`, `reduced-motion`. Mixins rather than custom
-  properties, because a custom property does not work inside a media query. Reach
-  them with `@use "…/styles/breakpoints" as *;`. Every one is `min-width`, so the
-  phone's rules are the base.
+  `can-hover`, `phone-landscape`, `phone-touch`, `reduced-motion`. Mixins rather
+  than custom properties, because a custom property does not work inside a media
+  query. Reach them with `@use "…/styles/breakpoints" as *;`. Every width one is
+  `min-width` and the phone's rules are the base, except `phone-touch`, which is a
+  swap rather than extra room.
 - `_focus.scss`: `focus-ring`, the app's one focus ring, and `$focus-ring-reach`,
   the room it needs outside a control a scrolling ancestor would clip it against
 - `_ink.scss`: `ink-height`, an icon drawn as tall as the text beside it

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -49,6 +49,23 @@ $breakpoint-wide: 601px;
 }
 
 /**
+ * A phone, and nothing else. The one `max-width` in this file, because it is the
+ * one rule that has to stop at a phone rather than start there.
+ *
+ * Width alone would take in a desktop window dragged narrow, where the gesture
+ * this guards cannot be performed at all. The pointer is what tells the two
+ * apart: a mouse reports `hover` and a fine pointer, so asking for neither leaves
+ * only touch.
+ */
+$phone-touch-query: "(max-width: #{$breakpoint-roomy - 1px}) and (hover: none) and (pointer: coarse)";
+
+@mixin phone-touch {
+  @media #{$phone-touch-query} {
+    @content;
+  }
+}
+
+/**
  * A phone turned on its side. Three things have to agree, because the overlay
  * takes the whole screen and there is no way past it.
  *


### PR DESCRIPTION
## What

Pull down from the top of the results table to refresh a live week. On a phone-sized touch screen the refresh button is read and not drawn.

<video src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/pull-to-refresh/pull.mp4" controls></video>

## Changes

* `usePullToRefresh` writes the pull to the root element instead of into state, the way `useViewportInsets` does, so a finger over a thousand cells re-renders none of them.
* The axis locks on the first move past 8px, biased against the pull. A picks table is wider than the phone, so a sideways pan keeps scrolling it.
* The puck holds for 400ms. A warm rescore finishes in a frame, and a throttled call never starts. Without a floor both look like a failure.
* The transform goes on the scroll box. Inside it, it would add scroll extent and make the frame a rasterization layer, the Firefox for Android bug `Table.scss` documents.
* The button stays in the accessibility tree under `visually-hidden`, and returns to the bar on `:focus-within`. A screen reader owns every swipe.
* Drop the tiled logo. Every page stands on the case the roomier screens already used. `logo512.png` stays as an install icon.
* Drop the toast a successful refresh raised, and close the rest after 2s. Failures still speak.

## Verification

Chromium at 430px with touch. Not on a real device, where Safari's rubber-band is the risk.

## Notes / Follow-ups

* A screen reader pressing Refresh now gets no confirmation that it worked.
* `record-demo` gains a `--touch` flag, off by default: touch emulation also kills the `can-hover` rules other scenarios capture.
