### PR TITLE
style(navbar): stand the light chrome on a dark gray bar

### DIFF
--- a/src/components/button/Button.scss
+++ b/src/components/button/Button.scss
@@ -291,10 +291,6 @@
   &.--busy {
     @include skeleton-sheen;
     cursor: default;
-    // A key this small reads the sheen's usual loop as a slow, faint smear rather
-    // than as work happening. `dialog-sweep`'s own progress bar is the other place
-    // the app times a sweep to the box it crosses rather than to the shared loop.
-    --rak-duration-loop: 900ms;
 
     // A key is disabled for as long as it is working, so this is where most of the
     // app's waiting is seen. The sweep is white, which is invisible on the grey a

--- a/src/components/dialog/DialogShell.scss
+++ b/src/components/dialog/DialogShell.scss
@@ -164,7 +164,10 @@ $bar-height: 2px;
     width: 40%;
     height: 100%;
     background-color: var(--rak-progress-fill);
-    animation: dialog-sweep 900ms ease-in-out infinite;
+    // The app's one sweep speed, the same `_skeleton.scss` times its sheen to.
+    // The curve is this bar's own: a sheen crosses at a constant rate, and a
+    // progress bar eases at each end of its run.
+    animation: dialog-sweep var(--rak-duration-loop) ease-in-out infinite;
   }
 
   // Still says work is under way, without a thing crossing the screen to say it.

--- a/src/components/navbar/Navbar.scss
+++ b/src/components/navbar/Navbar.scss
@@ -7,7 +7,8 @@
   align-items: center;
   justify-content: center;
   z-index: var(--rak-z-navbar);
-  box-shadow: var(--rak-shadow-raised);
+  // The highest of the three bands the scoreboard steps down through.
+  box-shadow: var(--rak-shadow-band-navbar);
   // The bar's chrome, which light mode takes off the brand blue. Pinned as ramp
   // steps rather than read one at a time, so the key faces below, the name
   // plate's ring (`lcd-glass`), and a key's lower edge all follow: `Button.scss`

--- a/src/components/navbar/Navbar.scss
+++ b/src/components/navbar/Navbar.scss
@@ -18,6 +18,7 @@
   --rak-primary-600: var(--rak-nav-key-active);
   --rak-primary-700: var(--rak-nav-key-edge);
   --rak-on-solid: var(--rak-nav-ink);
+  --rak-key-top: var(--rak-nav-key-top);
   // The lamp, which cannot be the blue the bar itself is filled in.
   --rak-led-on: var(--rak-nav-led);
 

--- a/src/components/navbar/Navbar.scss
+++ b/src/components/navbar/Navbar.scss
@@ -8,6 +8,19 @@
   justify-content: center;
   z-index: var(--rak-z-navbar);
   box-shadow: var(--rak-shadow-raised);
+  // The bar's chrome, which light mode takes off the brand blue. Pinned as ramp
+  // steps rather than read one at a time, so the key faces below, the name
+  // plate's ring (`lcd-glass`), and a key's lower edge all follow: `Button.scss`
+  // reads that edge from `--rak-primary-700` at a specificity no `--rak-key-edge`
+  // set here can beat.
+  --rak-primary-400: var(--rak-nav-key);
+  --rak-primary-500: var(--rak-nav-fill);
+  --rak-primary-600: var(--rak-nav-key-active);
+  --rak-primary-700: var(--rak-nav-key-edge);
+  --rak-on-solid: var(--rak-nav-ink);
+  // The lamp, which cannot be the blue the bar itself is filled in.
+  --rak-led-on: var(--rak-nav-led);
+
   background-color: var(--rak-primary-500);
   color: var(--rak-on-solid);
   // Every button in here sits on the app's own primary, which a ring in that same

--- a/src/components/pageLayout/PageLayout.scss
+++ b/src/components/pageLayout/PageLayout.scss
@@ -68,7 +68,7 @@
     // the box, so nothing but that gap ever shows this. A roomier screen leaves
     // room beside the table, where it would show as a second dark band against the
     // header, so the surface every other page carries goes back below.
-    background-color: var(--rak-primary-600);
+    background-color: var(--rak-band-caption);
 
     // Nothing of its own, so the case behind the page shows either side of the
     // table, which is what every other page stands on. The shadow goes with it: it

--- a/src/components/pageLayout/PullIndicator.scss
+++ b/src/components/pageLayout/PullIndicator.scss
@@ -25,7 +25,7 @@
   width: var(--rak-touch-target);
   height: var(--rak-touch-target);
   border-radius: 50%;
