### PR TITLE
fix(dialog): raise and drop a phone's keyboard with the field

### DIFF
--- a/src/App.routes.test.tsx
+++ b/src/App.routes.test.tsx
@@ -154,6 +154,6 @@ describe("the app: the URL decides which week is fetched, and what shows while i
     await user.click(await screen.findByRole("button", { name: "Settings" }));
 
     expect(screen.getByRole("group", { name: "Theme" })).toBeInTheDocument();
-    expect(screen.getByLabelText("Your Player Name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Player Name")).toBeInTheDocument();
   });
 });

--- a/src/components/dialog/DialogCombobox.tsx
+++ b/src/components/dialog/DialogCombobox.tsx
@@ -121,9 +121,11 @@ export default function DialogCombobox<T>({
           in the input. This fills the field and everything else in it draws over
           it, so the icon, the adornment, and the padding around them all reach it.
 
-          The input alone sits above it and keeps its own press, which is what a
-          phone needs: the trigger raises no keyboard on a touch, and a search
-          opened without one cannot be typed into.
+          The input alone sits above it and keeps its own press, which places the
+          caret where the reader pressed. Base UI hands the input the focus from
+          here as well, but not from a touch, so a phone opened the search with no
+          keyboard to type into it. The click covers that, and it is the gesture a
+          phone raises the keyboard on.
 
           Out of a reader's way, which has the input's own `combobox` role for all
           of this and would otherwise be offered a second, nameless control.
@@ -132,6 +134,7 @@ export default function DialogCombobox<T>({
           className="dialog__search-trigger"
           aria-hidden="true"
           tabIndex={-1}
+          onClick={() => inputRef.current?.focus()}
         />
         <Combobox.Input
           ref={inputRef}

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
@@ -228,5 +228,14 @@ describe("PlayerAnalysisDialog", () => {
     // Half a name reaches nobody yet, so there is nobody for the mark to speak
     // for until the next one is picked.
     expect(document.querySelector(".player-analysis__input-status")).toBeNull();
+
+    // A touch on the field hands the input the focus as well. Base UI skips that
+    // for a touch, and a phone raises its keyboard on the focus, so the search
+    // opened with no way to type a name into it.
+    await user.keyboard("{Escape}");
+    search.blur();
+    await user.pointer({ target: field!, keys: "[TouchA]" });
+
+    expect(search).toHaveFocus();
   });
 });

--- a/src/components/settings/CLAUDE.md
+++ b/src/components/settings/CLAUDE.md
@@ -2,7 +2,7 @@
 
 `SettingsDialog`: the theme and the reader's own name, in the `DialogShell` the
 player analysis and the game status use. Opened from the home page footer, which
-is the only thing that opens it. Your Player Name comes first: an `lcd-field`
+is the only thing that opens it. Player Name comes first: an `lcd-field`
 shell holding a text input and a clear button, whose value marks that player's
 row in both tables. Theme is three `Button`s with `selected`, the navbar's own
 switch idiom. Both go through `SettingsContext`.

--- a/src/components/settings/SettingsDialog.test.tsx
+++ b/src/components/settings/SettingsDialog.test.tsx
@@ -29,7 +29,7 @@ describe("SettingsDialog", () => {
       .getAllByRole("heading", { level: 3 })
       .map((heading) => heading.textContent);
 
-    expect(headings).toEqual(["Your Player Name", "Theme"]);
+    expect(headings).toEqual(["Player Name", "Theme"]);
   });
 
   it("closes from the shell's own close button", async () => {
@@ -80,7 +80,7 @@ describe("SettingsDialog, the theme", () => {
 describe("SettingsDialog, the reader's own name", () => {
   it("saves what is typed", async () => {
     const user = mountDialog();
-    await user.type(screen.getByLabelText("Your Player Name"), "Linebacher");
+    await user.type(screen.getByLabelText("Player Name"), "Linebacher");
 
     expect(localStorage.getItem(PLAYER_NAME_KEY)).toBe("Linebacher");
   });
@@ -89,13 +89,13 @@ describe("SettingsDialog, the reader's own name", () => {
     localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
     mountDialog();
 
-    expect(screen.getByLabelText("Your Player Name")).toHaveValue("Linebacher");
+    expect(screen.getByLabelText("Player Name")).toHaveValue("Linebacher");
   });
 
   it("forgets the name once the field is cleared", async () => {
     localStorage.setItem(PLAYER_NAME_KEY, "Linebacher");
     const user = mountDialog();
-    await user.clear(screen.getByLabelText("Your Player Name"));
+    await user.clear(screen.getByLabelText("Player Name"));
 
     expect(localStorage.getItem(PLAYER_NAME_KEY)).toBeNull();
   });
@@ -107,7 +107,7 @@ describe("SettingsDialog, the reader's own name", () => {
       screen.getByRole("button", { name: "Clear your player name" }),
     );
 
-    expect(screen.getByLabelText("Your Player Name")).toHaveValue("");
+    expect(screen.getByLabelText("Player Name")).toHaveValue("");
     expect(localStorage.getItem(PLAYER_NAME_KEY)).toBeNull();
   });
 
@@ -120,7 +120,16 @@ describe("SettingsDialog, the reader's own name", () => {
 
     // The button unmounts on the same click, so without this the focus lands on
     // `<body>` and the next tab restarts from the top of the document.
-    expect(screen.getByLabelText("Your Player Name")).toHaveFocus();
+    expect(screen.getByLabelText("Player Name")).toHaveFocus();
+  });
+
+  it("leaves the field on enter, which drops a phone's keyboard", async () => {
+    const user = mountDialog();
+    const field = screen.getByLabelText("Player Name");
+    await user.type(field, "Linebacher{Enter}");
+
+    expect(field).not.toHaveFocus();
+    expect(field).toHaveValue("Linebacher");
   });
 
   it("offers nothing to clear while the field is empty", () => {

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -31,7 +31,7 @@ export default function SettingsDialog({
       <div className="settings">
         <section className="settings__section">
           <h3 className="settings__label">
-            <label htmlFor={nameInputId}>Your Player Name</label>
+            <label htmlFor={nameInputId}>Player Name</label>
           </h3>
           {/* The well is the shell rather than the input, so the clear button
               sits inside it in a bay of its own, the way the home page's selects
@@ -47,6 +47,13 @@ export default function SettingsDialog({
               placeholder="As it appears in the picks"
               value={playerName}
               onChange={(event) => setPlayerName(event.target.value)}
+              // There is no form to submit, so enter would otherwise do nothing
+              // and a phone would hold its keyboard over the rest of the dialog.
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.currentTarget.blur();
+                }
+              }}
             />
             {/* Nothing to clear while the field is empty, and a button that does
                 nothing is one more thing to tab past. Clearing therefore takes

--- a/src/components/table/playerName/PlayerName.scss
+++ b/src/components/table/playerName/PlayerName.scss
@@ -25,3 +25,9 @@
     white-space: nowrap;
   }
 }
+
+// Set heavier inside the rules `Table.scss` draws above and below the row, so the
+// reader's own row is told from its neighbours by weight as well as by that mark.
+.--mine .player-name__name {
+  font-weight: var(--rak-weight-bold);
+}

--- a/src/components/table/playerName/PlayerName.scss
+++ b/src/components/table/playerName/PlayerName.scss
@@ -25,9 +25,3 @@
     white-space: nowrap;
   }
 }
-
-// Set heavier inside the rules `Table.scss` draws above and below the row, so the
-// reader's own row is told from its neighbours by weight as well as by that mark.
-.--mine .player-name__name {
-  font-weight: var(--rak-weight-bold);
-}


### PR DESCRIPTION
## What

Two dialog fields now open and close a phone's keyboard when the reader expects it. The settings name field leaves focus on enter. The search combobox takes focus from a touch anywhere in the field.

## Why

The settings name field sits in no form, so enter did nothing and the keyboard stayed over the rest of the dialog. Base UI skips the focus for a touch, so a press on the search chevron or the status mark opened the list with no keyboard to type a name into.

## Changes

- Blur from `onKeyDown` rather than wrap the settings field in a form, which would add a submit path the dialog has no use for.
- Focus the search input from the trigger's click, the gesture a phone raises its keyboard on. The trigger already covers the chevron, the mark, and the padding around them.
- Rename the settings label to `Player Name`. The dialog is the reader's own settings, so `Your` was already implied.

🔍 Investigated by [Agent Ron Stoppable](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
