### PR TITLE
feat(footer): pulse the settings link until a reader opens it

### DIFF
--- a/.claude/skills/record-demo/SKILL.md
+++ b/.claude/skills/record-demo/SKILL.md
@@ -45,6 +45,9 @@ instead of recording the whole run.
   dialog theme switch, the reader's own row, and the home page's two colored
   keys, in both themes. Writes its crops to `$LED_SHOT_DIR`, so `--out` is a
   throwaway.
+- `scenarios/settings-pulse.js` — the footer's Settings control pulsing at a
+  reader who has never opened it, then going quiet as they do. Takes its theme
+  from `$PULSE_THEME`, so run it once per theme.
 - `scenarios/pull-to-refresh.js` — pulls down from the top of the scoreboard on
   a phone, where the navbar's refresh button is read and not drawn. Needs
   `--touch`.

--- a/.claude/skills/record-demo/scripts/scenarios/led-indicator.js
+++ b/.claude/skills/record-demo/scripts/scenarios/led-indicator.js
@@ -114,7 +114,7 @@ export default async function run({ page, context, baseUrl }) {
       .click();
     const controls = page.locator(".home__controls");
     await controls.waitFor({ timeout: 20000 });
-    // Both keys stay grey until the week has been scored, so wait for the last
+    // Both keys stay gray until the week has been scored, so wait for the last
     // of them to come up rather than for a fixed delay.
     await page
       .locator(".home__button:not([disabled])", { hasText: "Export Results" })

--- a/.claude/skills/record-demo/scripts/scenarios/settings-pulse.js
+++ b/.claude/skills/record-demo/scripts/scenarios/settings-pulse.js
@@ -1,0 +1,72 @@
+import {
+  buildPicksWorkbook,
+  makeGame,
+  registerAppMocks,
+} from "../lib/mocks.js";
+
+const SEASON = 2024;
+const WEEK = 5;
+const THEME_KEY = "rak-madness:settings:theme";
+const SEEN_KEY = "rak-madness:settings:settingsSeenAt";
+
+const ROWS = [
+  { Name: "Alice", P1: "KC", P2: "SF", P3: "MIA" },
+  { Name: "Bob", P1: "BUF", P2: "DAL", P3: "NYJ" },
+];
+
+function events() {
+  return {
+    events: [
+      makeGame("P1EVT", "KC", "BUF", 24, 17, "3"),
+      makeGame("P2EVT", "SF", "DAL", 27, 20, "3"),
+      makeGame("P3EVT", "NYJ", "MIA", 16, 20, "3"),
+    ],
+  };
+}
+
+/** Three full cycles of the 1.6s pulse, which is what reads as a breath. */
+const PULSE_HOLD = 5000;
+
+/**
+ * The footer's Settings control pulsing at a reader who has never opened it, and
+ * going quiet the moment they do.
+ *
+ * The theme comes from `$PULSE_THEME`, since the pulse has a color in each and one
+ * clip cannot hold both. Run it twice.
+ */
+export default async function run({ page, context, baseUrl }) {
+  const theme = process.env.PULSE_THEME ?? "light";
+
+  await registerAppMocks(context, {
+    season: SEASON,
+    week: WEEK,
+    xlsxBuffer: buildPicksWorkbook(ROWS),
+    events,
+  });
+
+  await page.goto(`${baseUrl}/`);
+  // A reader who has chosen a theme but has never opened the settings, which is
+  // the state the pulse is for.
+  await page.evaluate(
+    ([themeKey, theme, seenKey]) => {
+      localStorage.setItem(themeKey, theme);
+      localStorage.removeItem(seenKey);
+    },
+    [THEME_KEY, theme, SEEN_KEY],
+  );
+  await page.goto(`${baseUrl}/`);
+  // A toast stands over the footer, and the settings button is under it.
+  await page.addStyleTag({ content: ".toaster { display: none !important; }" });
+
+  const settings = page.getByRole("button", { name: "Settings" });
+  await settings.waitFor({ timeout: 20000 });
+  await page.waitForTimeout(PULSE_HOLD);
+
+  await settings.click();
+  await page.locator(".dialog__popup").waitFor({ timeout: 20000 });
+  await page.waitForTimeout(1500);
+
+  // Back to the footer, where the control is now the same gray as its neighbours.
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(2500);
+}

--- a/.claude/skills/record-demo/scripts/scenarios/settings-pulse.js
+++ b/.claude/skills/record-demo/scripts/scenarios/settings-pulse.js
@@ -66,7 +66,7 @@ export default async function run({ page, context, baseUrl }) {
   await page.locator(".dialog__popup").waitFor({ timeout: 20000 });
   await page.waitForTimeout(1500);
 
-  // Back to the footer, where the control is now the same gray as its neighbours.
+  // Back to the footer, where the control is now the same gray as its neighbors.
   await page.keyboard.press("Escape");
   await page.waitForTimeout(2500);
 }

--- a/.claude/skills/record-demo/scripts/scenarios/settings-pulse.js
+++ b/.claude/skills/record-demo/scripts/scenarios/settings-pulse.js
@@ -7,7 +7,7 @@ import {
 const SEASON = 2024;
 const WEEK = 5;
 const THEME_KEY = "rak-madness:settings:theme";
-const SEEN_KEY = "rak-madness:settings:settingsSeenAt";
+const SETTINGS_SEEN_KEY = "rak-madness:settings:settingsSeenAt";
 
 const ROWS = [
   { Name: "Alice", P1: "KC", P2: "SF", P3: "MIA" },
@@ -52,7 +52,7 @@ export default async function run({ page, context, baseUrl }) {
       localStorage.setItem(themeKey, theme);
       localStorage.removeItem(seenKey);
     },
-    [THEME_KEY, theme, SEEN_KEY],
+    [THEME_KEY, theme, SETTINGS_SEEN_KEY],
   );
   await page.goto(`${baseUrl}/`);
   // A toast stands over the footer, and the settings button is under it.

--- a/src/components/button/Button.scss
+++ b/src/components/button/Button.scss
@@ -59,7 +59,7 @@
   line-height: var(--rak-line-height);
   cursor: pointer;
   // The key's travel and the edge it stands on are timed with its fill, so a
-  // press is one move rather than a colour easing while the face jumps.
+  // press is one move rather than a color easing while the face jumps.
   //
   // This order (background-color, color, transform, box-shadow) is read
   // positionally by every `transition-delay` override below, `--selectable`'s
@@ -74,7 +74,7 @@
 
   @include focus-ring;
 
-  // Only a real `disabled` greys out. `aria-disabled` says the button is waiting
+  // Only a real `disabled` grays out. `aria-disabled` says the button is waiting
   // on something rather than unavailable, and a control that is about to work
   // should not look like one that never will.
   &:disabled {
@@ -100,7 +100,7 @@
     aspect-ratio: 1;
   }
 
-  // A key moulded out of the panel: lit along its top edge, standing on a lower
+  // A key molded out of the panel: lit along its top edge, standing on a lower
   // edge in its own color one step down. Each variant names that step below, so
   // a key is never edged in a color it does not otherwise carry.
   &.--solid {
@@ -155,7 +155,7 @@
     // two eased moves land back to back — the browser drops `:active` the instant
     // the pointer lifts, a render tick before React can add `--selected`, so a fill
     // a step darker flashes through the one below it on every click. The press is
-    // said in the travel and the edge instead, which is what a moulded key says it
+    // said in the travel and the edge instead, which is what a molded key says it
     // with. A phone has no pointer, so the same step is the one it gets on touch.
     //
     // Properties rather than an override, because a fill that varies by surface
@@ -226,7 +226,7 @@
   }
 
   // Which one is chosen, said in something other than a fill one step from its
-  // neighbours': a lamp set into the key's bottom lip, on the edge it shares
+  // neighbors': a lamp set into the key's bottom lip, on the edge it shares
   // with the page. A key that could be chosen carries the lamp unlit, so the
   // row reads as lamps with one of them on rather than as one key wearing a
   // rule under it.
@@ -293,7 +293,7 @@
     cursor: default;
 
     // A key is disabled for as long as it is working, so this is where most of the
-    // app's waiting is seen. The sweep is white, which is invisible on the grey a
+    // app's waiting is seen. The sweep is white, which is invisible on the gray a
     // disabled key stands in, and the key looked switched off rather than busy.
     &:disabled {
       --rak-loading-sheen: var(--rak-loading-sheen-on-light);

--- a/src/components/dialog/DialogShell.scss
+++ b/src/components/dialog/DialogShell.scss
@@ -215,7 +215,7 @@ $bar-height: 2px;
     transform: translate(-50%, -50%);
 
     // The fade alone, at the transform it rests at, so the window opens where it
-    // will stand rather than travelling into place.
+    // will stand rather than traveling into place.
     &[data-starting-style],
     &[data-ending-style] {
       opacity: 0;

--- a/src/components/footer/CLAUDE.md
+++ b/src/components/footer/CLAUDE.md
@@ -5,3 +5,9 @@ then links to Standings (rakmadness.net) and the GitHub repo. Each is marked
 with an `Icon.tsx` icon rather than an emoji, so the mark is the same on every
 platform and can be colored. Hidden below 540px viewport height, where the row
 would sit under the home page's last button.
+
+The settings pulse in the theme keys' lamp blue for a reader who has not opened
+them lately. `Footer.tsx` stamps the moment they do, and weighs it against its
+own `SETTINGS_CHANGED_AT`, so moving that forward sends everyone back to a dialog
+that gained something. `Footer.scss` keeps the pulse lit rather than still under
+reduced motion.

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -30,15 +30,22 @@
 // blue through the label and the gear together, since the icon draws in
 // `currentColor`, and stops for good the first time the dialog opens.
 //
+// The halo is `drop-shadow` rather than `text-shadow`, which reaches the glyphs
+// and the icon's own path where a text shadow would leave the gear unlit. Both
+// ends of the run are one shadow, since a filter list interpolates only against
+// a list the same length, and `none` is not one.
+//
 // An animated property outranks a normal declaration whatever its specificity,
 // so this beats the `.footer > *` ink above without a stronger selector.
 @keyframes rak-footer-pulse {
   0%,
   100% {
     color: var(--rak-text-tertiary);
+    filter: drop-shadow(0 0 0 transparent);
   }
   50% {
     color: var(--rak-attention-ink);
+    filter: drop-shadow(0 0 4px var(--rak-attention-glow));
   }
 }
 
@@ -54,6 +61,7 @@
   @include reduced-motion {
     animation: none;
     color: var(--rak-attention-ink);
+    filter: drop-shadow(0 0 4px var(--rak-attention-glow));
   }
 }
 

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -1,3 +1,5 @@
+@use "../../styles/breakpoints" as *;
+
 // The quietest ink the app has that still clears 4.5:1 on the surface these links
 // stand on.
 .footer,
@@ -20,6 +22,38 @@
 
   > * {
     text-decoration: none;
+  }
+}
+
+// A reader who has never opened the settings has nothing pointing them at the
+// one control here that opens something. This breathes the theme keys' own lamp
+// blue through the label and the gear together, since the icon draws in
+// `currentColor`, and stops for good the first time the dialog opens.
+//
+// An animated property outranks a normal declaration whatever its specificity,
+// so this beats the `.footer > *` ink above without a stronger selector.
+@keyframes rak-footer-pulse {
+  0%,
+  100% {
+    color: var(--rak-text-tertiary);
+  }
+  50% {
+    color: var(--rak-attention-ink);
+  }
+}
+
+.footer__link--unseen {
+  // Twice the loop the sheens run at, which is a breath rather than a blink for
+  // something that has no end to run to.
+  animation: rak-footer-pulse calc(var(--rak-duration-loop) * 2)
+    var(--rak-ease-standard) infinite;
+
+  // Held lit rather than stopped. The global guard in `index.scss` only makes an
+  // animation instant, which would leave this reader the plain gray label and no
+  // mark at all.
+  @include reduced-motion {
+    animation: none;
+    color: var(--rak-attention-ink);
   }
 }
 

--- a/src/components/footer/Footer.test.tsx
+++ b/src/components/footer/Footer.test.tsx
@@ -1,7 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { SettingsContextProvider } from "../../context/SettingsContext";
-import Footer from "./Footer";
+import Footer, { SETTINGS_SEEN_KEY } from "./Footer";
+
+/**
+ * The settings control itself. Base UI hides the page behind an open dialog, so a
+ * role query stops finding it exactly when this file wants to look at it.
+ */
+function settingsControl() {
+  return document.querySelector(".footer__link");
+}
 
 function mountFooter() {
   const user = userEvent.setup();
@@ -14,6 +22,8 @@ function mountFooter() {
 }
 
 describe("Footer", () => {
+  beforeEach(() => localStorage.clear());
+
   it("offers the settings, the standings, and the repo, in that order", () => {
     mountFooter();
     const labels = Array.from(document.querySelectorAll(".footer__link")).map(
@@ -46,6 +56,47 @@ describe("Footer", () => {
     expect(
       screen.getByRole("dialog", { name: "Settings" }),
     ).toBeInTheDocument();
+  });
+
+  it("pulses the settings at a reader who has never opened them", () => {
+    mountFooter();
+
+    expect(settingsControl()).toHaveClass("footer__link--unseen");
+  });
+
+  it("stops pulsing as the settings open, rather than once they close", async () => {
+    const user = mountFooter();
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Settings" }),
+    ).toBeInTheDocument();
+    expect(settingsControl()).not.toHaveClass("footer__link--unseen");
+    expect(
+      Date.parse(localStorage.getItem(SETTINGS_SEEN_KEY) ?? ""),
+    ).not.toBeNaN();
+  });
+
+  it("leaves the settings quiet for a reader who has opened them since", () => {
+    localStorage.setItem(SETTINGS_SEEN_KEY, new Date().toISOString());
+    mountFooter();
+
+    expect(settingsControl()).not.toHaveClass("footer__link--unseen");
+  });
+
+  it("pulses again at a reader whose last look predates the settings' own", () => {
+    localStorage.setItem(SETTINGS_SEEN_KEY, "2020-01-01T00:00:00.000Z");
+    mountFooter();
+
+    expect(settingsControl()).toHaveClass("footer__link--unseen");
+  });
+
+  it("treats a stamp it cannot read as never having looked", () => {
+    localStorage.setItem(SETTINGS_SEEN_KEY, "true");
+    mountFooter();
+
+    expect(settingsControl()).toHaveClass("footer__link--unseen");
   });
 
   it("names each link by its text, not the decorative icon beside it", () => {

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,10 +1,51 @@
 import { useState } from "react";
 import { EmojiEventsIcon, GitHubIcon, SettingsIcon } from "../icon/Icon";
 import SettingsDialog from "../settings/SettingsDialog";
+import getClasses from "../../utils/getClasses";
+import { PREFIX, readSetting, writeSetting } from "../../utils/settingsStore";
 import "./Footer.scss";
+
+const SETTINGS_SEEN_SETTING = "settingsSeenAt";
+
+/** Composed here for a test that reads localStorage directly. */
+export const SETTINGS_SEEN_KEY = PREFIX + SETTINGS_SEEN_SETTING;
+
+/**
+ * When the settings last gained something worth being sent back for. A reader who
+ * opened the dialog before this has not seen what is in it now, so the pulse
+ * starts over for them. Move it forward on the same commit that adds the thing,
+ * and leave it alone for a change nobody would go looking for.
+ *
+ * A reader who opens the dialog stores the moment they did. That is what makes
+ * this comparable rather than a flag that can only be set once.
+ */
+const SETTINGS_CHANGED_AT = Date.parse("2026-08-30T00:00:00Z");
+
+/**
+ * Whether this reader has opened the settings since the last thing worth showing
+ * them landed in it. An unset name, and a stored value no longer parseable, both
+ * read as never.
+ */
+function hasSeenLatestSettings(): boolean {
+  const seenAt = Date.parse(readSetting(SETTINGS_SEEN_SETTING) ?? "");
+  return seenAt >= SETTINGS_CHANGED_AT;
+}
 
 export default function Footer() {
   const [isSettingsOpen, setSettingsOpen] = useState(false);
+
+  // Only this stamp counts as having found the dialog. A reader with a theme or a
+  // name already saved still gets the pulse, since neither of those was chosen
+  // from here.
+  const [hasSeenSettings, setSeenSettings] = useState(hasSeenLatestSettings);
+
+  // Stamped on the way open rather than on the way closed, so the pulse stops as
+  // the dialog appears instead of staying under it.
+  function openSettings() {
+    setSettingsOpen(true);
+    setSeenSettings(true);
+    writeSetting(SETTINGS_SEEN_SETTING, new Date().toISOString());
+  }
 
   return (
     <div className="footer">
@@ -13,8 +54,10 @@ export default function Footer() {
           player analysis and the game status do too. */}
       <button
         type="button"
-        className="footer__link"
-        onClick={() => setSettingsOpen(true)}
+        className={getClasses("footer__link", {
+          "footer__link--unseen": !hasSeenSettings,
+        })}
+        onClick={openSettings}
       >
         <SettingsIcon />
         Settings

--- a/src/components/gameStatus/GameStatusSummary.scss
+++ b/src/components/gameStatus/GameStatusSummary.scss
@@ -71,7 +71,7 @@
 .game-status__spread {
   align-self: center;
   margin: 0;
-  // The grey the labels over the two names are set in, so the line over the
+  // The gray the labels over the two names are set in, so the line over the
   // scoreline and the labels inside it read as one tier of the same dialog.
   color: var(--rak-text-secondary);
   font-size: var(--rak-text-sm);
@@ -81,8 +81,8 @@
 
 // The line itself, in the face the picks table sets every number in. `None` too: it
 // answers the same question, and a value that changes face with its own value reads
-// as two different fields. Set in the grey the records under the two names carry,
-// which is the same grey their labels do, so the face is what tells the answer from
+// as two different fields. Set in the gray the records under the two names carry,
+// which is the same gray their labels do, so the face is what tells the answer from
 // the question rather than a second color on one line.
 .game-status__spread-value {
   color: var(--rak-text-secondary);

--- a/src/components/home/HomePage.scss
+++ b/src/components/home/HomePage.scss
@@ -24,7 +24,7 @@
 
   &[data-disabled] {
     cursor: default;
-    // A dim readout rather than a greyed field: the glass stays, only the
+    // A dim readout rather than a grayed field: the glass stays, only the
     // value goes dark, the same as a socket with nothing chosen yet.
     color: var(--rak-unlit);
   }

--- a/src/components/navbar/ScoresNavbar.scss
+++ b/src/components/navbar/ScoresNavbar.scss
@@ -11,12 +11,12 @@
 }
 
 // Below this the icon carries the button on its own, so the app name beside it
-// keeps to two lines. Labelled buttons squeeze it to three. The label is only
+// keeps to two lines. Labeled buttons squeeze it to three. The label is only
 // drawn, never removed: the button is named for a screen reader either way.
 .scores-nav__label {
   display: none;
 
-  @include labelled-navbar {
+  @include labeled-navbar {
     display: inline;
   }
 }

--- a/src/components/navbar/ScoresNavbar.tsx
+++ b/src/components/navbar/ScoresNavbar.tsx
@@ -78,9 +78,9 @@ export default function ScoresNavbar({
 
   // A results route always names a view, even while it loads, so that button
   // keeps looking selected through the wait: only `aria-disabled`, never a real
-  // `disabled` that would greyscale its highlight. The home page has no view
+  // `disabled` that would grayscale its highlight. The home page has no view
   // yet to show as selected, so there is nothing that look would protect, and
-  // it greys out for real instead.
+  // it grays out for real instead.
   const noViewYet = disabled && view == null;
 
   return (

--- a/src/components/results/ResultsFrame.scss
+++ b/src/components/results/ResultsFrame.scss
@@ -51,7 +51,7 @@
   text-align: center;
   // Between the navbar above and the header below, so the three step down into
   // the table. No border under it: the step off this fill is what divides the
-  // caption from the header, and a rule drawn in either neighbour's color would
+  // caption from the header, and a rule drawn in either neighbor's color would
   // be a line one of them could not show.
   background-color: var(--rak-band-caption);
   // Over the header rather than under it, which is the order the three bands

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -161,7 +161,7 @@
         border-left: var(--rak-table-no-border);
       }
 
-      // The corner, stuck to the top and the left at once. Above its neighbours
+      // The corner, stuck to the top and the left at once. Above its neighbors
       // rather than level with them: they come after it in the table, so at the
       // same step they would draw over it on the way past.
       &.table__player-col {

--- a/src/components/table/playerName/PlayerName.scss
+++ b/src/components/table/playerName/PlayerName.scss
@@ -27,7 +27,7 @@
 }
 
 // Set heavier inside the rules `Table.scss` draws above and below the row, so the
-// reader's own row is told from its neighbours by weight as well as by that mark.
+// reader's own row is told from its neighbors by weight as well as by that mark.
 .--mine .player-name__name {
   font-weight: var(--rak-weight-bold);
 }

--- a/src/context/SettingsContext.test.tsx
+++ b/src/context/SettingsContext.test.tsx
@@ -84,7 +84,7 @@ function holdFrames() {
         next(0);
       }
     },
-    /** How many frames are waiting, which a cancelled one is not. */
+    /** How many frames are waiting, which a canceled one is not. */
     pending: () => queued.size,
     restore() {
       window.requestAnimationFrame = originalRequest;

--- a/src/index.scss
+++ b/src/index.scss
@@ -492,6 +492,12 @@
   --rak-led-off: #2e2e2e;
   --rak-led-socket: 0 -1px 0 rgb(0 0 0 / 22%);
   --rak-led-glow: 0 0 4px rgb(2 132 199 / 55%);
+  // The lamp's blue said as ink rather than as a lens, for the footer's Settings
+  // control before anyone has opened it. A lens only has to clear 3:1 and
+  // `--rak-led-on` is set for that. A word has to clear 4.5:1, and
+  // `--rak-info-400` misses it here at about 4.1:1. One step down the ramp
+  // carries the same blue at about 5.4:1.
+  --rak-attention-ink: var(--rak-info-500);
   // The same lamp where it is drawn as a rule inside something rather than as a
   // lens in a lip: the reader's own row in `Table.scss`. Inset, because the rule
   // is inset and a halo outside the cell would fall under the cell beside it.
@@ -791,6 +797,9 @@ html {
   --rak-led-socket: 0 -1px 0 rgb(0 0 0 / 40%);
   --rak-led-glow:
     0 0 6px rgb(125 211 252 / 55%), 0 0 12px rgb(125 211 252 / 25%);
+  // The lit lens is already light enough to read as a word on this surface, so
+  // the ink and the lens are one step here.
+  --rak-attention-ink: var(--rak-info-200);
   --rak-led-bloom:
     inset 0 8px 7px -6px rgb(125 211 252 / 15%),
     inset 0 -8px 7px -6px rgb(125 211 252 / 15%);

--- a/src/index.scss
+++ b/src/index.scss
@@ -76,7 +76,7 @@
   --rak-space-4: 16px;
   --rak-space-6: 24px;
 
-  // Squarer than a card's. The app is drawn as a moulded case with keys set into
+  // Squarer than a card's. The app is drawn as a molded case with keys set into
   // it, and a corner rounded much past this stops reading as something pressed
   // out of a panel.
   --rak-radius-xs: 2px;
@@ -118,7 +118,7 @@
   --rak-duration-slow: 300ms;
   --rak-duration-loop: 800ms;
   --rak-ease-standard: ease;
-  // A key's travel. Out fast and settling, the way a moulded key answers a
+  // A key's travel. Out fast and settling, the way a molded key answers a
   // finger, rather than the symmetric curve every other transition uses.
   --rak-ease-key: cubic-bezier(0.2, 0.8, 0.3, 1);
   // Something going home under nothing but its own weight, which starts from a
@@ -189,7 +189,7 @@
   // The lit rim along a key's top edge, weaker than the one every other key in
   // the app wears. That 70% white was set against a near-white key face; on the
   // dark face a key in this bar carries, it reads as a white line rather than as
-  // an edge, and a key held down looks as raised as its neighbours.
+  // an edge, and a key held down looks as raised as its neighbors.
   --rak-nav-key-top: inset 0 1px 0 rgb(255 255 255 / 25%);
   // The lamp saying which view is chosen. `--rak-info-400`, which rules the
   // reader's own row and lit this lamp when the bar was near white, is 2.30:1
@@ -201,7 +201,7 @@
   // The fill a combobox's field sinks into: `lcd-field` in `_lcd.scss`. Its own
   // token rather than a read of the step above, which is the header/frame
   // chrome: a field reads brighter than the panel it is set into, so this stays
-  // near white here while that step stays mid-grey. Dark mode below pins this
+  // near white here while that step stays mid-gray. Dark mode below pins this
   // back to the old dark field, unchanged.
   --rak-well-fill: #f5f5f5;
   // The fill a readout's own glass sinks into: `lcd-glass` in `_lcd.scss`, the
@@ -312,7 +312,7 @@
 
   --rak-surface: #fff;
   // What a dialog stands on, one plane above the page. The same white here,
-  // where the scrim already takes the page to grey under it. Dark mode has no
+  // where the scrim already takes the page to gray under it. Dark mode has no
   // such room and lifts the plane instead.
   --rak-surface-raised: var(--rak-surface);
   --rak-fill-subtle: #f3f3f3;
@@ -405,13 +405,13 @@
   --rak-disabled-bg: #f3f3f3;
   --rak-disabled-text: #737373;
   // The lower edge a key that cannot be pressed stands on. A disabled key keeps
-  // its moulding, so enabling one eases its fill rather than growing an edge out
+  // its molding, so enabling one eases its fill rather than growing an edge out
   // of nothing under a fill that is already moving.
   --rak-disabled-edge: #d6d6d6;
 
   // How far an even row is taken from the fill its cells already carry. One value
   // for every column, so a striped name cell, a striped pick, and a striped score
-  // are all the same step apart from their odd-row neighbours. Its own dark value
+  // are all the same step apart from their odd-row neighbors. Its own dark value
   // rather than a read of `--rak-primary-800`, which is light here: mixing toward
   // a light color would fade the stripe instead of darkening it. Dark mode moves
   // this to `--rak-text` below, off that mode's own light ink.
@@ -455,7 +455,7 @@
   --rak-shadow-band-caption: 0 2px 4px -1px rgb(var(--rak-shadow-color) / 15%);
   --rak-shadow-band-header: 0 2px 3px -1px rgb(var(--rak-shadow-color) / 11%);
 
-  // Moulding, for the three things the app draws as parts of a device rather than
+  // Molding, for the three things the app draws as parts of a device rather than
   // as panes of a page: a key, the bezel around a screen, and the well a readout
   // is sunk into. Every one is an alpha, so it is read against whatever fill it is
   // laid on and none of them has to be repainted per surface. The dark lower edge
@@ -486,7 +486,7 @@
   // boundary itself, at 2.99:1 on the face a chosen key wears, so the socket
   // stays a seam rather than the bezel a light lens needed.
   //
-  // Off is grey, and dark enough to leave the lit lens somewhere to be brighter
+  // Off is gray, and dark enough to leave the lit lens somewhere to be brighter
   // than: 3.32:1 between the two, which is what says which key is chosen.
   --rak-led-on: var(--rak-info-400);
   --rak-led-off: #2e2e2e;
@@ -498,6 +498,10 @@
   // `--rak-info-400` misses it here at about 4.1:1. One step down the ramp
   // carries the same blue at about 5.4:1.
   --rak-attention-ink: var(--rak-info-500);
+  // The halo off the lit lens, at the one strength this app gives a lamp. Text and
+  // an icon take it through `drop-shadow` rather than `box-shadow`, so this is the
+  // color alone and `Footer.scss` says how far it carries.
+  --rak-attention-glow: rgb(2 132 199 / 55%);
   // The same lamp where it is drawn as a rule inside something rather than as a
   // lens in a lip: the reader's own row in `Table.scss`. Inset, because the rule
   // is inset and a halo outside the cell would fall under the cell beside it.
@@ -546,7 +550,7 @@
   --rak-loading-sheen: rgb(255 255 255 / 30%);
   // The same sweep on a fill light enough that white crossing it cannot be seen.
   // The only one is a key that is working and disabled while it does, which stands
-  // in the app's lightest grey.
+  // in the app's lightest gray.
   --rak-loading-sheen-on-light: rgb(0 0 0 / 10%);
 }
 
@@ -568,7 +572,7 @@ body {
 
 * {
   box-sizing: border-box;
-  // Every fill in the app is chosen, so nothing wants a translucent grey laid
+  // Every fill in the app is chosen, so nothing wants a translucent gray laid
   // over it on tap. Both cells and buttons draw their own `:active` state.
   -webkit-tap-highlight-color: transparent;
 }
@@ -735,7 +739,7 @@ html {
   --rak-mark-upcoming-text: var(--rak-text);
 
   // The toast's own darkened fills, off the same hues as their light
-  // pastel. `primary` and `neutral` are both grey chrome, so they take the
+  // pastel. `primary` and `neutral` are both gray chrome, so they take the
   // selected-row and muted-panel fills already this dark; `success` and
   // `danger` reuse the table cell's own darkened green/red. `warning` gets
   // its own: its hue is the orange the rest of its ramp runs on, not the
@@ -776,7 +780,7 @@ html {
   --rak-progress-fill: var(--rak-border);
 
   --rak-well-light: inset 0 1px 2px rgb(0 0 0 / 42%);
-  // The key's own moulding, back to the cut it always dished by against this
+  // The key's own molding, back to the cut it always dished by against this
   // mode's dark fills.
   --rak-key-top: inset 0 1px 0 rgb(255 255 255 / 18%);
   --rak-key-dish: inset 0 -2px 3px rgb(0 0 0 / 14%);
@@ -800,6 +804,7 @@ html {
   // The lit lens is already light enough to read as a word on this surface, so
   // the ink and the lens are one step here.
   --rak-attention-ink: var(--rak-info-200);
+  --rak-attention-glow: rgb(125 211 252 / 55%);
   --rak-led-bloom:
     inset 0 8px 7px -6px rgb(125 211 252 / 15%),
     inset 0 -8px 7px -6px rgb(125 211 252 / 15%);

--- a/src/styles/CLAUDE.md
+++ b/src/styles/CLAUDE.md
@@ -4,7 +4,7 @@ Sass partials, mixins and variables only, so a partial emits no CSS however many
 files `@use` it. `_skeleton.scss` is the one exception, and says so: it holds
 keyframes. Design tokens live in `src/index.scss` instead.
 
-- `_breakpoints.scss`: `roomy-screen`, `labelled-navbar`, `wide-screen`,
+- `_breakpoints.scss`: `roomy-screen`, `labeled-navbar`, `wide-screen`,
   `can-hover`, `phone-landscape`, `phone-touch`, `reduced-motion`. Mixins rather
   than custom properties, because a custom property does not work inside a media
   query. Reach them with `@use "…/styles/breakpoints" as *;`. Every width one is

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -13,11 +13,11 @@
 $breakpoint-roomy: 481px;
 
 /**
- * Above this the navbar can hold the app name and three labelled buttons at
+ * Above this the navbar can hold the app name and three labeled buttons at
  * once. Measured: with the labels showing, the name wraps to three lines at 540px
  * and to two at 560px.
  */
-$breakpoint-labelled-navbar: 561px;
+$breakpoint-labeled-navbar: 561px;
 
 /**
  * Above this a dialog centered in the viewport leaves enough either side of it to
@@ -35,8 +35,8 @@ $breakpoint-wide: 601px;
 }
 
 /** Room enough for the navbar to label its buttons. */
-@mixin labelled-navbar {
-  @media (min-width: $breakpoint-labelled-navbar) {
+@mixin labeled-navbar {
+  @media (min-width: $breakpoint-labeled-navbar) {
     @content;
   }
 }

--- a/src/styles/_lcd.scss
+++ b/src/styles/_lcd.scss
@@ -26,7 +26,7 @@
 /**
  * The same well, without the plate ring: for a control the reader types or
  * chooses into rather than a display, sitting on its own page or panel rather
- * than another readout's surface. The ring's outer two layers read as a grey
+ * than another readout's surface. The ring's outer two layers read as a gray
  * outline there instead of an edge to the well, so this keeps only the sunk
  * shadow, plus the lit color every readout in the app sets its value in.
  */

--- a/src/styles/_listbox.scss
+++ b/src/styles/_listbox.scss
@@ -41,7 +41,7 @@ $-max-rows: 5;
   }
 
   // The one already set, said in the app's own primary rather than a step further
-  // down the same greys the row under the pointer uses. Two neutrals one step
+  // down the same grays the row under the pointer uses. Two neutrals one step
   // apart cannot say which of them means chosen.
   &[data-selected] {
     background-color: var(--rak-selected-fill);


### PR DESCRIPTION
## What

The footer's Settings control pulses in blue for a reader who has not opened the dialog lately, and goes quiet the moment they do.

<video src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/settings-pulse/settings-pulse-light.mp4" controls></video>

<video src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/settings-pulse/settings-pulse-dark.mp4" controls></video>

## Why

The dialog holds the reader's own name, which is what marks their row in both tables. It sat as one gray label among three, so a reader had no reason to open it.

## Changes

- Store the moment the reader opens the dialog, not a flag. `SETTINGS_CHANGED_AT` in `Footer.tsx` is the floor. Move it forward and every reader gets the pulse again.
- Stamp on the way open, so the pulse stops as the dialog appears rather than under it.
- Ignore a saved theme or name. Neither was chosen from here, so every current reader sees this once.
- Add `--rak-attention-ink` rather than reuse `--rak-led-on`. The lamp's `#0284c7` reads at 4.10:1 on white, which fails as text. One ramp step down holds the blue at 5.45:1.
- Glow with `drop-shadow`, which reaches the icon's own path where `text-shadow` would not. Both ends of the run are one shadow, since a filter list interpolates only against one the same length.
- Hold the color and the glow lit under reduced motion. The global guard in `index.scss` only makes an animation instant, which would leave that reader no mark.

## Verification

Ran the app in both themes and with Reduce Motion on. The glow peaks at the lamp's own 4px.

## Notes / Follow-ups

The American English spelling pass is separate from the feature. It touches comments, plus the `labeled-navbar` mixin and its breakpoint variable.

🚁 Extracted by [Agent Juni Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