-  background-color: var(--rak-primary-500);
+  background-color: var(--rak-nav-fill);
   // Lit and unlit over a beat rather than in one frame. The unlighting lands on
   // the close, where the puck starts moving in the same frame, and a fill
   // snapping back there is read as part of the movement going wrong.
@@ -48,14 +48,14 @@
   opacity: var(--rak-pull-progress, 0);
 
   > svg {
-    fill: var(--rak-on-solid);
+    fill: var(--rak-nav-ink);
   }
 }
 
 // Far enough that letting go would refresh. The app's own key, lit.
 :root[data-pull="armed"] .page__pull-puck,
 :root[data-pull="refreshing"] .page__pull-puck {
-  background-color: var(--rak-primary-400);
+  background-color: var(--rak-nav-key);
 }
 
 // The one way the app says it is still working, which is a sheen and never a

--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -27,7 +27,7 @@
   // height; painted the same, it reads as that row being the taller for it rather
   // than as the page running out before the table does. The caption's own color,
   // not the header's: this is the frame around the table, not the table itself.
-  background-color: var(--rak-primary-600);
+  background-color: var(--rak-band-caption);
   // The table is the app's screen, so the dark band around it is drawn as the
   // bezel holding it: lit along its top edge and shadowed along its bottom. Inset,
   // so it costs no room and nothing inside the frame moves.
@@ -53,7 +53,7 @@
   // the table. No border under it: the step off this fill is what divides the
   // caption from the header, and a rule drawn in either neighbour's color would
   // be a line one of them could not show.
-  background-color: var(--rak-primary-600);
+  background-color: var(--rak-band-caption);
   // No `z-index`, so the sticky header passes over it on the way up.
   color: var(--rak-on-solid);
   // The header row's own type, so the two read as one head with a line drawn

--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -54,7 +54,12 @@
   // caption from the header, and a rule drawn in either neighbour's color would
   // be a line one of them could not show.
   background-color: var(--rak-band-caption);
-  // No `z-index`, so the sticky header passes over it on the way up.
+  // Over the header rather than under it, which is the order the three bands
+  // are lit in: the caption's own shadow falls on the header, and the header's
+  // on the rows. The sticky header passes under this on the way up.
+  position: relative;
+  z-index: var(--rak-z-caption);
+  box-shadow: var(--rak-shadow-band-caption);
   color: var(--rak-on-solid);
   // The header row's own type, so the two read as one head with a line drawn
   // through it rather than as two bands set differently. The size is the token

--- a/src/components/table/SkeletonTable.scss
+++ b/src/components/table/SkeletonTable.scss
@@ -56,10 +56,4 @@
     // The header's own ink, so the bars read as gaps in it.
     background-color: var(--rak-loading-fill-on-solid);
   }
-
-  // A real table draws this edge from its sticky player column, which the
-  // wireframe has no stand-in for, so the rank column would run into the next one.
-  td:nth-child(2) {
-    border-left: var(--rak-table-border);
-  }
 }

--- a/src/components/table/SkeletonTable.scss
+++ b/src/components/table/SkeletonTable.scss
@@ -20,21 +20,6 @@
   @include visually-hidden;
 }
 
