### PR TITLE
feat(settings): let a reader turn off a live week's player status

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -19,7 +19,7 @@ export const SETTINGS_SEEN_KEY = PREFIX + SETTINGS_SEEN_SETTING;
  * A reader who opens the dialog stores the moment they did. That is what makes
  * this comparable rather than a flag that can only be set once.
  */
-const SETTINGS_CHANGED_AT = Date.parse("2026-08-30T00:00:00Z");
+const SETTINGS_CHANGED_AT = Date.parse("2026-08-30T17:00:00Z");
 
 /**
  * Whether this reader has opened the settings since the last thing worth showing

--- a/src/components/settings/CLAUDE.md
+++ b/src/components/settings/CLAUDE.md
@@ -1,11 +1,12 @@
 # settings
 
-`SettingsDialog`: the theme and the reader's own name, in the `DialogShell` the
-player analysis and the game status use. Opened from the home page footer, which
-is the only thing that opens it. Player Name comes first: an `lcd-field`
-shell holding a text input and a clear button, whose value marks that player's
-row in both tables. Theme is three `Button`s with `selected`, the navbar's own
-switch idiom. Both go through `SettingsContext`.
+`SettingsDialog`: three settings in the `DialogShell` the player analysis and the
+game status use. Opened from the home page footer, which is the only thing that
+opens it. Player Name comes first: an `lcd-field` shell holding a text input and
+a clear button, whose value marks that player's row in both tables. Live Player
+Analysis and Theme follow, each a row of `Button`s with `selected`, the navbar's
+own switch idiom. All three go through `SettingsContext`. A new one
+means moving `Footer.tsx`'s `SETTINGS_CHANGED_AT` forward.
 
 `SettingsDialog.scss`: the column, its labels, and the well the field and its
 clear button share. The well takes the focus ring, not the input.

--- a/src/components/settings/SettingsDialog.test.tsx
+++ b/src/components/settings/SettingsDialog.test.tsx
@@ -20,12 +20,12 @@ function mountDialog(onOpenChange = () => undefined) {
 
 /** The choices under one heading, which is what names their group. */
 function choiceLabels(group: string): Array<string> {
+  const row = screen.getByRole("group", { name: group });
   return screen
     .getAllByRole("button", { name: /.+/ })
     .filter(
       (button) =>
-        button.classList.contains("settings__choice") &&
-        screen.getByRole("group", { name: group }).contains(button),
+        button.classList.contains("settings__choice") && row.contains(button),
     )
     .map((button) => button.textContent);
 }