-// What holds the sheen to the wireframe rather than letting it cross the page
-// around it. A box of its own, cut to the table, rather than the `<table>`: a
-// browser generates a wrapper box around a table and splits the properties
-// between the two, so `position` and `overflow` written on one element do not
-// always land on the same box, and a clip that does not hold the sheen's own
-// containing block does not hold the sheen. This is one box either way.
-.skeleton__sheen {
-  @include skeleton-sheen;
-
-  width: max-content;
-  // Centered where the frame is wider than the table, which the table does for
-  // itself in `Table.scss`.
-  margin-inline: auto;
-}
-
 .table.--skeleton {
   th {
     @include skeleton-reserve;

--- a/src/components/table/SkeletonTable.tsx
+++ b/src/components/table/SkeletonTable.tsx
@@ -93,28 +93,25 @@ function SkeletonTable({ view }: { view: ScoresView }) {
       <span className="skeleton__status" role="status">
         Loading {view.toLowerCase()} results
       </span>
-      {/* The box the sheen sweeps inside, cut to the table by `SkeletonTable.scss`. */}
-      <div className="skeleton__sheen">
-        <TableShell
-          className="--skeleton"
-          columnCount={columns.length}
-          standInRows={PLAYER_COUNT}
-          busy
-          ariaHidden
-          header={columns.map((column, index) => (
-            // The heading itself, hidden, so a header that wraps to two lines is two
-            // lines tall here as well.
-            <th
-              key={index}
-              className={headerClass(column)}
-              scope="col"
-              data-skeleton-text={column.header}
-            >
-              <span className="skeleton__bar" />
-            </th>
-          ))}
-        />
-      </div>
+      <TableShell
+        className="--skeleton"
+        columnCount={columns.length}
+        standInRows={PLAYER_COUNT}
+        busy
+        ariaHidden
+        header={columns.map((column, index) => (
+          // The heading itself, hidden, so a header that wraps to two lines is two
+          // lines tall here as well.
+          <th
+            key={index}
+            className={headerClass(column)}
+            scope="col"
+            data-skeleton-text={column.header}
+          >
+            <span className="skeleton__bar" />
+          </th>
+        ))}
+      />
     </>
   );
 }

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -102,6 +102,16 @@
   // the table is cut to its own width and needs an edge to end at.
   --rak-table-edge: var(--rak-table-no-border);
   --rak-table-header-edge: var(--rak-table-no-border);
+  // The rule between the rank and the player, drawn by the rank's right edge
+  // rather than the player's left. The player column sticks to `left: 0`, so a
+  // rule on its left edge sits on the screen's own edge once the table is
+  // panned across. On the rank it travels with the rank, under that sticky
+  // column and out of sight. Twice the width, since the sticky column covers
+  // half of it for the whole pan.
+  --rak-table-rank-border: calc(2 * var(--rak-border-width)) solid
+    var(--rak-panel-border);
+  --rak-table-header-rank-border: calc(2 * var(--rak-border-width)) solid
+    var(--rak-table-header-divider);
   --rak-table-header-border: var(--rak-border-width) solid
     var(--rak-table-header-divider);
   // For an edge that draws nothing. Never `none`, which resets the color to
@@ -152,15 +162,14 @@
       border-right: var(--rak-table-header-border);
       &:first-child {
         width: var(--rak-table-rank-width);
-        // The rank and the player read as one block, so nothing divides them.
-        border-right: var(--rak-table-no-border);
+        border-right: var(--rak-table-header-rank-border);
         border-left: var(--rak-table-header-edge);
       }
       &:last-child {
         border-right: var(--rak-table-header-edge);
       }
       &:nth-child(2) {
-        border-left: var(--rak-table-header-border);
+        border-left: var(--rak-table-no-border);
       }
 
       // The corner, stuck to the top and the left at once. Above its neighbours
@@ -272,7 +281,9 @@
     }
 
     .table__player-col {
-      border-left: var(--rak-table-border);
+      // Nothing here. The rank's right edge carries this rule instead, so it is
+      // not left standing on the screen's edge once this column sticks.
+      border-left: var(--rak-table-no-border);
       // A name is read, not compared down the column, and it is the one cell cut
       // short with an ellipsis. Centering would move where it starts from row to
       // row and put the cut at both ends.
@@ -345,8 +356,7 @@
       border-right: var(--rak-table-border);
       &:first-child {
         border-left: var(--rak-table-edge);
-        // The player column draws this divider on its own left edge.
-        border-right: var(--rak-table-no-border);
+        border-right: var(--rak-table-rank-border);
       }
       &:last-child {
         border-right: var(--rak-table-edge);

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -102,16 +102,6 @@
   // the table is cut to its own width and needs an edge to end at.
   --rak-table-edge: var(--rak-table-no-border);
   --rak-table-header-edge: var(--rak-table-no-border);
-  // The rule between the rank and the player, drawn by the rank's right edge
-  // rather than the player's left. The player column sticks to `left: 0`, so a
-  // rule on its left edge sits on the screen's own edge once the table is
-  // panned across. On the rank it travels with the rank, under that sticky
-  // column and out of sight. Twice the width, since the sticky column covers
-  // half of it for the whole pan.
-  --rak-table-rank-border: calc(2 * var(--rak-border-width)) solid
-    var(--rak-panel-border);
-  --rak-table-header-rank-border: calc(2 * var(--rak-border-width)) solid
-    var(--rak-table-header-divider);
   --rak-table-header-border: var(--rak-border-width) solid
     var(--rak-table-header-divider);
   // For an edge that draws nothing. Never `none`, which resets the color to
@@ -162,7 +152,6 @@
       border-right: var(--rak-table-header-border);
       &:first-child {
         width: var(--rak-table-rank-width);
-        border-right: var(--rak-table-header-rank-border);
         border-left: var(--rak-table-header-edge);
       }
       &:last-child {
@@ -356,7 +345,6 @@
       border-right: var(--rak-table-border);
       &:first-child {
         border-left: var(--rak-table-edge);
-        border-right: var(--rak-table-rank-border);
       }
       &:last-child {
         border-right: var(--rak-table-edge);

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -100,7 +100,7 @@
     var(--rak-table-header-divider);
   // For an edge that draws nothing. Never `none`, which resets the color to
   // `currentColor`.
-  --rak-table-no-border: 0 solid var(--rak-primary-800);
+  --rak-table-no-border: 0 solid var(--rak-band-header);
 
   // The table's own accessible name. Not shown: a caption here would add a line
   // above the header no sighted reader needs, since the page around the table
@@ -110,7 +110,7 @@
   }
 
   .table__header {
-    background-color: var(--rak-primary-800);
+    background-color: var(--rak-band-header);
 
     th {
       // The screen-printed label every heading in the app is set in.
@@ -125,7 +125,7 @@
       position: sticky;
       top: 0;
       color: var(--rak-on-solid);
-      background-color: var(--rak-primary-800);
+      background-color: var(--rak-band-header);
       // The header row is what a fixed layout reads its columns off, so the widths
       // are named here and every cell under one follows.
       width: var(--rak-table-score-width);
@@ -359,7 +359,7 @@
       padding: 0;
       // The last real row already carries the table's bottom edge.
       border: var(--rak-table-no-border);
-      background-color: var(--rak-primary-600);
+      background-color: var(--rak-band-caption);
     }
   }
 }

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -139,7 +139,7 @@
       // takes `currentColor`, which is white here.
       border-color: var(--rak-table-header-divider);
 
-      border-bottom: var(--rak-table-header-border);
+      border-bottom: var(--rak-table-header-seam);
       border-right: var(--rak-table-header-border);
       &:first-child {
         width: var(--rak-table-rank-width);

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -96,6 +96,12 @@
       2 * var(--rak-table-cell-padding-x) - 2 * var(--rak-border-width)
   );
   --rak-table-border: var(--rak-border-width) solid var(--rak-panel-border);
+  // The table's own outer left and right edges. Nothing on a phone, where the
+  // table is as wide as the screen and a rule down each side reads as the app
+  // boxing in what the reader came for. `roomy-screen` puts them back, where
+  // the table is cut to its own width and needs an edge to end at.
+  --rak-table-edge: var(--rak-table-no-border);
+  --rak-table-header-edge: var(--rak-table-no-border);
   --rak-table-header-border: var(--rak-border-width) solid
     var(--rak-table-header-divider);
   // For an edge that draws nothing. Never `none`, which resets the color to
@@ -139,13 +145,19 @@
       // takes `currentColor`, which is white here.
       border-color: var(--rak-table-header-divider);
 
-      border-bottom: var(--rak-table-header-seam);
+      border-bottom: var(--rak-table-header-border);
+      // The lowest of the three bands, cast onto the rows that pass under it.
+      // Per cell rather than on the row, which a sticky `<thead>` cannot carry.
+      box-shadow: var(--rak-shadow-band-header);
       border-right: var(--rak-table-header-border);
       &:first-child {
         width: var(--rak-table-rank-width);
         // The rank and the player read as one block, so nothing divides them.
         border-right: var(--rak-table-no-border);
-        border-left: var(--rak-table-header-border);
+        border-left: var(--rak-table-header-edge);
+      }
+      &:last-child {
+        border-right: var(--rak-table-header-edge);
       }
       &:nth-child(2) {
         border-left: var(--rak-table-header-border);
@@ -332,9 +344,12 @@
       border-bottom: var(--rak-table-border);
       border-right: var(--rak-table-border);
       &:first-child {
-        border-left: var(--rak-table-border);
+        border-left: var(--rak-table-edge);
         // The player column draws this divider on its own left edge.
         border-right: var(--rak-table-no-border);
+      }
+      &:last-child {
+        border-right: var(--rak-table-edge);
       }
     }
 
@@ -368,6 +383,8 @@
 // these go back up.
 @include roomy-screen {
   .table {
+    --rak-table-edge: var(--rak-table-border);
+    --rak-table-header-edge: var(--rak-table-header-border);
     font-size: var(--rak-text-md);
     --rak-table-row-height: 32px;
     // About twenty-four characters of a name here, against seventeen on a phone.

--- a/src/index.scss
+++ b/src/index.scss
@@ -611,16 +611,24 @@ html {
   --rak-primary-600: #404040;
   --rak-primary-700: #333333;
   --rak-primary-800: #262626;
-  // The bands and the navbar's chrome, unmoved: this mode's ramp already runs
-  // light-to-dark down the scoreboard. Literals for the navbar, since it pins
-  // the ramp steps to these and a read back would be a cycle.
-  --rak-band-caption: var(--rak-primary-600);
+  // The bands, which already run light-to-dark down the scoreboard in this mode.
+  // The caption sits a step under the ramp's own 600, to leave the bar below
+  // room to sink: at the 600 the two read as one block. 1.38:1 against the bar
+  // above and 1.20:1 against the header below.
+  --rak-band-caption: #333333;
   --rak-band-header: var(--rak-primary-800);
-  --rak-nav-fill: #4f4f4f;
-  --rak-nav-key: #5e5e5e;
-  --rak-nav-key-active: #404040;
-  --rak-nav-key-edge: #333333;
+  // The navbar's chrome, on the brand blue as it is in light mode, sunk to sit
+  // under the bands rather than over them. Literals, since the bar pins the
+  // ramp steps to these and a read back would be a cycle. White ink clears
+  // 9.17:1 on the fill and 7.31:1 on a key.
+  --rak-nav-fill: #074c73;
+  --rak-nav-key: #085b8a;
+  --rak-nav-key-active: #053d5d;
+  --rak-nav-key-edge: #043149;
   --rak-nav-ink: #fff;
+  // The lamp stays this mode's own light blue, which the sunk key leaves it
+  // room to be light against at 4.38:1. Light mode moves it to orange instead,
+  // where the bar is the blue it would otherwise take.
   --rak-nav-led: var(--rak-info-200);
   // The combobox field, back to the same dark fill this step always stood on
   // in this mode. The readout glass needs no override: `--rak-glass-fill`

--- a/src/index.scss
+++ b/src/index.scss
@@ -172,19 +172,22 @@
   // both ways.
   --rak-band-caption: #bfbfbf;
   --rak-band-header: #f0f0f0;
-  // The navbar's own chrome, on the brand blue while the ramp above stays
-  // achromatic for every key elsewhere. `Navbar.scss` pins the ramp to these
-  // inside the bar, so its keys, the name plate's ring, and the pull puck all
-  // read one set. White ink clears 7.19:1 on the fill and 5.45:1 on a key.
-  --rak-nav-fill: #095c8c;
-  --rak-nav-key: #0a6fa8;
-  --rak-nav-key-active: #074a6f;
-  --rak-nav-key-edge: #063f60;
+  // The navbar's own chrome. Its own steps rather than the ramp above, which
+  // runs light here for every key elsewhere: the bar is the darkest of the
+  // three bands now, and a key set into it goes lighter, not darker.
+  // `Navbar.scss` pins the ramp to these inside the bar, so its keys, the name
+  // plate's ring, and the pull puck all read one set. White ink clears 7.23:1
+  // on the fill and 5.49:1 on a key.
+  --rak-nav-fill: #575757;
+  --rak-nav-key: #696969;
+  --rak-nav-key-active: #464646;
+  --rak-nav-key-edge: #3b3b3b;
   --rak-nav-ink: #fff;
-  // The lamp saying which view is chosen, in the brand orange: the blue it takes
-  // elsewhere is the bar's own color here, which it cannot be seen against.
-  // 3.23:1 on the key's face, and the table's own row marker stays blue.
-  --rak-nav-led: #fdba74;
+  // The lamp saying which view is chosen. `--rak-info-400`, which rules the
+  // reader's own row and lit this lamp when the bar was near white, is 2.30:1
+  // on the face a chosen key wears now. This step is 5.66:1 there, the light
+  // the dark bar leaves it room to be, and the row's own rule is unmoved.
+  --rak-nav-led: var(--rak-info-200);
   // The fill a combobox's field sinks into: `lcd-field` in `_lcd.scss`. Its own
   // token rather than a read of the step above, which is the header/frame
   // chrome: a field reads brighter than the panel it is set into, so this stays
@@ -611,24 +614,16 @@ html {
   --rak-primary-600: #404040;
   --rak-primary-700: #333333;
   --rak-primary-800: #262626;
-  // The bands, which already run light-to-dark down the scoreboard in this mode.
-  // The caption sits a step under the ramp's own 600, to leave the bar below
-  // room to sink: at the 600 the two read as one block. 1.38:1 against the bar
-  // above and 1.20:1 against the header below.
-  --rak-band-caption: #333333;
+  // The bands and the navbar's chrome, unmoved: this mode's ramp already runs
+  // light-to-dark down the scoreboard. Literals for the navbar, since it pins
+  // the ramp steps to these and a read back would be a cycle.
+  --rak-band-caption: var(--rak-primary-600);
   --rak-band-header: var(--rak-primary-800);
-  // The navbar's chrome, on the brand blue as it is in light mode, sunk to sit
-  // under the bands rather than over them. Literals, since the bar pins the
-  // ramp steps to these and a read back would be a cycle. White ink clears
-  // 9.17:1 on the fill and 7.31:1 on a key.
-  --rak-nav-fill: #074c73;
-  --rak-nav-key: #085b8a;
-  --rak-nav-key-active: #053d5d;
-  --rak-nav-key-edge: #043149;
+  --rak-nav-fill: #4f4f4f;
+  --rak-nav-key: #5e5e5e;
+  --rak-nav-key-active: #404040;
+  --rak-nav-key-edge: #333333;
   --rak-nav-ink: #fff;
-  // The lamp stays this mode's own light blue, which the sunk key leaves it
-  // room to be light against at 4.38:1. Light mode moves it to orange instead,
-  // where the bar is the blue it would otherwise take.
   --rak-nav-led: var(--rak-info-200);
   // The combobox field, back to the same dark fill this step always stood on
   // in this mode. The readout glass needs no override: `--rak-glass-fill`

--- a/src/index.scss
+++ b/src/index.scss
@@ -116,7 +116,7 @@
   // the reader is waiting on the page rather than watching it.
   --rak-duration-medium: 200ms;
   --rak-duration-slow: 300ms;
-  --rak-duration-loop: 1400ms;
+  --rak-duration-loop: 1000ms;
   --rak-ease-standard: ease;
   // A key's travel. Out fast and settling, the way a moulded key answers a
   // finger, rather than the symmetric curve every other transition uses.

--- a/src/index.scss
+++ b/src/index.scss
@@ -116,7 +116,7 @@
   // the reader is waiting on the page rather than watching it.
   --rak-duration-medium: 200ms;
   --rak-duration-slow: 300ms;
-  --rak-duration-loop: 2000ms;
+  --rak-duration-loop: 1400ms;
   --rak-ease-standard: ease;
   // A key's travel. Out fast and settling, the way a moulded key answers a
   // finger, rather than the symmetric curve every other transition uses.

--- a/src/index.scss
+++ b/src/index.scss
@@ -183,6 +183,11 @@
   --rak-nav-key-active: #464646;
   --rak-nav-key-edge: #3b3b3b;
   --rak-nav-ink: #fff;
+  // The lit rim along a key's top edge, weaker than the one every other key in
+  // the app wears. That 70% white was set against a near-white key face; on the
+  // dark face a key in this bar carries, it reads as a white line rather than as
+  // an edge, and a key held down looks as raised as its neighbours.
+  --rak-nav-key-top: inset 0 1px 0 rgb(255 255 255 / 25%);
   // The lamp saying which view is chosen. `--rak-info-400`, which rules the
   // reader's own row and lit this lamp when the bar was near white, is 2.30:1
   // on the face a chosen key wears now. Its own value rather than a step on
@@ -626,6 +631,9 @@ html {
   --rak-nav-key-active: #404040;
   --rak-nav-key-edge: #333333;
   --rak-nav-ink: #fff;
+  // A literal, like the fills above: the bar pins `--rak-key-top` to this, and
+  // a read back would be a cycle. Unchanged from what this mode always wore.
+  --rak-nav-key-top: inset 0 1px 0 rgb(255 255 255 / 18%);
   --rak-nav-led: var(--rak-info-200);
   // The combobox field, back to the same dark fill this step always stood on
   // in this mode. The readout glass needs no override: `--rak-glass-fill`

--- a/src/index.scss
+++ b/src/index.scss
@@ -185,9 +185,11 @@
   --rak-nav-ink: #fff;
   // The lamp saying which view is chosen. `--rak-info-400`, which rules the
   // reader's own row and lit this lamp when the bar was near white, is 2.30:1
-  // on the face a chosen key wears now. This step is 5.66:1 there, the light
-  // the dark bar leaves it room to be, and the row's own rule is unmoved.
-  --rak-nav-led: var(--rak-info-200);
+  // on the face a chosen key wears now. Its own value rather than a step on
+  // that ramp: between the 400 and the 200 the lamp wants a blue this dark bar
+  // leaves room to be light against, and no step there is one. 4.41:1 on the
+  // chosen face, and the row's own rule is unmoved.
+  --rak-nav-led: #38bdf8;
   // The fill a combobox's field sinks into: `lcd-field` in `_lcd.scss`. Its own
   // token rather than a read of the step above, which is the header/frame
   // chrome: a field reads brighter than the panel it is set into, so this stays

--- a/src/index.scss
+++ b/src/index.scss
@@ -133,6 +133,9 @@
   // The header cell of the column that also sticks left. Above the header cells
   // after it in the table, which pass under it as the table scrolls sideways.
   --rak-z-sticky-corner: 25;
+  // Over the sticky header and its corner, so the caption's own plane is above
+  // the header's. `ResultsFrame.scss` says why.
+  --rak-z-caption: 26;
   --rak-z-skeleton: 30;
   // The pull-to-refresh puck, over the table it is dragged off and under the bar
   // it is dragged out from beneath.
@@ -334,13 +337,6 @@
   // both. Dark mode pins it to its own old value below, against the header's
   // dark fill there.
   --rak-table-header-divider: #373737;
-  // The rule under the whole header, which is heavier than the ones inside it.
-  // The header's fill is a step off white here, so the fill alone parts it from
-  // the rows by 1.14:1. This seam is what actually divides the two. In
-  // `--rak-panel-border` rather than the divider above, since the body's own
-  // grid is already drawn in that darker step and a lighter seam would read as
-  // the faintest line in the table.
-  --rak-table-header-seam: 4px solid var(--rak-panel-border);
   // The dialog progress bar's sweep. Its own token rather than a direct read of
   // `--rak-primary-500`, for the same reason as `--rak-panel-border`: that ramp
   // step is light here, and the track it sweeps over (`--rak-fill-subtle`)
@@ -449,6 +445,15 @@
   --rak-shadow-modal:
     0 8px 24px -4px rgb(var(--rak-shadow-color) / 18%),
     0 16px 40px -8px rgb(var(--rak-shadow-color) / 12%);
+
+  // The scoreboard's three bands, each on its own plane over the one below:
+  // the navbar, the week caption, and the table's header, down onto the rows.
+  // Weaker at every step, so the stack reads as a stack and no one shadow is
+  // looked at. Alphas, so a dark mode that casts almost nothing still casts
+  // it in the right order.
+  --rak-shadow-band-navbar: 0 3px 5px -1px rgb(var(--rak-shadow-color) / 20%);
+  --rak-shadow-band-caption: 0 2px 4px -1px rgb(var(--rak-shadow-color) / 15%);
+  --rak-shadow-band-header: 0 2px 3px -1px rgb(var(--rak-shadow-color) / 11%);
 
   // Moulding, for the three things the app draws as parts of a device rather than
   // as panes of a page: a key, the bezel around a screen, and the well a readout
@@ -647,10 +652,6 @@ html {
   // above is fixed to this same value in both modes already.
   --rak-well-fill: #262626;
   --rak-table-header-divider: #757575;
-  // Unmoved: this mode's header is dark against dark rows, and the divider
-  // carries that boundary already.
-  --rak-table-header-seam: var(--rak-border-width) solid
-    var(--rak-table-header-divider);
   // The chrome's own ink, light again against the dark fill above.
   --rak-on-solid: #fff;
   // The stronger cut, for the dark fill the field sinks into here. Same as

--- a/src/index.scss
+++ b/src/index.scss
@@ -116,7 +116,7 @@
   // the reader is waiting on the page rather than watching it.
   --rak-duration-medium: 200ms;
   --rak-duration-slow: 300ms;
-  --rak-duration-loop: 1000ms;
+  --rak-duration-loop: 800ms;
   --rak-ease-standard: ease;
   // A key's travel. Out fast and settling, the way a moulded key answers a
   // finger, rather than the symmetric curve every other transition uses.

--- a/src/index.scss
+++ b/src/index.scss
@@ -165,6 +165,26 @@
   --rak-primary-600: #dcdcdc;
   --rak-primary-700: #c4c4c4;
   --rak-primary-800: #a8a8a8;
+  // The two chrome bands under the navbar: the week caption and the table's
+  // header. Their own tokens rather than steps on the ramp above, which also
+  // fills every solid key in the app. The bands step dark-to-light down the
+  // scoreboard here and light-to-dark in dark mode, and one ramp cannot run
+  // both ways.
+  --rak-band-caption: #bfbfbf;
+  --rak-band-header: #f0f0f0;
+  // The navbar's own chrome, on the brand blue while the ramp above stays
+  // achromatic for every key elsewhere. `Navbar.scss` pins the ramp to these
+  // inside the bar, so its keys, the name plate's ring, and the pull puck all
+  // read one set. White ink clears 7.19:1 on the fill and 5.45:1 on a key.
+  --rak-nav-fill: #095c8c;
+  --rak-nav-key: #0a6fa8;
+  --rak-nav-key-active: #074a6f;
+  --rak-nav-key-edge: #063f60;
+  --rak-nav-ink: #fff;
+  // The lamp saying which view is chosen, in the brand orange: the blue it takes
+  // elsewhere is the bar's own color here, which it cannot be seen against.
+  // 3.23:1 on the key's face, and the table's own row marker stays blue.
+  --rak-nav-led: #fdba74;
   // The fill a combobox's field sinks into: `lcd-field` in `_lcd.scss`. Its own
   // token rather than a read of the step above, which is the header/frame
   // chrome: a field reads brighter than the panel it is set into, so this stays
@@ -591,6 +611,17 @@ html {
   --rak-primary-600: #404040;
   --rak-primary-700: #333333;
   --rak-primary-800: #262626;
+  // The bands and the navbar's chrome, unmoved: this mode's ramp already runs
+  // light-to-dark down the scoreboard. Literals for the navbar, since it pins
+  // the ramp steps to these and a read back would be a cycle.
+  --rak-band-caption: var(--rak-primary-600);
+  --rak-band-header: var(--rak-primary-800);
+  --rak-nav-fill: #4f4f4f;
+  --rak-nav-key: #5e5e5e;
+  --rak-nav-key-active: #404040;
+  --rak-nav-key-edge: #333333;
+  --rak-nav-ink: #fff;
+  --rak-nav-led: var(--rak-info-200);
   // The combobox field, back to the same dark fill this step always stood on
   // in this mode. The readout glass needs no override: `--rak-glass-fill`
   // above is fixed to this same value in both modes already.

--- a/src/index.scss
+++ b/src/index.scss
@@ -334,6 +334,13 @@
   // both. Dark mode pins it to its own old value below, against the header's
   // dark fill there.
   --rak-table-header-divider: #373737;
+  // The rule under the whole header, which is heavier than the ones inside it.
+  // The header's fill is a step off white here, so the fill alone parts it from
+  // the rows by 1.14:1. This seam is what actually divides the two. In
+  // `--rak-panel-border` rather than the divider above, since the body's own
+  // grid is already drawn in that darker step and a lighter seam would read as
+  // the faintest line in the table.
+  --rak-table-header-seam: 4px solid var(--rak-panel-border);
   // The dialog progress bar's sweep. Its own token rather than a direct read of
   // `--rak-primary-500`, for the same reason as `--rak-panel-border`: that ramp
   // step is light here, and the track it sweeps over (`--rak-fill-subtle`)
@@ -640,6 +647,10 @@ html {
   // above is fixed to this same value in both modes already.
   --rak-well-fill: #262626;
   --rak-table-header-divider: #757575;
+  // Unmoved: this mode's header is dark against dark rows, and the divider
+  // carries that boundary already.
+  --rak-table-header-seam: var(--rak-border-width) solid
+    var(--rak-table-header-divider);
   // The chrome's own ink, light again against the dark fill above.
   --rak-on-solid: #fff;
   // The stronger cut, for the dark fill the field sinks into here. Same as

--- a/src/styles/_skeleton.scss
+++ b/src/styles/_skeleton.scss
@@ -33,11 +33,9 @@ $sheen-fraction: 0.6;
 }
 
 /**
- * One sheen crossing the whole element, rather than a pulse in each of the
- * fifteen hundred bars a wireframe table holds. Animating them all cost three
- * quarters of the frame budget on a throttled phone, over the same seconds the
- * week is being scored. This is one transform on the compositor, so it costs the
- * same whatever the element's size.
+ * One sheen crossing the whole element, rather than a pulse in each of the parts
+ * inside it. This is one transform on the compositor, so it costs the same
+ * whatever the element's size.
  *
  * Applies to the element it is included in, which becomes the containing block
  * and clips the sheen: the sheen is as wide as most of the box, so both ends of


### PR DESCRIPTION
## What

Light mode's chrome now steps down from a dark gray navbar to a near-white table header, each band on its own plane.

![before and after, light above and dark below](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/light-theme-blue-chrome/before-after.png)

## Why

The light bands ran the wrong way. The navbar was the lightest of the three and the header the darkest, so contrast fell down the page while dark mode's rose.

## Changes

* Give the caption, the header, and the navbar their own tokens. The primary ramp fills every solid key in the app, and it cannot run dark-to-light in one mode and light-to-dark in the other.
* Pin the ramp inside `.navbar`, so its keys, the name plate's ring, and a key's lower edge follow one set. `Button.scss` reads that edge from `--rak-primary-700`, past any local `--rak-key-edge`.
* Give the lamp its own blue, `#38bdf8`. The `--rak-info-400` it took is 2.30:1 on the face a chosen key wears now, and the ramp holds no step between it and the 200.
* Quiet the lit rim on the bar's keys, from 70% white to 25%. The 70% was set against a near-white face, so a key held down looked as raised as its neighbors.
* Light the three bands as planes, each shadow weaker than the one above. The caption goes over the sticky header, so its shadow falls on it.
* Drop the table's outer left and right edges on a phone, where it fills the screen. `roomy-screen` puts them back.

## Verification

* The band shadows are alphas, so dark mode casts in the same order. Against near-black surfaces it casts almost nothing.

💣 Neutralized by [Agent Kim Possible](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