--- a/src/components/settings/SettingsDialog.test.tsx
+++ b/src/components/settings/SettingsDialog.test.tsx
@@ -151,16 +151,16 @@ describe("SettingsDialog, the reader's own name", () => {
 });
 
 describe("SettingsDialog, the live player analysis", () => {
-  it("offers enable then disable", () => {
+  it("offers on then off", () => {
     mountDialog();
 
-    expect(choiceLabels("Live Player Analysis")).toEqual(["Enable", "Disable"]);
+    expect(choiceLabels("Live Player Analysis")).toEqual(["On", "Off"]);
   });
 
-  it("starts enabled", () => {
+  it("starts on", () => {
     mountDialog();
 
-    expect(screen.getByRole("button", { name: "Enable" })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "On" })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
@@ -168,9 +168,9 @@ describe("SettingsDialog, the live player analysis", () => {
 
   it("saves the choice to disable, and shows it as chosen", async () => {
     const user = mountDialog();
-    await user.click(screen.getByRole("button", { name: "Disable" }));
+    await user.click(screen.getByRole("button", { name: "Off" }));
 
-    expect(screen.getByRole("button", { name: "Disable" })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Off" })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
@@ -179,8 +179,8 @@ describe("SettingsDialog, the live player analysis", () => {
 
   it("forgets the choice on the way back to enabled, the default", async () => {
     const user = mountDialog();
-    await user.click(screen.getByRole("button", { name: "Disable" }));
-    await user.click(screen.getByRole("button", { name: "Enable" }));
+    await user.click(screen.getByRole("button", { name: "Off" }));
+    await user.click(screen.getByRole("button", { name: "On" }));
 
     expect(localStorage.getItem(LIVE_ANALYSIS_KEY)).toBeNull();
   });
@@ -189,7 +189,7 @@ describe("SettingsDialog, the live player analysis", () => {
     localStorage.setItem(LIVE_ANALYSIS_KEY, "off");
     mountDialog();
 
-    expect(screen.getByRole("button", { name: "Disable" })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Off" })).toHaveAttribute(
       "aria-pressed",
       "true",
     );

--- a/src/components/settings/SettingsDialog.test.tsx
+++ b/src/components/settings/SettingsDialog.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import {
+  LIVE_ANALYSIS_KEY,
   PLAYER_NAME_KEY,
   SettingsContextProvider,
   THEME_KEY,
@@ -17,19 +18,31 @@ function mountDialog(onOpenChange = () => undefined) {
   return user;
 }
 
+/** The choices under one heading, which is what names their group. */
+function choiceLabels(group: string): Array<string> {
+  return screen
+    .getAllByRole("button", { name: /.+/ })
+    .filter(
+      (button) =>
+        button.classList.contains("settings__choice") &&
+        screen.getByRole("group", { name: group }).contains(button),
+    )
+    .map((button) => button.textContent);
+}
+
 beforeEach(() => {
   localStorage.clear();
   delete document.documentElement.dataset.theme;
 });
 
 describe("SettingsDialog", () => {
-  it("asks for the name first, then the theme", () => {
+  it("asks for the name first, then the analysis, then the theme", () => {
     mountDialog();
     const headings = screen
       .getAllByRole("heading", { level: 3 })
       .map((heading) => heading.textContent);
 
-    expect(headings).toEqual(["Player Name", "Theme"]);
+    expect(headings).toEqual(["Player Name", "Live Player Analysis", "Theme"]);
   });
 
   it("closes from the shell's own close button", async () => {
@@ -44,12 +57,8 @@ describe("SettingsDialog", () => {
 describe("SettingsDialog, the theme", () => {
   it("offers auto, dark, and light, in that order", () => {
     mountDialog();
-    const labels = screen
-      .getAllByRole("button")
-      .filter((button) => button.classList.contains("settings__choice"))
-      .map((button) => button.textContent);
 
-    expect(labels).toEqual(["Auto", "Dark", "Light"]);
+    expect(choiceLabels("Theme")).toEqual(["Auto", "Dark", "Light"]);
   });
 
   it("starts on auto", () => {
@@ -138,5 +147,51 @@ describe("SettingsDialog, the reader's own name", () => {
     expect(
       screen.queryByRole("button", { name: "Clear your player name" }),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("SettingsDialog, the live player analysis", () => {
+  it("offers enable then disable", () => {
+    mountDialog();
+
+    expect(choiceLabels("Live Player Analysis")).toEqual(["Enable", "Disable"]);
+  });
+
+  it("starts enabled", () => {
+    mountDialog();
+
+    expect(screen.getByRole("button", { name: "Enable" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("saves the choice to disable, and shows it as chosen", async () => {
+    const user = mountDialog();
+    await user.click(screen.getByRole("button", { name: "Disable" }));
+
+    expect(screen.getByRole("button", { name: "Disable" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(localStorage.getItem(LIVE_ANALYSIS_KEY)).toBe("off");
+  });
+
+  it("forgets the choice on the way back to enabled, the default", async () => {
+    const user = mountDialog();
+    await user.click(screen.getByRole("button", { name: "Disable" }));
+    await user.click(screen.getByRole("button", { name: "Enable" }));
+
+    expect(localStorage.getItem(LIVE_ANALYSIS_KEY)).toBeNull();
+  });
+
+  it("starts on the choice last made", () => {
+    localStorage.setItem(LIVE_ANALYSIS_KEY, "off");
+    mountDialog();
+
+    expect(screen.getByRole("button", { name: "Disable" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 });

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -13,7 +13,14 @@ const THEMES: Array<{ value: Theme; label: string }> = [
   { value: "light", label: "Light" },
 ];
 
-/** How the app looks, and who the reader is. */
+// The on choice first, against the alphabetical order above, because these two are
+// one setting's two states rather than three peers.
+const LIVE_ANALYSIS: Array<{ value: boolean; label: string }> = [
+  { value: true, label: "Enable" },
+  { value: false, label: "Disable" },
+];
+
+/** How the app looks, who the reader is, and how much it tells them. */
 export default function SettingsDialog({
   open,
   onOpenChange,
@@ -21,8 +28,16 @@ export default function SettingsDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const { theme, setTheme, playerName, setPlayerName } = useSettings();
+  const {
+    theme,
+    setTheme,
+    playerName,
+    setPlayerName,
+    liveAnalysis,
+    setLiveAnalysis,
+  } = useSettings();
   const themeLabelId = useId();
+  const liveAnalysisLabelId = useId();
   const nameInputId = useId();
   const nameInput = useRef<HTMLInputElement>(null);
 
@@ -76,6 +91,32 @@ export default function SettingsDialog({
           </div>
           <p className="settings__hint">
             Your row is marked in the scoreboard and picks tables.
+          </p>
+        </section>
+
+        <section className="settings__section">
+          <h3 className="settings__label" id={liveAnalysisLabelId}>
+            Live Player Analysis
+          </h3>
+          <div
+            className="settings__choices"
+            role="group"
+            aria-labelledby={liveAnalysisLabelId}
+          >
+            {LIVE_ANALYSIS.map(({ value, label }) => (
+              <Button
+                key={label}
+                compact
+                selected={liveAnalysis === value}
+                onClick={() => setLiveAnalysis(value)}
+                className="settings__choice"
+              >
+                {label}
+              </Button>
+            ))}
+          </div>
+          <p className="settings__hint">
+            {"Sometimes you don't want to know."}
           </p>
         </section>
 

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -16,8 +16,8 @@ const THEMES: Array<{ value: Theme; label: string }> = [
 // The on choice first, against the alphabetical order above, because these two are
 // one setting's two states rather than three peers.
 const LIVE_ANALYSIS: Array<{ value: boolean; label: string }> = [
-  { value: true, label: "Enable" },
-  { value: false, label: "Disable" },
+  { value: true, label: "On" },
+  { value: false, label: "Off" },
 ];
 
 /** How the app looks, who the reader is, and how much it tells them. */

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -89,9 +89,7 @@ export default function SettingsDialog({
               </button>
             )}
           </div>
-          <p className="settings__hint">
-            Your row is marked in the scoreboard and picks tables.
-          </p>
+          <p className="settings__hint">Your results are highlighted.</p>
         </section>
 
         <section className="settings__section">

--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -248,8 +248,8 @@
   tbody {
     // Both of these hold a `.table__cell-button` filling them, so both answer to a
     // touch the same way. The wireframe takes no clicks at all, so it never
-    // reaches this.
-    .table__player-col,
+    // reaches this, and neither does a name cell with nothing to open.
+    .table__player-col:not(.--no-status),
     .table__pick {
       // The button inside carries this instead, so the cell's whole box is inside
       // its hit area.
@@ -284,6 +284,13 @@
 
       &.--knocked-out {
         --rak-cell-base: var(--rak-knocked-out-300);
+      }
+
+      // A reader who has turned the live analysis off is told nothing by this
+      // column, so it takes the fill and the ink every other cell has.
+      &.--no-status {
+        --rak-cell-base: var(--rak-surface);
+        color: var(--rak-text);
       }
 
       // The one change a name cell can show is a player just being knocked out,

--- a/src/components/table/playerName/CLAUDE.md
+++ b/src/components/table/playerName/CLAUDE.md
@@ -1,17 +1,17 @@
 # playerName
 
-`PlayerName`: table cell (`<td>`) holding a `.table__cell-button` with the player
-name and status icon. Click opens the player analysis on that player, through
-`PlayerAnalysisContext`. Name is cut short with an ellipsis rather than wrapped, so
-every row is one line tall. A `.table__sr-only` span carries the words for the fill
-color.
+`PlayerName`: table cell (`<td>`) for one player, the name cut short with an
+ellipsis rather than wrapped, so every row is one line tall.
 
-`PlayerStatusIcon`: that icon on its own, sized from `--rak-player-icon-size`. The
-player analysis search renders it too, so the same player wears the same icon in
-both places.
+Where `useShowPlayerStatus` says yes, it is a `.table__cell-button` holding the
+name and `PlayerStatusIcon`, opening the player analysis through
+`PlayerAnalysisContext`, with a `.table__sr-only` span carrying the words for the
+fill color and a `.table__cell-wipe` over the fill a just-knocked-out player
+held. Where it says no, it is the bare name under `--no-status`, which
+`Table.scss` takes the fill and the hit area off.
 
-`--mine`, from `useIsMyPlayer`, marks the reader's own. `Table.scss` reads it
-off the row and rules every cell, lit like the navbar's lamp.
+`PlayerStatusIcon`: that icon alone, sized from `--rak-player-icon-size`. The
+player analysis search renders it too.
 
-A player a refresh just knocked out renders a `.table__cell-wipe`, from
-`useScoreChanges()`, over the fill they held before that.
+`--mine`, from `useIsMyPlayer`, marks the reader's own either way, ruled in
+`Table.scss` and lit like the navbar's lamp.

--- a/src/components/table/playerName/PlayerName.test.tsx
+++ b/src/components/table/playerName/PlayerName.test.tsx
@@ -1,0 +1,97 @@
+import { Mock } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  useIsWinnerDecided,
+  useScoreChanges,
+} from "../../../context/AppDataContext";
+import {
+  LIVE_ANALYSIS_KEY,
+  SettingsContextProvider,
+} from "../../../context/SettingsContext";
+import { PlayerAnalysisContextProvider } from "../../../context/PlayerAnalysisContext";
+import { NO_SCORE_CHANGES } from "../../../utils/scoring/scoreChanges";
+import { playerScore } from "../../../weekFixtures";
+import PlayerName from "./PlayerName";
+
+vi.mock("../../../context/AppDataContext", () => ({
+  useIsWinnerDecided: vi.fn(),
+  useScoreChanges: vi.fn(),
+}));
+
+const mockIsWinnerDecided = useIsWinnerDecided as Mock;
+const mockScoreChanges = useScoreChanges as Mock;
+
+const knockedOut = playerScore({
+  name: "Bob",
+  status: { hasNoPicks: false, isKnockedOut: true },
+});
+
+function mountCell(player = knockedOut) {
+  return render(
+    <SettingsContextProvider>
+      <PlayerAnalysisContextProvider showPlayerAnalysis={vi.fn()}>
+        <table>
+          <tbody>
+            <tr>
+              <PlayerName player={player} />
+            </tr>
+          </tbody>
+        </table>
+      </PlayerAnalysisContextProvider>
+    </SettingsContextProvider>,
+  );
+}
+
+function cell(): HTMLElement {
+  return screen.getByRole("cell");
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockIsWinnerDecided.mockReturnValue(false);
+  mockScoreChanges.mockReturnValue(NO_SCORE_CHANGES);
+});
+
+describe("PlayerName", () => {
+  it("opens the analysis and marks the status while the analysis is live", () => {
+    mountCell();
+
+    expect(screen.getByRole("button", { name: /Bob/ })).toBeInTheDocument();
+    expect(screen.getByTestId("SkullOutlinedIcon")).toBeInTheDocument();
+    expect(cell()).toHaveClass("--knocked-out");
+  });
+
+  it("says only the name once a reader turns the live analysis off", () => {
+    localStorage.setItem(LIVE_ANALYSIS_KEY, "off");
+    mountCell();
+
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByTestId("SkullOutlinedIcon")).toBeNull();
+    expect(screen.queryByText("Knocked out")).toBeNull();
+    expect(cell()).not.toHaveClass("--knocked-out");
+    expect(cell()).toHaveClass("--no-status");
+  });
+
+  it("tells a reader who turned it off how a decided week went", () => {
+    localStorage.setItem(LIVE_ANALYSIS_KEY, "off");
+    mockIsWinnerDecided.mockReturnValue(true);
+    mountCell();
+
+    expect(screen.getByRole("button", { name: /Bob/ })).toBeInTheDocument();
+    expect(screen.getByTestId("SkullOutlinedIcon")).toBeInTheDocument();
+    expect(cell()).toHaveClass("--knocked-out");
+    expect(cell()).not.toHaveClass("--no-status");
+  });
+
+  it("holds back the flash a knockout would otherwise draw", () => {
+    localStorage.setItem(LIVE_ANALYSIS_KEY, "off");
+    mockScoreChanges.mockReturnValue({
+      players: new Map([["Bob", false]]),
+      picks: new Map(),
+    });
+    mountCell();
+
+    expect(cell().querySelector(".table__cell-wipe")).toBeNull();
+  });
+});

--- a/src/components/table/playerName/PlayerName.tsx
+++ b/src/components/table/playerName/PlayerName.tsx
@@ -4,6 +4,7 @@ import { PlayerScore } from "../../../types/RakMadnessScores";
 import getClasses from "../../../utils/getClasses";
 import { useShowPlayerAnalysis } from "../../../context/PlayerAnalysisContext";
 import { useIsMyPlayer } from "../../../context/SettingsContext";
+import useShowPlayerStatus from "../../../hooks/useShowPlayerStatus";
 import { PLAYER_COL_CLASS } from "../TableShell";
 import PlayerStatusIcon from "./PlayerStatusIcon";
 import "./PlayerName.scss";
@@ -11,33 +12,52 @@ import "./PlayerName.scss";
 function PlayerName({ player }: { player: PlayerScore }) {
   const showPlayerAnalysis = useShowPlayerAnalysis();
   const { players: playerChanges } = useScoreChanges();
-  const justKnockedOut = playerChanges.has(player.name);
+  const showStatus = useShowPlayerStatus();
+  // A knockout is the one change this cell flashes, so the flash is a way of
+  // saying where the player stands and goes wherever the rest of it does.
+  const justKnockedOut = showStatus && playerChanges.has(player.name);
   const isMine = useIsMyPlayer(player.name);
+
+  // Whose row this is stands apart from where they stand, so it is said either way.
+  const name = (
+    <>
+      <span className="player-name">
+        <span className="player-name__name">{player.name}</span>
+        {showStatus && (
+          <PlayerStatusIcon isKnockedOut={player.status.isKnockedOut} />
+        )}
+      </span>
+      {isMine && <span className="table__sr-only">Your row</span>}
+    </>
+  );
 
   return (
     <td
       className={getClasses(PLAYER_COL_CLASS, {
-        "--knocked-out": player.status.isKnockedOut,
+        "--knocked-out": showStatus && player.status.isKnockedOut,
+        // Takes the column's own fill and its hit area back off in `Table.scss`,
+        // leaving the cell shaped like every other one in the row.
+        "--no-status": !showStatus,
         "--mine": isMine,
       })}
     >
-      <button
-        type="button"
-        className="table__cell-button"
-        onClick={() => showPlayerAnalysis(player.name)}
-      >
-        <span className="player-name">
-          <span className="player-name__name">{player.name}</span>
-          <PlayerStatusIcon isKnockedOut={player.status.isKnockedOut} />
-        </span>
-        {isMine && <span className="table__sr-only">Your row</span>}
-        <span className="table__sr-only">
-          {player.status.isKnockedOut ? "Knocked out" : "Still in contention"}
-        </span>
-        {justKnockedOut && (
-          <span className="table__cell-wipe" aria-hidden="true" />
-        )}
-      </button>
+      {showStatus ? (
+        <button
+          type="button"
+          className="table__cell-button"
+          onClick={() => showPlayerAnalysis(player.name)}
+        >
+          {name}
+          <span className="table__sr-only">
+            {player.status.isKnockedOut ? "Knocked out" : "Still in contention"}
+          </span>
+          {justKnockedOut && (
+            <span className="table__cell-wipe" aria-hidden="true" />
+          )}
+        </button>
+      ) : (
+        name
+      )}
     </td>
   );
 }

--- a/src/context/CLAUDE.md
+++ b/src/context/CLAUDE.md
@@ -1,14 +1,14 @@
 # context
 
 - `AppDataContext`: the season list, week list, picks, and scores, held above the
-  routes, with the season and week derived from the pathname. Publishes
+  routes, season and week derived from the pathname. Publishes
   `WinnerDecidedContext` and `ScoreChangesContext` separately, the latter what a
   refresh just changed, for the tables to flash.
-- `SettingsContext`: the theme and the reader's own name, from `settingsStore`.
-  Writes `data-theme` for `index.scss`, and answers `useIsMyPlayer`.
+- `SettingsContext`: the theme, the reader's own name, and whether a live week
+  says where players stand, from `settingsStore`. Writes `data-theme` for
+  `index.scss`, and answers `useIsMyPlayer`.
 - `ToastContext`: the toast list, split from its actions.
-- `PlayerAnalysisContext`: how a player's name in a table opens the player analysis
-  on them. One callback, a no-op with no provider above.
-- `GameStatusContext`: the same, for a pick cell opening the game status on the
-  column it sits in. Both single-callback contexts share their plumbing via
-  `createCallbackContext`.
+- `PlayerAnalysisContext`: how a name cell opens the player analysis on that
+  player. One callback, a no-op with no provider above.
+- `GameStatusContext`: the same, for a pick cell opening its game's status. Both
+  single-callback contexts share plumbing via `createCallbackContext`.

--- a/src/context/SettingsContext.test.tsx
+++ b/src/context/SettingsContext.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import {
+  LIVE_ANALYSIS_KEY,
   PLAYER_NAME_KEY,
   SettingsContextProvider,
   THEME_KEY,
@@ -10,13 +11,23 @@ import {
 } from "./SettingsContext";
 
 function Probe({ candidate = "Linebacher" }: { candidate?: string }) {
-  const { theme, setTheme, playerName, setPlayerName } = useSettings();
+  const {
+    theme,
+    setTheme,
+    playerName,
+    setPlayerName,
+    liveAnalysis,
+    setLiveAnalysis,
+  } = useSettings();
   const isMine = useIsMyPlayer(candidate);
   return (
     <>
       <span data-testid="theme">{theme}</span>
       <span data-testid="playerName">{playerName}</span>
       <span data-testid="isMine">{String(isMine)}</span>
+      <span data-testid="liveAnalysis">{String(liveAnalysis)}</span>
+      <button onClick={() => setLiveAnalysis(false)}>hide analysis</button>
+      <button onClick={() => setLiveAnalysis(true)}>show analysis</button>
       {(["light", "dark", "auto"] as Array<Theme>).map((option) => (
         <button key={option} onClick={() => setTheme(option)}>
           {option}
@@ -175,6 +186,45 @@ describe("SettingsContext, the reader's own name", () => {
     mountProbe("Barb Wire");
 
     expect(screen.getByTestId("isMine")).toHaveTextContent("false");
+  });
+});
+
+describe("SettingsContext, the live player analysis", () => {
+  it("is on for a reader who has never said otherwise", () => {
+    mountProbe();
+
+    expect(screen.getByTestId("liveAnalysis")).toHaveTextContent("true");
+  });
+
+  it("saves the one value it has to store, and reads it back", async () => {
+    const user = mountProbe();
+    await user.click(screen.getByRole("button", { name: "hide analysis" }));
+
+    expect(screen.getByTestId("liveAnalysis")).toHaveTextContent("false");
+    expect(localStorage.getItem(LIVE_ANALYSIS_KEY)).toBe("off");
+  });
+
+  it("stores nothing for the default, the way the theme does", async () => {
+    const user = mountProbe();
+    await user.click(screen.getByRole("button", { name: "hide analysis" }));
+    await user.click(screen.getByRole("button", { name: "show analysis" }));
+
+    expect(screen.getByTestId("liveAnalysis")).toHaveTextContent("true");
+    expect(localStorage.getItem(LIVE_ANALYSIS_KEY)).toBeNull();
+  });
+
+  it("starts off where it was left off", () => {
+    localStorage.setItem(LIVE_ANALYSIS_KEY, "off");
+    mountProbe();
+
+    expect(screen.getByTestId("liveAnalysis")).toHaveTextContent("false");
+  });
+
+  it("reads anything else stored as on, rather than as off", () => {
+    localStorage.setItem(LIVE_ANALYSIS_KEY, "true");
+    mountProbe();
+
+    expect(screen.getByTestId("liveAnalysis")).toHaveTextContent("true");
   });
 });
 

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -14,10 +14,15 @@ export type Theme = "light" | "dark" | "auto";
 
 const THEME_SETTING = "theme";
 const PLAYER_NAME_SETTING = "playerName";
+const LIVE_ANALYSIS_SETTING = "liveAnalysis";
 
 /** The exact key `settingsStore` writes to, for a test that reads localStorage directly. */
 export const THEME_KEY = PREFIX + THEME_SETTING;
 export const PLAYER_NAME_KEY = PREFIX + PLAYER_NAME_SETTING;
+export const LIVE_ANALYSIS_KEY = PREFIX + LIVE_ANALYSIS_SETTING;
+
+/** The only value this setting is ever stored as, the default being stored as nothing. */
+const LIVE_ANALYSIS_OFF = "off";
 
 /** Follow the operating system, which is what the app did before it could be told. */
 const DEFAULT_THEME: Theme = "auto";
@@ -44,6 +49,13 @@ type Settings = {
    */
   playerName: string;
   setPlayerName: (name: string) => void;
+  /**
+   * Whether a week still being played says where each player stands. Off, the
+   * tables mark nobody and open nothing until the week is decided, for a reader
+   * who would rather watch the games than be told how they end.
+   */
+  liveAnalysis: boolean;
+  setLiveAnalysis: (enabled: boolean) => void;
 };
 
 // Defaults rather than a throw, following `PlayerAnalysisContext`: the tables read
@@ -53,11 +65,21 @@ const SettingsContext = createContext<Settings>({
   setTheme: doNothing,
   playerName: "",
   setPlayerName: doNothing,
+  liveAnalysis: true,
+  setLiveAnalysis: doNothing,
 });
 
 function storedTheme(): Theme {
   const saved = readSetting(THEME_SETTING);
   return saved === "light" || saved === "dark" ? saved : DEFAULT_THEME;
+}
+
+/**
+ * On unless it was turned off, which is what the app did before it could be told.
+ * Anything else stored reads as on, the same way an unparseable theme does.
+ */
+function storedLiveAnalysis(): boolean {
+  return readSetting(LIVE_ANALYSIS_SETTING) !== LIVE_ANALYSIS_OFF;
 }
 
 const DARK_QUERY = "(prefers-color-scheme: dark)";
@@ -134,6 +156,8 @@ export function SettingsContextProvider({ children }: PropsWithChildren) {
   const [playerName, setPlayerNameState] = useState<string>(
     () => readSetting(PLAYER_NAME_SETTING) ?? "",
   );
+  const [liveAnalysis, setLiveAnalysisState] =
+    useState<boolean>(storedLiveAnalysis);
 
   useEffect(() => {
     applyTheme(theme);
@@ -166,9 +190,21 @@ export function SettingsContextProvider({ children }: PropsWithChildren) {
     writeSetting(PLAYER_NAME_SETTING, next);
   }, []);
 
+  const setLiveAnalysis = useCallback((next: boolean) => {
+    setLiveAnalysisState(next);
+    writeSetting(LIVE_ANALYSIS_SETTING, next ? "" : LIVE_ANALYSIS_OFF);
+  }, []);
+
   const value = useMemo(
-    () => ({ theme, setTheme, playerName, setPlayerName }),
-    [theme, setTheme, playerName, setPlayerName],
+    () => ({
+      theme,
+      setTheme,
+      playerName,
+      setPlayerName,
+      liveAnalysis,
+      setLiveAnalysis,
+    }),
+    [theme, setTheme, playerName, setPlayerName, liveAnalysis, setLiveAnalysis],
   );
 
   return (

--- a/src/hooks/CLAUDE.md
+++ b/src/hooks/CLAUDE.md
@@ -16,3 +16,4 @@ The data layer, plus the two page measurements. The first four mount once in
 - `useWeekRouteGuard`: whether a `/:season/:week` URL has anything to show
 - `useFillerRows`: the empty rows carrying a table to the viewport bottom
 - `useViewportInsets`: what a keyboard covers, as root properties
+- `useShowPlayerStatus`: whether the tables may say where a player stands

--- a/src/hooks/useShowPlayerStatus.ts
+++ b/src/hooks/useShowPlayerStatus.ts
@@ -1,0 +1,17 @@
+import { useIsWinnerDecided } from "../context/AppDataContext";
+import { useSettings } from "../context/SettingsContext";
+
+/**
+ * Whether the tables may say where a player stands, and open the analysis saying
+ * why.
+ *
+ * A decided week is history, and history is told however the reader has set this:
+ * the setting only covers a week whose games are still being played. One hook
+ * rather than the same pair of reads in each place, so a name cell and the fill
+ * behind it cannot disagree about which of the two it is.
+ */
+export default function useShowPlayerStatus(): boolean {
+  const isWinnerDecided = useIsWinnerDecided();
+  const { liveAnalysis } = useSettings();
+  return isWinnerDecided || liveAnalysis;
+}


### PR DESCRIPTION
## What

A new Live Player Analysis setting in the settings dialog, under Player Name. On is the default and keeps today's behavior. Off makes a week still in play say nothing about where anyone stands.

<video src="https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/live-player-analysis/live-analysis.mp4" controls></video>

## Why

A reader who watches the games does not always want the table to tell them who is out before the week ends.

## Changes

- Gate on `useIsWinnerDecided`, so a decided week reads the same either way. That is the app's own idea of a finished week, and it already hides the refresh button.
- Put the rule in one hook, `useShowPlayerStatus`, so the name cell and the fill behind it cannot disagree.
- Drop the `<button>` when the status is off. The analysis dialog has no other way in, so nothing else needs a guard.
- Take the `.table__sr-only` status words and the knockout flash off with the icon and the fill. Both say the same thing to a reader who cannot see color.
- Keep the pick cell colors. They score a pick, not a player.
- Store the setting only when it is off, the way the theme stores only a non-default choice.

🏍️ Exfiltrated by [Agent Alex Rider](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
