### PR TITLE
perf(analysis): work out the paths to victory from sixteen open games

### DIFF
--- a/.claude/skills/record-demo/SKILL.md
+++ b/.claude/skills/record-demo/SKILL.md
@@ -55,6 +55,10 @@ instead of recording the whole run.
   and once stretched, with a candidate close animation injected from
   `$CLOSE_CSS` and `$CLOSE_CSS_SLOW`. Needs `--touch`. For comparing curves
   against one build instead of rebuilding per candidate.
+- `scenarios/analysis-limit.js` — opens Player Analysis on a mocked week built to
+  land on one shape of answer. `$ANALYSIS_PHASE` picks the shape: `headline`,
+  `paths`, `chain`, `routes`, `help`, `clinched`, `knockedOut`. `$ANALYSIS_THEME`
+  is `light` or `dark`.
 - `scenarios/live-refresh.js` — opens the Game Status dialog on a live pick,
   waits out its real poll interval, and shows the table update on its own
   once the mocked game goes final.

--- a/.claude/skills/record-demo/SKILL.md
+++ b/.claude/skills/record-demo/SKILL.md
@@ -57,8 +57,8 @@ instead of recording the whole run.
   against one build instead of rebuilding per candidate.
 - `scenarios/analysis-limit.js` — opens Player Analysis on a mocked week built to
   land on one shape of answer. `$ANALYSIS_PHASE` picks the shape: `headline`,
-  `paths`, `chain`, `routes`, `help`, `clinched`, `knockedOut`. `$ANALYSIS_THEME`
-  is `light` or `dark`.
+  `paths`, `chain`, `routes`, `help`, `clinched`, `clinchedTie`, `knockedOut`.
+  `$ANALYSIS_THEME` is `light` or `dark`.
 - `scenarios/live-refresh.js` — opens the Game Status dialog on a live pick,
   waits out its real poll interval, and shows the table update on its own
   once the mocked game goes final.

--- a/.claude/skills/record-demo/scripts/scenarios/analysis-limit.js
+++ b/.claude/skills/record-demo/scripts/scenarios/analysis-limit.js
@@ -6,14 +6,14 @@ import {
 
 const SEASON = 2024;
 const WEEK = 5;
-// One of the rows below, and the row the dialog is opened on.
-const SUBJECT = "Alice";
 
-/**
- * Which branch to show. `headline` leaves eighteen games open, above
- * `MAX_SEARCHED_GAMES`. `paths` leaves five, under it.
- */
+/** Which shape of answer to show. One of `PHASES`. */
 const PHASE = process.env.ANALYSIS_PHASE ?? "headline";
+
+/** Which theme to render in, since the blue an `And` is set in has one of each. */
+const THEME = process.env.ANALYSIS_THEME ?? "light";
+
+const THEME_KEY = "rak-madness:settings:theme";
 
 /** Four college then sixteen pro, the order a sheet's columns run in. */
 const GAMES = [
@@ -39,76 +39,158 @@ const GAMES = [
   { key: "P16", league: "pro", home: "LV", away: "NE" },
 ];
 
+const KEYS = GAMES.map((game) => game.key);
+
+/** Every column up to and including `key`, which is how a phase names its settled games. */
+function upTo(key) {
+  return KEYS.slice(0, KEYS.indexOf(key) + 1);
+}
+
 /**
- * `opposed` is open and picked both ways, which is what a route can turn on. Every
- * other open game is picked the same way by everyone, so it moves the field
- * together and decides nothing. `aliceWins` are the settled games Alice took, and
- * Bob took the rest, which is what puts him ahead of her.
+ * A row in the sheet.
+ *
+ * `wins` names the settled games this player got right, and every settled game
+ * left out is one they missed. `open` is the side they back in every game still to
+ * be played, and `picks` names the open games they back the other way, or leave
+ * blank with `null`. The home side wins every settled game, so `wins` is read
+ * against `home`.
+ */
+function player(name, points, wins, open, picks = {}) {
+  return { name, points, wins, open, picks };
+}
+
+/** The settled games a player wins to land on a given score, college first. */
+const AT = Object.fromEntries(
+  [1, 2, 8, 9, 19].map((score) => [score, KEYS.slice(0, score)]),
+);
+
+/**
+ * One week each, built to land on a shape the dialog renders differently. Every
+ * score below is a count of settled wins, and each rival's gap to Alice is what
+ * decides how many open games she needs and whether they only leave her tied.
  */
 const PHASES = {
+  // Eighteen games open, over `MAX_SEARCHED_GAMES`: the floor, the must-win games
+  // proven off it, and the note saying what is held back.
   headline: {
     settled: ["C1", "C2"],
-    aliceWins: [],
-    opposed: ["C3", "C4", "P1"],
-  },
-  paths: {
-    settled: [
-      "C1",
-      "C2",
-      "C3",
-      "C4",
-      "P1",
-      "P2",
-      "P3",
-      "P4",
-      "P5",
-      "P6",
-      "P7",
-      "P8",
-      "P9",
-      "P10",
-      "P11",
+    subject: "Alice",
+    rows: [
+      player("Alice", 45, [], "home"),
+      player("Bob", 48, ["C1", "C2"], "home", {
+        C3: "away",
+        C4: "away",
+        P1: "away",
+      }),
+      player("Carol", 41, [], "home"),
     ],
-    aliceWins: ["C1", "C2", "C3", "C4", "P1", "P2", "P3"],
-    opposed: ["P12", "P13", "P14", "P15", "P16"],
+  },
+  // One rival a point ahead across five opposed games, which is one pool of one
+  // size: any three of them, and then the tiebreaker.
+  paths: {
+    settled: upTo("P11"),
+    subject: "Alice",
+    rows: [
+      player("Alice", 45, ["C1", "C2", "C3", "C4", "P1", "P2", "P3"], "home"),
+      player(
+        "Bob",
+        48,
+        ["P4", "P5", "P6", "P7", "P8", "P9", "P10", "P11"],
+        "away",
+      ),
+      player("Carol", 41, [], "home"),
+    ],
+  },
+  // Carol cannot be caught up, read off the same week as `paths`.
+  knockedOut: null,
+  // Two rivals at different distances. Dave is only reachable through P12, which
+  // makes it must-win, and Bob is level, which makes the rest a pool of two.
+  chain: {
+    settled: upTo("P11"),
+    subject: "Alice",
+    rows: [
+      player("Alice", 45, AT[8], "home"),
+      player("Bob", 48, AT[8], "home", {
+        P13: "away",
+        P14: "away",
+        P15: "away",
+        P16: "away",
+      }),
+      player("Dave", 50, AT[9], "home", { P12: "away" }),
+      player("Carol", 41, AT[2], "home"),
+    ],
+  },
+  // Three rivals over overlapping sets of games, so no one pool covers them and
+  // the answer is a list of routes, each with its own total to hit.
+  routes: {
+    settled: upTo("P11"),
+    subject: "Alice",
+    rows: [
+      player("Alice", 45, AT[8], "home"),
+      player("Bob", 48, AT[9], "home", {
+        P12: "away",
+        P13: "away",
+        P14: "away",
+      }),
+      player("Dave", 50, AT[9], "home", {
+        P14: "away",
+        P15: "away",
+        P16: "away",
+      }),
+      player("Erin", 41, AT[8], "home", { P12: "away", P16: "away" }),
+      player("Carol", 38, AT[2], "home"),
+    ],
+  },
+  // Alice left P15 blank, so nothing she does decides it and Bob has to miss it.
+  help: {
+    settled: upTo("P14"),
+    subject: "Alice",
+    rows: [
+      player("Alice", 45, AT[8], "home", { P15: null }),
+      player("Bob", 48, AT[9], "home", { P16: "away" }),
+      player("Carol", 41, AT[1], "home"),
+    ],
+  },
+  // Nineteen games gone Alice's way and none anyone else's, so the last one cannot
+  // take the week off her.
+  clinched: {
+    settled: upTo("P15"),
+    subject: "Alice",
+    rows: [
+      player("Alice", 45, AT[19], "home"),
+      player("Bob", 48, [], "home"),
+      player("Carol", 41, [], "away"),
+    ],
   },
 };
 
-const shape = PHASES[PHASE];
-if (shape == null) {
-  throw new Error(`ANALYSIS_PHASE has to be headline or paths, not ${PHASE}`);
+PHASES.knockedOut = { ...PHASES.paths, subject: "Carol" };
+
+const phase = PHASES[PHASE];
+if (phase == null) {
+  throw new Error(
+    `ANALYSIS_PHASE has to be one of ${Object.keys(PHASES).join(", ")}, not ${PHASE}`,
+  );
 }
 
-const isSettled = (key) => shape.settled.includes(key);
-const isOpposed = (key) => shape.opposed.includes(key);
+const isSettled = (key) => phase.settled.includes(key);
 
 function rows() {
-  const pick = (game, who) => {
-    if (isSettled(game.key)) {
-      // Carol misses every settled game, so she trails without being knocked out.
-      if (who === "carol") return game.away;
-      const alice = shape.aliceWins.includes(game.key) ? "home" : "away";
-      const mine = who === "alice" ? alice : alice === "home" ? "away" : "home";
-      return game[mine];
-    }
-    // Carol shadows Alice through the open games, so she never bears on Alice's
-    // own routes.
-    if (isOpposed(game.key) && who === "bob") return game.away;
-    return game.home;
-  };
-  const row = (name, who, tiebreaker) => {
-    const cells = { Name: name };
+  return phase.rows.map((row) => {
+    const cells = { Name: row.name };
     GAMES.forEach((game) => {
-      cells[game.key] = pick(game, who);
+      if (isSettled(game.key)) {
+        cells[game.key] = row.wins.includes(game.key) ? game.home : game.away;
+        return;
+      }
+      const side = game.key in row.picks ? row.picks[game.key] : row.open;
+      // `null` rather than a key left off, which the sheet builder would append
+      // after the columns every row does carry, and so relabel the games.
+      cells[game.key] = side == null ? null : game[side];
     });
-    cells.Pts = tiebreaker;
+    cells.Pts = row.points;
     return cells;
-  };
-  return [
-    row("Alice", "alice", 45),
-    row("Bob", "bob", 48),
-    row("Carol", "carol", 41),
-  ];
+  });
 }
 
 /** The home side won every game that has been played. */
@@ -122,7 +204,7 @@ function eventsFor(league) {
   };
 }
 
-/** Opens Player Analysis on a player who is behind, and ends on the dialog. */
+/** Opens Player Analysis on the phase's own row, and ends on the dialog. */
 export default async function run({ page, context, baseUrl }) {
   await registerAppMocks(context, {
     season: SEASON,
@@ -133,7 +215,12 @@ export default async function run({ page, context, baseUrl }) {
   });
 
   await page.goto(`${baseUrl}/${SEASON}/${WEEK}/scoreboard`);
-  await page.getByRole("button", { name: new RegExp(SUBJECT) }).click();
+  await page.evaluate(
+    ([key, theme]) => localStorage.setItem(key, theme),
+    [THEME_KEY, THEME],
+  );
+  await page.goto(`${baseUrl}/${SEASON}/${WEEK}/scoreboard`);
+  await page.getByRole("button", { name: new RegExp(phase.subject) }).click();
   await page.getByText("Player Analysis").waitFor({ timeout: 10000 });
   // The answer replaces the bar that stands over the search while it runs.
   await page

--- a/.claude/skills/record-demo/scripts/scenarios/analysis-limit.js
+++ b/.claude/skills/record-demo/scripts/scenarios/analysis-limit.js
@@ -151,6 +151,17 @@ const PHASES = {
       player("Carol", 41, AT[1], "home"),
     ],
   },
+  // Alice and Bob hold the same picks and the same points guess, so no game and no
+  // tiebreaker can part them. Each has clinched a share of the week.
+  clinchedTie: {
+    settled: upTo("P15"),
+    subject: "Alice",
+    rows: [
+      player("Alice", 45, AT[19], "home"),
+      player("Bob", 45, AT[19], "home"),
+      player("Carol", 41, [], "away"),
+    ],
+  },
   // Nineteen games gone Alice's way and none anyone else's, so the last one cannot
   // take the week off her.
   clinched: {

--- a/.claude/skills/record-demo/scripts/scenarios/analysis-limit.js
+++ b/.claude/skills/record-demo/scripts/scenarios/analysis-limit.js
@@ -15,29 +15,43 @@ const THEME = process.env.ANALYSIS_THEME ?? "light";
 
 const THEME_KEY = "rak-madness:settings:theme";
 
-/** Four college then sixteen pro, the order a sheet's columns run in. */
+/**
+ * Four college then sixteen pro, the order a sheet's columns run in.
+ *
+ * `line` is what the home side gives up, so a sheet writes the home cell `-line`
+ * and the away cell `+line`. Every one is under the seven points the home side
+ * wins a settled game by, so the home side covers each of them and a phase reads
+ * its settled games the way it names them. A half point is a game no margin can
+ * land on, which is how `canPush` tells the two apart.
+ */
 const GAMES = [
-  { key: "C1", league: "college", home: "UGA", away: "ALA" },
-  { key: "C2", league: "college", home: "OSU", away: "MICH" },
-  { key: "C3", league: "college", home: "TEX", away: "OU" },
-  { key: "C4", league: "college", home: "ORE", away: "WASH" },
-  { key: "P1", league: "pro", home: "KC", away: "BUF" },
-  { key: "P2", league: "pro", home: "SF", away: "DAL" },
-  { key: "P3", league: "pro", home: "PHI", away: "NYG" },
-  { key: "P4", league: "pro", home: "BAL", away: "CIN" },
-  { key: "P5", league: "pro", home: "DET", away: "GB" },
-  { key: "P6", league: "pro", home: "MIA", away: "NYJ" },
-  { key: "P7", league: "pro", home: "HOU", away: "IND" },
-  { key: "P8", league: "pro", home: "LAR", away: "SEA" },
-  { key: "P9", league: "pro", home: "TB", away: "ATL" },
-  { key: "P10", league: "pro", home: "MIN", away: "CHI" },
-  { key: "P11", league: "pro", home: "PIT", away: "CLE" },
-  { key: "P12", league: "pro", home: "DEN", away: "LAC" },
-  { key: "P13", league: "pro", home: "NO", away: "CAR" },
-  { key: "P14", league: "pro", home: "JAX", away: "TEN" },
-  { key: "P15", league: "pro", home: "WSH", away: "ARI" },
-  { key: "P16", league: "pro", home: "LV", away: "NE" },
+  { key: "C1", league: "college", home: "UGA", away: "ALA", line: 3 },
+  { key: "C2", league: "college", home: "OSU", away: "MICH", line: 6.5 },
+  { key: "C3", league: "college", home: "TEX", away: "OU", line: 2.5 },
+  { key: "C4", league: "college", home: "ORE", away: "WASH", line: 6 },
+  { key: "P1", league: "pro", home: "KC", away: "BUF", line: 3 },
+  { key: "P2", league: "pro", home: "SF", away: "DAL", line: 1.5 },
+  { key: "P3", league: "pro", home: "PHI", away: "NYG", line: 6 },
+  { key: "P4", league: "pro", home: "BAL", away: "CIN", line: 2.5 },
+  { key: "P5", league: "pro", home: "DET", away: "GB", line: 3 },
+  { key: "P6", league: "pro", home: "MIA", away: "NYJ", line: 4.5 },
+  { key: "P7", league: "pro", home: "HOU", away: "IND", line: 6 },
+  { key: "P8", league: "pro", home: "LAR", away: "SEA", line: 1.5 },
+  { key: "P9", league: "pro", home: "TB", away: "ATL", line: 4 },
+  { key: "P10", league: "pro", home: "MIN", away: "CHI", line: 5.5 },
+  { key: "P11", league: "pro", home: "PIT", away: "CLE", line: 3 },
+  { key: "P12", league: "pro", home: "DEN", away: "LAC", line: 2.5 },
+  { key: "P13", league: "pro", home: "NO", away: "CAR", line: 6 },
+  { key: "P14", league: "pro", home: "JAX", away: "TEN", line: 3.5 },
+  { key: "P15", league: "pro", home: "WSH", away: "ARI", line: 4 },
+  { key: "P16", league: "pro", home: "LV", away: "NE", line: 1.5 },
 ];
+
+/** One side of a game as a sheet writes it, the team then the line it gives up. */
+function cell(game, side) {
+  const spread = side === "home" ? -game.line : game.line;
+  return `${game[side]} ${spread > 0 ? "+" : ""}${spread}`;
+}
 
 const KEYS = GAMES.map((game) => game.key);
 
@@ -191,13 +205,16 @@ function rows() {
     const cells = { Name: row.name };
     GAMES.forEach((game) => {
       if (isSettled(game.key)) {
-        cells[game.key] = row.wins.includes(game.key) ? game.home : game.away;
+        cells[game.key] = cell(
+          game,
+          row.wins.includes(game.key) ? "home" : "away",
+        );
         return;
       }
       const side = game.key in row.picks ? row.picks[game.key] : row.open;
       // `null` rather than a key left off, which the sheet builder would append
       // after the columns every row does carry, and so relabel the games.
-      cells[game.key] = side == null ? null : game[side];
+      cells[game.key] = side == null ? null : cell(game, side);
     });
     cells.Pts = row.points;
     return cells;

--- a/.claude/skills/record-demo/scripts/scenarios/analysis-limit.js
+++ b/.claude/skills/record-demo/scripts/scenarios/analysis-limit.js
@@ -1,0 +1,144 @@
+import {
+  buildPicksWorkbook,
+  makeGame,
+  registerAppMocks,
+} from "../lib/mocks.js";
+
+const SEASON = 2024;
+const WEEK = 5;
+// One of the rows below, and the row the dialog is opened on.
+const SUBJECT = "Alice";
+
+/**
+ * Which branch to show. `headline` leaves eighteen games open, above
+ * `MAX_SEARCHED_GAMES`. `paths` leaves five, under it.
+ */
+const PHASE = process.env.ANALYSIS_PHASE ?? "headline";
+
+/** Four college then sixteen pro, the order a sheet's columns run in. */
+const GAMES = [
+  { key: "C1", league: "college", home: "UGA", away: "ALA" },
+  { key: "C2", league: "college", home: "OSU", away: "MICH" },
+  { key: "C3", league: "college", home: "TEX", away: "OU" },
+  { key: "C4", league: "college", home: "ORE", away: "WASH" },
+  { key: "P1", league: "pro", home: "KC", away: "BUF" },
+  { key: "P2", league: "pro", home: "SF", away: "DAL" },
+  { key: "P3", league: "pro", home: "PHI", away: "NYG" },
+  { key: "P4", league: "pro", home: "BAL", away: "CIN" },
+  { key: "P5", league: "pro", home: "DET", away: "GB" },
+  { key: "P6", league: "pro", home: "MIA", away: "NYJ" },
+  { key: "P7", league: "pro", home: "HOU", away: "IND" },
+  { key: "P8", league: "pro", home: "LAR", away: "SEA" },
+  { key: "P9", league: "pro", home: "TB", away: "ATL" },
+  { key: "P10", league: "pro", home: "MIN", away: "CHI" },
+  { key: "P11", league: "pro", home: "PIT", away: "CLE" },
+  { key: "P12", league: "pro", home: "DEN", away: "LAC" },
+  { key: "P13", league: "pro", home: "NO", away: "CAR" },
+  { key: "P14", league: "pro", home: "JAX", away: "TEN" },
+  { key: "P15", league: "pro", home: "WSH", away: "ARI" },
+  { key: "P16", league: "pro", home: "LV", away: "NE" },
+];
+
+/**
+ * `opposed` is open and picked both ways, which is what a route can turn on. Every
+ * other open game is picked the same way by everyone, so it moves the field
+ * together and decides nothing. `aliceWins` are the settled games Alice took, and
+ * Bob took the rest, which is what puts him ahead of her.
+ */
+const PHASES = {
+  headline: {
+    settled: ["C1", "C2"],
+    aliceWins: [],
+    opposed: ["C3", "C4", "P1"],
+  },
+  paths: {
+    settled: [
+      "C1",
+      "C2",
+      "C3",
+      "C4",
+      "P1",
+      "P2",
+      "P3",
+      "P4",
+      "P5",
+      "P6",
+      "P7",
+      "P8",
+      "P9",
+      "P10",
+      "P11",
+    ],
+    aliceWins: ["C1", "C2", "C3", "C4", "P1", "P2", "P3"],
+    opposed: ["P12", "P13", "P14", "P15", "P16"],
+  },
+};
+
+const shape = PHASES[PHASE];
+if (shape == null) {
+  throw new Error(`ANALYSIS_PHASE has to be headline or paths, not ${PHASE}`);
+}
+
+const isSettled = (key) => shape.settled.includes(key);
+const isOpposed = (key) => shape.opposed.includes(key);
+
+function rows() {
+  const pick = (game, who) => {
+    if (isSettled(game.key)) {
+      // Carol misses every settled game, so she trails without being knocked out.
+      if (who === "carol") return game.away;
+      const alice = shape.aliceWins.includes(game.key) ? "home" : "away";
+      const mine = who === "alice" ? alice : alice === "home" ? "away" : "home";
+      return game[mine];
+    }
+    // Carol shadows Alice through the open games, so she never bears on Alice's
+    // own routes.
+    if (isOpposed(game.key) && who === "bob") return game.away;
+    return game.home;
+  };
+  const row = (name, who, tiebreaker) => {
+    const cells = { Name: name };
+    GAMES.forEach((game) => {
+      cells[game.key] = pick(game, who);
+    });
+    cells.Pts = tiebreaker;
+    return cells;
+  };
+  return [
+    row("Alice", "alice", 45),
+    row("Bob", "bob", 48),
+    row("Carol", "carol", 41),
+  ];
+}
+
+/** The home side won every game that has been played. */
+function eventsFor(league) {
+  return {
+    events: GAMES.filter((game) => game.league === league).map((game) =>
+      isSettled(game.key)
+        ? makeGame(`${game.key}EVT`, game.home, game.away, 27, 20, "3")
+        : makeGame(`${game.key}EVT`, game.home, game.away, 0, 0, "1"),
+    ),
+  };
+}
+
+/** Opens Player Analysis on a player who is behind, and ends on the dialog. */
+export default async function run({ page, context, baseUrl }) {
+  await registerAppMocks(context, {
+    season: SEASON,
+    week: WEEK,
+    xlsxBuffer: buildPicksWorkbook(rows()),
+    events: () => eventsFor("pro"),
+    collegeEvents: () => eventsFor("college"),
+  });
+
+  await page.goto(`${baseUrl}/${SEASON}/${WEEK}/scoreboard`);
+  await page.getByRole("button", { name: new RegExp(SUBJECT) }).click();
+  await page.getByText("Player Analysis").waitFor({ timeout: 10000 });
+  // The answer replaces the bar that stands over the search while it runs.
+  await page
+    .locator(".analysis__body")
+    .first()
+    .waitFor({ state: "visible", timeout: 30000 });
+  await page.waitForTimeout(1200);
+}

--- a/src/components/playerAnalysis/AnalysisBody.tsx
+++ b/src/components/playerAnalysis/AnalysisBody.tsx
@@ -37,7 +37,7 @@ function Lead({ result }: { result: PathsResult }) {
       ? "Takes the week outright, whatever the MNF Points come to."
       : // Only worth saying where it asks more than the routes below already do.
         result.outrightAt != null && result.outrightAt > fewestWins(result)
-        ? `Winning ${plural(result.outrightAt, "game")} takes the week outright.`
+        ? `${result.player} wins the week outright with ${plural(result.outrightAt, "game win")}.`
         : null;
   // Nothing below to lead into, and the closing sentence there is the answer.
   if (outright == null && !hasGames(result)) return null;

--- a/src/components/playerAnalysis/AnalysisBody.tsx
+++ b/src/components/playerAnalysis/AnalysisBody.tsx
@@ -28,8 +28,8 @@ function fewestWins(result: PathsResult): number {
 
 /**
  * Winning the week on points alone leads, since it settles the tiebreaker before
- * the reader has to think about it. Where there is no such line the player is
- * named as standing instead, so the sections below never open on their own.
+ * the reader has to think about it. Where there is no such line the standing is
+ * given instead, so the sections below never open on their own.
  */
 function Lead({ result }: { result: PathsResult }) {
   const outright =
@@ -43,7 +43,7 @@ function Lead({ result }: { result: PathsResult }) {
   if (outright == null && !hasGames(result)) return null;
   return (
     <p className="analysis__line">
-      {outright ?? `${result.player} can still win the week.`}
+      {outright ?? "Can still win the week."}
       {/* Hands over to the sections under it, which ask for less. */}
       {hasGames(result) &&
         (outright != null ? " Otherwise:" : " What it takes:")}
@@ -86,11 +86,7 @@ export default function AnalysisBody({
   if (result.kind === "knockedOut") {
     // The explanation names who knocked them out and by how much, so it says they
     // cannot win on its own. Only a player without one needs telling.
-    return (
-      <Message
-        lines={[result.explanation ?? `${result.player} cannot win this week.`]}
-      />
-    );
+    return <Message lines={[result.explanation ?? "Cannot win this week."]} />;
   }
 
   if (result.kind === "clinched") {
@@ -100,8 +96,10 @@ export default function AnalysisBody({
     return (
       <Message
         lines={[
-          `${result.player} has won ${weekNumber != null ? `week ${weekNumber}` : "the week"}.`,
-          isEveryGameSettled ? undefined : "No other player can surpass them.",
+          `Won ${weekNumber != null ? `week ${weekNumber}` : "the week"}.`,
+          isEveryGameSettled
+            ? undefined
+            : "No other player can surpass this score.",
         ]}
       />
     );
@@ -112,7 +110,7 @@ export default function AnalysisBody({
       <>
         <Message
           lines={[
-            `${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`,
+            `Needs at least ${result.minimumWins} of ${result.remainingPickCount} remaining picks.`,
             result.needsMondayNight
               ? "That is only enough to tie, so the MNF Points tiebreaker would still decide it."
               : undefined,

--- a/src/components/playerAnalysis/AnalysisBody.tsx
+++ b/src/components/playerAnalysis/AnalysisBody.tsx
@@ -28,8 +28,8 @@ function fewestWins(result: PathsResult): number {
 
 /**
  * Winning the week on points alone leads, since it settles the tiebreaker before
- * the reader has to think about it. Where there is no such line the standing is
- * given instead, so the sections below never open on their own.
+ * the reader has to think about it. Where there is no such line the player is
+ * named as standing instead, so the sections below never open on their own.
  */
 function Lead({ result }: { result: PathsResult }) {
   const outright =
@@ -43,7 +43,7 @@ function Lead({ result }: { result: PathsResult }) {
   if (outright == null && !hasGames(result)) return null;
   return (
     <p className="analysis__line">
-      {outright ?? "Can still win the week."}
+      {outright ?? `${result.player} can still win the week.`}
       {/* Hands over to the sections under it, which ask for less. */}
       {hasGames(result) &&
         (outright != null ? " Otherwise:" : " What it takes:")}
@@ -86,7 +86,11 @@ export default function AnalysisBody({
   if (result.kind === "knockedOut") {
     // The explanation names who knocked them out and by how much, so it says they
     // cannot win on its own. Only a player without one needs telling.
-    return <Message lines={[result.explanation ?? "Cannot win this week."]} />;
+    return (
+      <Message
+        lines={[result.explanation ?? `${result.player} cannot win this week.`]}
+      />
+    );
   }
 
   if (result.kind === "clinched") {
@@ -96,10 +100,8 @@ export default function AnalysisBody({
     return (
       <Message
         lines={[
-          `Won ${weekNumber != null ? `week ${weekNumber}` : "the week"}.`,
-          isEveryGameSettled
-            ? undefined
-            : "No other player can surpass this score.",
+          `${result.player} has won ${weekNumber != null ? `week ${weekNumber}` : "the week"}.`,
+          isEveryGameSettled ? undefined : "No other player can surpass them.",
         ]}
       />
     );
@@ -110,7 +112,7 @@ export default function AnalysisBody({
       <>
         <Message
           lines={[
-            `Needs at least ${result.minimumWins} of ${result.remainingPickCount} remaining picks.`,
+            `${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`,
             result.needsMondayNight
               ? "That is only enough to tie, so the MNF Points tiebreaker would still decide it."
               : undefined,

--- a/src/components/playerAnalysis/AnalysisBody.tsx
+++ b/src/components/playerAnalysis/AnalysisBody.tsx
@@ -115,7 +115,8 @@ export default function AnalysisBody({
           ]}
         />
 
-        {/* The games the floor proves, which a week this size can still name. */}
+        {/* Every must-win game there is, or none: `provenMustWin` holds nothing
+            back, and answers empty where it can prove nothing. */}
         {result.mustWin.length > 0 && (
           <Section title="Must win">
             <Picks className="analysis__must-win" games={result.mustWin} />
@@ -124,7 +125,7 @@ export default function AnalysisBody({
 
         {/* Why there is nothing more below it, in the place the paths count theirs. */}
         <p className="analysis__note">
-          {`Detailed paths are calculated once ${MAX_SEARCHED_GAMES} games remain.`}
+          {`Detailed analysis is performed once ${MAX_SEARCHED_GAMES} games remain.`}
         </p>
       </>
     );

--- a/src/components/playerAnalysis/AnalysisBody.tsx
+++ b/src/components/playerAnalysis/AnalysisBody.tsx
@@ -110,7 +110,7 @@ export default function AnalysisBody({
           lines={[
             `${result.player} needs at least ${result.minimumWins} of their ${result.remainingPickCount} remaining picks.`,
             result.needsMondayNight
-              ? "That is only enough to draw level, so the MNF Points tiebreaker would still decide it."
+              ? "That is only enough to tie, so the MNF Points tiebreaker would still decide it."
               : undefined,
           ]}
         />
@@ -124,7 +124,7 @@ export default function AnalysisBody({
 
         {/* Why there is nothing more below it, in the place the paths count theirs. */}
         <p className="analysis__note">
-          {`Detailed paths are calculated once ${MAX_SEARCHED_GAMES} games are left.`}
+          {`Detailed paths are calculated once ${MAX_SEARCHED_GAMES} games remain.`}
         </p>
       </>
     );

--- a/src/components/playerAnalysis/AnalysisBody.tsx
+++ b/src/components/playerAnalysis/AnalysisBody.tsx
@@ -51,10 +51,16 @@ function Lead({ result }: { result: PathsResult }) {
   );
 }
 
-function NeedsHelp({ games }: { games: Array<UncontrolledGame> }) {
+function NeedsHelp({
+  games,
+  conjoined,
+}: {
+  games: Array<UncontrolledGame>;
+  conjoined?: boolean;
+}) {
   if (games.length === 0) return null;
   return (
-    <Section title="Out of your hands">
+    <Section conjoined={conjoined} title="Out of your hands">
       <ul className="analysis__help">
         {games.map((game) => (
           <li key={game.label} className="analysis__line">
@@ -131,11 +137,28 @@ export default function AnalysisBody({
     );
   }
 
+  const hasMustWin = result.mustWin.length > 0;
+  const hasWaysThrough =
+    result.pool != null || (result.routes?.length ?? 0) > 0;
+  // A settled total says the games above decide the week, which is the opposite of
+  // one more thing to do. Only a range is a condition of its own.
+  const asksMondayNight = result.mondayNight?.kind === "range";
+
+  // A win needs every block below, and stacked they read as separate facts. So
+  // each block that has one above it opens with `AND`. The first never does.
+  const isConjoined = {
+    waysThrough: hasMustWin,
+    help: hasMustWin || hasWaysThrough,
+    mondayNight:
+      asksMondayNight &&
+      (hasMustWin || hasWaysThrough || result.needsHelp.length > 0),
+  };
+
   return (
     <>
       <Lead result={result} />
 
-      {result.mustWin.length > 0 && (
+      {hasMustWin && (
         <Section title="Must win">
           <Picks className="analysis__must-win" games={result.mustWin} />
         </Section>
@@ -143,7 +166,8 @@ export default function AnalysisBody({
 
       {result.pool && (
         <Section
-          title={`${result.mustWin.length > 0 ? "Then any" : "Any"} ${result.pool.choose} of these`}
+          conjoined={isConjoined.waysThrough}
+          title={`Any ${result.pool.choose} of these`}
         >
           <Picks games={result.pool.games} />
         </Section>
@@ -151,7 +175,8 @@ export default function AnalysisBody({
 
       {result.routes != null && result.routes.length > 0 && (
         <AnalysisRoutes
-          title={result.mustWin.length > 0 ? "Then one of" : "One of"}
+          conjoined={isConjoined.waysThrough}
+          title="One of"
           routes={result.routes}
           hiddenCount={result.hiddenRouteCount}
           showMondayNight={result.mondayNight == null}
@@ -166,8 +191,11 @@ export default function AnalysisBody({
         </p>
       )}
 
-      <NeedsHelp games={result.needsHelp} />
-      <MondayNight outlook={result.mondayNight} />
+      <NeedsHelp conjoined={isConjoined.help} games={result.needsHelp} />
+      <MondayNight
+        conjoined={isConjoined.mondayNight}
+        outlook={result.mondayNight}
+      />
     </>
   );
 }

--- a/src/components/playerAnalysis/AnalysisBody.tsx
+++ b/src/components/playerAnalysis/AnalysisBody.tsx
@@ -37,7 +37,7 @@ function Lead({ result }: { result: PathsResult }) {
       ? "Takes the week outright, whatever the MNF Points come to."
       : // Only worth saying where it asks more than the routes below already do.
         result.outrightAt != null && result.outrightAt > fewestWins(result)
-        ? `Winning ${plural(result.outrightAt, "game")} takes it outright.`
+        ? `Winning ${plural(result.outrightAt, "game")} takes the week outright.`
         : null;
   // Nothing below to lead into, and the closing sentence there is the answer.
   if (outright == null && !hasGames(result)) return null;

--- a/src/components/playerAnalysis/AnalysisBody.tsx
+++ b/src/components/playerAnalysis/AnalysisBody.tsx
@@ -1,5 +1,6 @@
 import { PlayerAnalysis, UncontrolledGame } from "../../types/PlayerAnalysis";
 import plural from "../../utils/plural";
+import { MAX_SEARCHED_GAMES } from "../../utils/scoring/getPlayerAnalysis";
 import { Message, NAMES, Picks, Section } from "./analysisParts";
 import { MondayNight } from "./mondayNight";
 import AnalysisRoutes from "./AnalysisRoutes";
@@ -113,9 +114,17 @@ export default function AnalysisBody({
               : undefined,
           ]}
         />
-        {/* Why there is nothing below it, in the place the paths count theirs. */}
+
+        {/* The games the floor proves, which a week this size can still name. */}
+        {result.mustWin.length > 0 && (
+          <Section title="Must win">
+            <Picks className="analysis__must-win" games={result.mustWin} />
+          </Section>
+        )}
+
+        {/* Why there is nothing more below it, in the place the paths count theirs. */}
         <p className="analysis__note">
-          Detailed paths are worked out once ten games are left.
+          {`Every path to victory is worked out once ${MAX_SEARCHED_GAMES} games are left.`}
         </p>
       </>
     );

--- a/src/components/playerAnalysis/AnalysisBody.tsx
+++ b/src/components/playerAnalysis/AnalysisBody.tsx
@@ -124,7 +124,7 @@ export default function AnalysisBody({
 
         {/* Why there is nothing more below it, in the place the paths count theirs. */}
         <p className="analysis__note">
-          {`Every path to victory is worked out once ${MAX_SEARCHED_GAMES} games are left.`}
+          {`Detailed paths are calculated once ${MAX_SEARCHED_GAMES} games are left.`}
         </p>
       </>
     );

--- a/src/components/playerAnalysis/AnalysisBody.tsx
+++ b/src/components/playerAnalysis/AnalysisBody.tsx
@@ -43,7 +43,7 @@ function Lead({ result }: { result: PathsResult }) {
   if (outright == null && !hasGames(result)) return null;
   return (
     <p className="analysis__line">
-      {outright ?? `${result.player} is still live to win the week.`}
+      {outright ?? `${result.player} can still win the week.`}
       {/* Hands over to the sections under it, which ask for less. */}
       {hasGames(result) &&
         (outright != null ? " Otherwise:" : " What it takes:")}
@@ -101,9 +101,7 @@ export default function AnalysisBody({
       <Message
         lines={[
           `${result.player} has won ${weekNumber != null ? `week ${weekNumber}` : "the week"}.`,
-          isEveryGameSettled
-            ? undefined
-            : "Nothing still to be played can take it away.",
+          isEveryGameSettled ? undefined : "No other player can surpass them.",
         ]}
       />
     );
@@ -167,7 +165,7 @@ export default function AnalysisBody({
       {result.pool && (
         <Section
           conjoined={isConjoined.waysThrough}
-          title={`Any ${result.pool.choose} of these`}
+          title={`Any ${result.pool.choose} of`}
         >
           <Picks games={result.pool.games} />
         </Section>

--- a/src/components/playerAnalysis/AnalysisRoutes.tsx
+++ b/src/components/playerAnalysis/AnalysisRoutes.tsx
@@ -12,6 +12,7 @@ const ROUTES_SHOWN_AT_FIRST = 4;
 /** The alternatives, fewest games first, with the long tail folded away. */
 export default function AnalysisRoutes({
   title,
+  conjoined,
   routes,
   hiddenCount,
   // Off where every route asks the same of the tiebreaker, which the section
@@ -19,6 +20,7 @@ export default function AnalysisRoutes({
   showMondayNight,
 }: {
   title: string;
+  conjoined?: boolean;
   routes: Array<VictoryRoute>;
   hiddenCount: number;
   showMondayNight: boolean;
@@ -27,7 +29,7 @@ export default function AnalysisRoutes({
   const folded = routes.length - ROUTES_SHOWN_AT_FIRST;
   const shown = isExpanded ? routes : routes.slice(0, ROUTES_SHOWN_AT_FIRST);
   return (
-    <Section title={title}>
+    <Section conjoined={conjoined} title={title}>
       <ol className="analysis__routes">
         {shown.map((route) => (
           <li

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -41,18 +41,6 @@
   @include stacked(var(--rak-space-2));
 }
 
-// The word that holds two blocks together, set like the `AND` inside a route line
-// and inset to the picks' own text. It opens the block under it rather than
-// sitting between the two, so it reads as part of what it asks for.
-.analysis__and {
-  margin: 0;
-  padding-inline-start: var(--rak-pick-inset);
-  color: var(--rak-text-tertiary);
-  font-family: var(--rak-font-mono);
-  font-size: var(--rak-text-sm);
-  font-weight: var(--rak-weight-bold);
-}
-
 // A win and a knockout, in the hues the tables and the search already mark those
 // players with.
 .analysis__headline {
@@ -125,6 +113,14 @@
 
 .analysis__pick-team {
   color: var(--rak-text);
+}
+
+// The one word saying a reader needs both sides of it, over a title and inside a
+// route alike. Set in the blue the app points with, so it carries what it says
+// against the tertiary ink of the labels it sits among. After those, since it
+// overrules the color they set.
+.analysis__and {
+  color: var(--rak-attention-ink);
 }
 
 .analysis__routes {

--- a/src/components/playerAnalysis/AnalysisSummary.scss
+++ b/src/components/playerAnalysis/AnalysisSummary.scss
@@ -41,6 +41,18 @@
   @include stacked(var(--rak-space-2));
 }
 
+// The word that holds two blocks together, set like the `AND` inside a route line
+// and inset to the picks' own text. It opens the block under it rather than
+// sitting between the two, so it reads as part of what it asks for.
+.analysis__and {
+  margin: 0;
+  padding-inline-start: var(--rak-pick-inset);
+  color: var(--rak-text-tertiary);
+  font-family: var(--rak-font-mono);
+  font-size: var(--rak-text-sm);
+  font-weight: var(--rak-weight-bold);
+}
+
 // A win and a knockout, in the hues the tables and the search already mark those
 // players with.
 .analysis__headline {

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -20,6 +20,12 @@ function under(title: string): Array<string> {
     .map((item) => item.textContent ?? "");
 }
 
+/** Whether the block a heading opens carries the word that conjoins it. */
+function isConjoined(title: string): boolean {
+  const heading = screen.getByRole("heading", { name: title });
+  return heading.previousElementSibling?.textContent === "AND";
+}
+
 /** The one tiebreaker range the cases below need: beat Rak on 45 points. */
 const RAK_BY_45 = {
   kind: "range" as const,
@@ -149,11 +155,38 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(under("Must win")).toEqual(["C4UGA -7"]);
-    expect(under("Then any 2 of these")).toEqual([
+    expect(under("Any 2 of these")).toEqual([
       "P2KC -3",
       "P9BUF +1",
       "P11SF -6",
     ]);
+  });
+
+  it("conjoins every block a win needs, and opens on the first", () => {
+    const result: PlayerAnalysis = {
+      ...base,
+      mustWin: [{ label: "C4", pick: "UGA -7" }],
+      pool: { choose: 2, games: [{ label: "P2", pick: "KC -3" }] },
+      needsHelp: [{ label: "P7", needsToMiss: ["Rak"] }],
+      mondayNight: RAK_BY_45,
+    };
+    render(<AnalysisSummary result={result} />);
+
+    expect(isConjoined("Must win")).toBe(false);
+    expect(isConjoined("Any 2 of these")).toBe(true);
+    expect(isConjoined("Out of your hands")).toBe(true);
+    expect(isConjoined("MNF Points")).toBe(true);
+  });
+
+  it("leaves a settled tiebreaker unconjoined, since it asks for nothing", () => {
+    const result: PlayerAnalysis = {
+      ...base,
+      mustWin: [{ label: "C4", pick: "UGA -7" }],
+      mondayNight: { kind: "settled" },
+    };
+    render(<AnalysisSummary result={result} />);
+
+    expect(isConjoined("MNF Points")).toBe(false);
   });
 
   it("says something for a player the games can no longer separate", () => {

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -111,7 +111,7 @@ describe("AnalysisSummary", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/MNF Points tiebreaker/)).toBeInTheDocument();
     const why = screen.getByText(
-      `Detailed paths are calculated once ${MAX_SEARCHED_GAMES} games remain.`,
+      `Detailed analysis is performed once ${MAX_SEARCHED_GAMES} games remain.`,
     );
     expect(why).toBe(
       document.querySelector(".analysis__body")?.lastElementChild,

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -111,7 +111,7 @@ describe("AnalysisSummary", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/MNF Points tiebreaker/)).toBeInTheDocument();
     const why = screen.getByText(
-      `Every path to victory is worked out once ${MAX_SEARCHED_GAMES} games are left.`,
+      `Detailed paths are calculated once ${MAX_SEARCHED_GAMES} games are left.`,
     );
     expect(why).toBe(
       document.querySelector(".analysis__body")?.lastElementChild,

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -59,14 +59,14 @@ describe("AnalysisSummary", () => {
     expect(
       screen.getByText("Knocked out on Total Score by Alice."),
     ).toBeInTheDocument();
-    expect(screen.queryByText("Bob cannot win this week.")).toBeNull();
+    expect(screen.queryByText("Cannot win this week.")).toBeNull();
   });
 
   it("tells a knocked out player carrying no reason that they cannot win", () => {
     const result: PlayerAnalysis = { kind: "knockedOut", player: "Bob" };
     render(<AnalysisSummary result={result} />);
 
-    expect(screen.getByText("Bob cannot win this week.")).toBeInTheDocument();
+    expect(screen.getByText("Cannot win this week.")).toBeInTheDocument();
   });
 
   it("says nothing left can undo a clinch with games still to play", () => {
@@ -78,9 +78,9 @@ describe("AnalysisSummary", () => {
     );
 
     // The header calls Alice the winner without naming the week, so this does.
-    expect(screen.getByText("Alice has won week 12.")).toBeInTheDocument();
+    expect(screen.getByText("Won week 12.")).toBeInTheDocument();
     expect(
-      screen.getByText("No other player can surpass them."),
+      screen.getByText("No other player can surpass this score."),
     ).toBeInTheDocument();
   });
 
@@ -93,7 +93,7 @@ describe("AnalysisSummary", () => {
       />,
     );
 
-    expect(screen.getByText("Alice has won week 12.")).toBeInTheDocument();
+    expect(screen.getByText("Won week 12.")).toBeInTheDocument();
     // Nothing is still to be played, so saying it cannot be undone adds nothing.
     expect(
       screen.queryByText(/Nothing still to be played/),
@@ -112,7 +112,7 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(
-      screen.getByText("Alice needs at least 6 of their 13 remaining picks."),
+      screen.getByText("Needs at least 6 of 13 remaining picks."),
     ).toBeInTheDocument();
     expect(screen.getByText(/MNF Points tiebreaker/)).toBeInTheDocument();
     const why = screen.getByText(
@@ -265,7 +265,7 @@ describe("AnalysisSummary", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("names the player standing where nothing takes the week outright", () => {
+  it("gives the standing where nothing takes the week outright", () => {
     const result: PlayerAnalysis = {
       ...base,
       mustWin: [{ label: "P1", pick: "KC -3" }],
@@ -274,7 +274,7 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(
-      screen.getByText("Alice can still win the week. What it takes:"),
+      screen.getByText("Can still win the week. What it takes:"),
     ).toBeInTheDocument();
   });
 

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -231,7 +231,9 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(
-      screen.getByText("Winning 3 games takes the week outright. Otherwise:"),
+      screen.getByText(
+        "Alice wins the week outright with 3 game wins. Otherwise:",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -261,7 +263,7 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(
-      screen.queryByText(/Winning \d+ games? takes the week outright/),
+      screen.queryByText(/wins the week outright with \d+ game wins?/),
     ).not.toBeInTheDocument();
   });
 

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -129,8 +129,7 @@ describe("AnalysisSummary", () => {
     };
     render(<AnalysisSummary result={result} />);
 
-    expect(screen.getByText("Must win")).toBeInTheDocument();
-    expect(screen.getByText("KC -7")).toBeInTheDocument();
+    expect(under("Must win")).toEqual(["P3KC -7"]);
   });
 
   it("lists the must-win games and the pool behind them", () => {

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -12,18 +12,21 @@ function routesOf(count: number): Array<VictoryRoute> {
   }));
 }
 
+/** The heading a block opens with, whether or not `And` conjoins it. */
+function blockHeading(title: string): HTMLElement {
+  return screen.getByRole("heading", { name: new RegExp(`^(And )?${title}$`) });
+}
+
 /** The picks under a heading, as the chips read on screen. */
 function under(title: string): Array<string> {
-  const heading = screen.getByRole("heading", { name: title });
-  return within(heading.parentElement as HTMLElement)
+  return within(blockHeading(title).parentElement as HTMLElement)
     .getAllByRole("listitem")
     .map((item) => item.textContent ?? "");
 }
 
-/** Whether the block a heading opens carries the word that conjoins it. */
+/** Whether a block's heading carries the word that conjoins it to the one above. */
 function isConjoined(title: string): boolean {
-  const heading = screen.getByRole("heading", { name: title });
-  return heading.previousElementSibling?.textContent === "AND";
+  return blockHeading(title).firstElementChild?.textContent === "And";
 }
 
 /** The one tiebreaker range the cases below need: beat Rak on 45 points. */
@@ -217,7 +220,7 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(
-      screen.getByText("38 ≤ MNF Points ≤ 44 to beat Rak and Bill."),
+      screen.getByText("38 ≤ Points ≤ 44 to beat Rak and Bill."),
     ).toBeInTheDocument();
   });
 
@@ -229,9 +232,7 @@ describe("AnalysisSummary", () => {
     };
     render(<AnalysisSummary result={result} />);
 
-    expect(
-      screen.getByText("MNF Points ≤ 45 to beat Rak."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Points ≤ 45 to beat Rak.")).toBeInTheDocument();
   });
 
   it("says what it takes to win without the tiebreaker at all", () => {
@@ -397,9 +398,7 @@ describe("AnalysisSummary", () => {
       "P1KC -3",
       "P2BUF -1",
     ]);
-    expect(
-      screen.getByText("MNF Points ≤ 32 to beat Rak."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Points ≤ 32 to beat Rak.")).toBeInTheDocument();
   });
 
   it("holds four routes open and folds the rest behind a button", () => {

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -59,14 +59,14 @@ describe("AnalysisSummary", () => {
     expect(
       screen.getByText("Knocked out on Total Score by Alice."),
     ).toBeInTheDocument();
-    expect(screen.queryByText("Cannot win this week.")).toBeNull();
+    expect(screen.queryByText("Bob cannot win this week.")).toBeNull();
   });
 
   it("tells a knocked out player carrying no reason that they cannot win", () => {
     const result: PlayerAnalysis = { kind: "knockedOut", player: "Bob" };
     render(<AnalysisSummary result={result} />);
 
-    expect(screen.getByText("Cannot win this week.")).toBeInTheDocument();
+    expect(screen.getByText("Bob cannot win this week.")).toBeInTheDocument();
   });
 
   it("says nothing left can undo a clinch with games still to play", () => {
@@ -78,9 +78,9 @@ describe("AnalysisSummary", () => {
     );
 
     // The header calls Alice the winner without naming the week, so this does.
-    expect(screen.getByText("Won week 12.")).toBeInTheDocument();
+    expect(screen.getByText("Alice has won week 12.")).toBeInTheDocument();
     expect(
-      screen.getByText("No other player can surpass this score."),
+      screen.getByText("No other player can surpass them."),
     ).toBeInTheDocument();
   });
 
@@ -93,7 +93,7 @@ describe("AnalysisSummary", () => {
       />,
     );
 
-    expect(screen.getByText("Won week 12.")).toBeInTheDocument();
+    expect(screen.getByText("Alice has won week 12.")).toBeInTheDocument();
     // Nothing is still to be played, so saying it cannot be undone adds nothing.
     expect(
       screen.queryByText(/Nothing still to be played/),
@@ -112,7 +112,7 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(
-      screen.getByText("Needs at least 6 of 13 remaining picks."),
+      screen.getByText("Alice needs at least 6 of their 13 remaining picks."),
     ).toBeInTheDocument();
     expect(screen.getByText(/MNF Points tiebreaker/)).toBeInTheDocument();
     const why = screen.getByText(
@@ -265,7 +265,7 @@ describe("AnalysisSummary", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("gives the standing where nothing takes the week outright", () => {
+  it("names the player standing where nothing takes the week outright", () => {
     const result: PlayerAnalysis = {
       ...base,
       mustWin: [{ label: "P1", pick: "KC -3" }],
@@ -274,7 +274,7 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(
-      screen.getByText("Can still win the week. What it takes:"),
+      screen.getByText("Alice can still win the week. What it takes:"),
     ).toBeInTheDocument();
   });
 

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -231,7 +231,7 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(
-      screen.getByText("Winning 3 games takes it outright. Otherwise:"),
+      screen.getByText("Winning 3 games takes the week outright. Otherwise:"),
     ).toBeInTheDocument();
   });
 
@@ -260,7 +260,9 @@ describe("AnalysisSummary", () => {
     };
     render(<AnalysisSummary result={result} />);
 
-    expect(screen.queryByText(/takes it outright/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Winning \d+ games? takes the week outright/),
+    ).not.toBeInTheDocument();
   });
 
   it("names the player standing where nothing takes the week outright", () => {

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PlayerAnalysis, VictoryRoute } from "../../types/PlayerAnalysis";
+import { MAX_SEARCHED_GAMES } from "../../utils/scoring/getPlayerAnalysis";
 import AnalysisSummary from "./AnalysisSummary";
 
 /** Routes of one game each, all different, so only their number matters. */
@@ -101,6 +102,7 @@ describe("AnalysisSummary", () => {
       remainingPickCount: 13,
       minimumWins: 6,
       needsMondayNight: true,
+      mustWin: [],
     };
     render(<AnalysisSummary result={result} />);
 
@@ -109,11 +111,26 @@ describe("AnalysisSummary", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/MNF Points tiebreaker/)).toBeInTheDocument();
     const why = screen.getByText(
-      "Detailed paths are worked out once ten games are left.",
+      `Every path to victory is worked out once ${MAX_SEARCHED_GAMES} games are left.`,
     );
     expect(why).toBe(
       document.querySelector(".analysis__body")?.lastElementChild,
     );
+  });
+
+  it("names the must-win games a week too big to search can prove", () => {
+    const result: PlayerAnalysis = {
+      kind: "headline",
+      player: "Alice",
+      remainingPickCount: 18,
+      minimumWins: 18,
+      needsMondayNight: false,
+      mustWin: [{ label: "P3", pick: "KC -7" }],
+    };
+    render(<AnalysisSummary result={result} />);
+
+    expect(screen.getByText("Must win")).toBeInTheDocument();
+    expect(screen.getByText("KC -7")).toBeInTheDocument();
   });
 
   it("lists the must-win games and the pool behind them", () => {

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -29,12 +29,8 @@ function isConjoined(title: string): boolean {
   return blockHeading(title).firstElementChild?.textContent === "And";
 }
 
-/** The one tiebreaker range the cases below need: beat Rak on 45 points. */
-const RAK_BY_45 = {
-  kind: "range" as const,
-  max: 45,
-  rivals: ["Rak"],
-};
+/** The one tiebreaker range the cases below need: a week won at 45 or under. */
+const RAK_BY_45 = { kind: "range" as const, max: 45 };
 
 const base = {
   kind: "paths" as const,
@@ -84,7 +80,7 @@ describe("AnalysisSummary", () => {
     // The header calls Alice the winner without naming the week, so this does.
     expect(screen.getByText("Alice has won week 12.")).toBeInTheDocument();
     expect(
-      screen.getByText("Nothing still to be played can take it away."),
+      screen.getByText("No other player can surpass them."),
     ).toBeInTheDocument();
   });
 
@@ -158,11 +154,7 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(under("Must win")).toEqual(["C4UGA -7"]);
-    expect(under("Any 2 of these")).toEqual([
-      "P2KC -3",
-      "P9BUF +1",
-      "P11SF -6",
-    ]);
+    expect(under("Any 2 of")).toEqual(["P2KC -3", "P9BUF +1", "P11SF -6"]);
   });
 
   it("conjoins every block a win needs, and opens on the first", () => {
@@ -176,9 +168,9 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(isConjoined("Must win")).toBe(false);
-    expect(isConjoined("Any 2 of these")).toBe(true);
+    expect(isConjoined("Any 2 of")).toBe(true);
     expect(isConjoined("Out of your hands")).toBe(true);
-    expect(isConjoined("MNF Points")).toBe(true);
+    expect(isConjoined("MNF Points ≤ 45")).toBe(true);
   });
 
   it("leaves a settled tiebreaker unconjoined, since it asks for nothing", () => {
@@ -206,22 +198,16 @@ describe("AnalysisSummary", () => {
     ).toBeInTheDocument();
   });
 
-  it("writes a bounded Monday night range as a sentence", () => {
+  it("sets a bounded Monday night range as the block's whole title", () => {
     const result: PlayerAnalysis = {
       ...base,
       mustWin: [{ label: "P1", pick: "KC -3" }],
-      mondayNight: {
-        kind: "range",
-        min: 38,
-        max: 44,
-        rivals: ["Rak", "Bill"],
-      },
+      mondayNight: { kind: "range", min: 38, max: 44 },
     };
     render(<AnalysisSummary result={result} />);
 
-    expect(
-      screen.getByText("38 ≤ Points ≤ 44 to beat Rak and Bill."),
-    ).toBeInTheDocument();
+    const heading = blockHeading("38 ≤ MNF Points ≤ 44");
+    expect(heading.parentElement?.childElementCount).toBe(1);
   });
 
   it("writes an open-ended range from the end it is bounded on", () => {
@@ -232,7 +218,7 @@ describe("AnalysisSummary", () => {
     };
     render(<AnalysisSummary result={result} />);
 
-    expect(screen.getByText("Points ≤ 45 to beat Rak.")).toBeInTheDocument();
+    expect(blockHeading("MNF Points ≤ 45")).toBeInTheDocument();
   });
 
   it("says what it takes to win without the tiebreaker at all", () => {
@@ -286,7 +272,7 @@ describe("AnalysisSummary", () => {
     render(<AnalysisSummary result={result} />);
 
     expect(
-      screen.getByText("Alice is still live to win the week. What it takes:"),
+      screen.getByText("Alice can still win the week. What it takes:"),
     ).toBeInTheDocument();
   });
 
@@ -317,7 +303,7 @@ describe("AnalysisSummary", () => {
             { label: "P2", pick: "BUF -1" },
             { label: "P3", pick: "SF -6" },
           ],
-          mondayNight: { kind: "range", max: 32, rivals: ["Rak"] },
+          mondayNight: { kind: "range", max: 32 },
         },
       ],
     };
@@ -328,7 +314,7 @@ describe("AnalysisSummary", () => {
     const routes = [...document.querySelectorAll(".analysis__route")];
     expect(routes.map((route) => route.textContent)).toEqual([
       "P1KC -3",
-      "P2BUF -1P3SF -6ANDMNF Points ≤ 32TO BEAT Rak",
+      "P2BUF -1P3SF -6ANDMNF Points ≤ 32",
     ]);
   });
 
@@ -364,25 +350,8 @@ describe("AnalysisSummary", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
-  it("names every player a route's total has to beat", () => {
-    const result: PlayerAnalysis = {
-      ...base,
-      routes: [
-        {
-          games: [{ label: "P1", pick: "KC -3" }],
-          mondayNight: { kind: "range", min: 30, rivals: ["Rak", "Bill"] },
-        },
-      ],
-    };
-    render(<AnalysisSummary result={result} />);
-
-    expect(document.querySelector(".analysis__route")?.textContent).toBe(
-      "P1KC -3ANDMNF Points ≥ 30TO BEAT Rak, Bill",
-    );
-  });
-
   it("states a total every route shares once, not on each of them", () => {
-    const shared = { kind: "range" as const, max: 32, rivals: ["Rak"] };
+    const shared = { kind: "range" as const, max: 32 };
     const result: PlayerAnalysis = {
       ...base,
       routes: [
@@ -398,7 +367,7 @@ describe("AnalysisSummary", () => {
       "P1KC -3",
       "P2BUF -1",
     ]);
-    expect(screen.getByText("Points ≤ 32 to beat Rak.")).toBeInTheDocument();
+    expect(blockHeading("MNF Points ≤ 32")).toBeInTheDocument();
   });
 
   it("holds four routes open and folds the rest behind a button", () => {

--- a/src/components/playerAnalysis/AnalysisSummary.test.tsx
+++ b/src/components/playerAnalysis/AnalysisSummary.test.tsx
@@ -111,7 +111,7 @@ describe("AnalysisSummary", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/MNF Points tiebreaker/)).toBeInTheDocument();
     const why = screen.getByText(
-      `Detailed paths are calculated once ${MAX_SEARCHED_GAMES} games are left.`,
+      `Detailed paths are calculated once ${MAX_SEARCHED_GAMES} games remain.`,
     );
     expect(why).toBe(
       document.querySelector(".analysis__body")?.lastElementChild,

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -12,7 +12,7 @@ their name in either table.
   is done, for both halves.
 - `analysisParts`: `Section`, `Picks`, `Message`, the pieces with no analysis
   logic of their own, shared by the three files below.
-- `mondayNight`: the MNF Points tiebreaker, its sentence and its route line.
+- `mondayNight`: the MNF Points tiebreaker, its own block and its route line.
 - `AnalysisRoutes`: the paths list, folded until asked to show more.
 - `AnalysisBody`: the switch on `PlayerAnalysis.kind` that picks what to render.
 - `Standing`: where the picked player stands, read off the scores, so it shows

--- a/src/components/playerAnalysis/Standing.test.tsx
+++ b/src/components/playerAnalysis/Standing.test.tsx
@@ -42,13 +42,13 @@ describe("Standing", () => {
   it("counts the player picked back to the leader", () => {
     render(<Standing scores={scores} playerName="Alice" />);
 
-    expect(standingText()).toBe("2 points behind Rak · 1 game still to play");
+    expect(standingText()).toBe("2 points behind Rak · 1 game remaining");
   });
 
   it("ties the player picked to the lead where they hold it", () => {
     render(<Standing scores={scores} playerName="Rak" />);
 
-    expect(standingText()).toBe("Tied for the lead · 1 game still to play");
+    expect(standingText()).toBe("Tied for the lead · 1 game remaining");
   });
 
   /** The same week with nothing left open, which is a week that has a winner. */
@@ -114,7 +114,7 @@ describe("Standing", () => {
       />,
     );
 
-    expect(standingText()).toBe("Winner · 1 game still to play");
+    expect(standingText()).toBe("Winner · 1 game remaining");
   });
 
   it("ties a clinched player for the win where the top is shared", () => {
@@ -129,7 +129,7 @@ describe("Standing", () => {
       />,
     );
 
-    expect(standingText()).toBe("Tied for the win · 1 game still to play");
+    expect(standingText()).toBe("Tied for the win · 1 game remaining");
   });
 
   it("ignores a clinch that answers for a different player", () => {
@@ -141,7 +141,7 @@ describe("Standing", () => {
       />,
     );
 
-    expect(standingText()).toBe("Tied for the lead · 1 game still to play");
+    expect(standingText()).toBe("Tied for the lead · 1 game remaining");
   });
 
   /** The same week with one player out of it. */
@@ -160,7 +160,7 @@ describe("Standing", () => {
       <Standing scores={knockedOut(scores, "Alice")} playerName="Alice" />,
     );
 
-    expect(standingText()).toBe("Knocked out · 1 game still to play");
+    expect(standingText()).toBe("Knocked out · 1 game remaining");
   });
 
   it("colors a win and a knockout, and leaves an open standing plain", () => {
@@ -244,6 +244,6 @@ describe("Standing", () => {
     };
     render(<Standing scores={fresh} playerName="Rak" />);
 
-    expect(standingText()).toBe("No finished games · 2 games still to play");
+    expect(standingText()).toBe("No finished games · 2 games remaining");
   });
 });

--- a/src/components/playerAnalysis/Standing.tsx
+++ b/src/components/playerAnalysis/Standing.tsx
@@ -110,7 +110,7 @@ export default function Standing({
       <span className={`analysis__headline ${tone ?? ""}`}>{text}</span>
       {" · "}
       {remaining > 0
-        ? `${plural(remaining, "game")} still to play`
+        ? `${plural(remaining, "game")} remaining`
         : unscoreable > 0
           ? `${plural(unscoreable, "game")} could not be scored`
           : "Week complete"}

--- a/src/components/playerAnalysis/analysisParts.tsx
+++ b/src/components/playerAnalysis/analysisParts.tsx
@@ -14,7 +14,8 @@ export function Section({
 }: {
   title: string;
   conjoined?: boolean;
-  children: ReactNode;
+  // Absent where the title says the whole of what the block asks for.
+  children?: ReactNode;
 }) {
   return (
     <section className="analysis__section">

--- a/src/components/playerAnalysis/analysisParts.tsx
+++ b/src/components/playerAnalysis/analysisParts.tsx
@@ -7,7 +7,8 @@ export const NAMES = new Intl.ListFormat("en-US");
 export function Section({
   title,
   // On where a block above this one is needed too. A gap between two blocks does
-  // not say that, and `AND` is what makes the two read as one condition.
+  // not say that, and `And` on the title is what makes the two read as one
+  // condition.
   conjoined,
   children,
 }: {
@@ -17,8 +18,11 @@ export function Section({
 }) {
   return (
     <section className="analysis__section">
-      {conjoined && <p className="analysis__and">AND</p>}
-      <h3 className="analysis__section-title">{title}</h3>
+      {/* In the title rather than over it, which costs no height, and read out
+          with it, since a reader hearing the blocks needs the word too. */}
+      <h3 className="analysis__section-title">
+        {conjoined && <span className="analysis__and">And</span>} {title}
+      </h3>
       {children}
     </section>
   );

--- a/src/components/playerAnalysis/analysisParts.tsx
+++ b/src/components/playerAnalysis/analysisParts.tsx
@@ -6,13 +6,18 @@ export const NAMES = new Intl.ListFormat("en-US");
 
 export function Section({
   title,
+  // On where a block above this one is needed too. A gap between two blocks does
+  // not say that, and `AND` is what makes the two read as one condition.
+  conjoined,
   children,
 }: {
   title: string;
+  conjoined?: boolean;
   children: ReactNode;
 }) {
   return (
     <section className="analysis__section">
+      {conjoined && <p className="analysis__and">AND</p>}
       <h3 className="analysis__section-title">{title}</h3>
       {children}
     </section>

--- a/src/components/playerAnalysis/mondayNight.tsx
+++ b/src/components/playerAnalysis/mondayNight.tsx
@@ -47,10 +47,16 @@ export function RouteMondayNight({ outlook }: { outlook: MondayNightRange }) {
   );
 }
 
-export function MondayNight({ outlook }: { outlook?: MondayNightOutlook }) {
+export function MondayNight({
+  outlook,
+  conjoined,
+}: {
+  outlook?: MondayNightOutlook;
+  conjoined?: boolean;
+}) {
   if (outlook == null || outlook.kind === "notNeeded") return null;
   return (
-    <Section title="MNF Points">
+    <Section conjoined={conjoined} title="MNF Points">
       <p className="analysis__line">{mondayNightSentence(outlook)}</p>
     </Section>
   );

--- a/src/components/playerAnalysis/mondayNight.tsx
+++ b/src/components/playerAnalysis/mondayNight.tsx
@@ -9,19 +9,28 @@ type DecidingOutlook = Exclude<MondayNightOutlook, { kind: "notNeeded" }>;
 /** The one outlook a route of its own carries, which is a total still to come. */
 type MondayNightRange = Extract<MondayNightOutlook, { kind: "range" }>;
 
-/** The MNF Points that win, named the way the scoreboard column is. */
-function mondayNightPoints({ min, max }: MondayNightRange): string {
+/**
+ * The totals that win, as a comparison. `term` names the scoreboard column, in
+ * full only where nothing beside the line already names it.
+ */
+function mondayNightPoints(
+  { min, max }: MondayNightRange,
+  term: string,
+): string {
   if (min != null && max != null) {
-    return min === max ? `MNF Points = ${min}` : `${min} ≤ MNF Points ≤ ${max}`;
+    return min === max ? `${term} = ${min}` : `${min} ≤ ${term} ≤ ${max}`;
   }
-  return min != null ? `MNF Points ≥ ${min}` : `MNF Points ≤ ${max}`;
+  return min != null ? `${term} ≥ ${min}` : `${term} ≤ ${max}`;
 }
 
 function mondayNightSentence(outlook: DecidingOutlook): string {
   if (outlook.kind === "settled") {
     return "MNF Points are already final, so the games above settle it.";
   }
-  return `${mondayNightPoints(outlook)} to beat ${NAMES.format(outlook.rivals)}.`;
+  // The section title over this line is the column's name, so the line itself
+  // only has to say which number.
+  const points = mondayNightPoints(outlook, "Points");
+  return `${points} to beat ${NAMES.format(outlook.rivals)}.`;
 }
 
 /**
@@ -31,8 +40,9 @@ function mondayNightSentence(outlook: DecidingOutlook): string {
 export function RouteMondayNight({ outlook }: { outlook: MondayNightRange }) {
   return (
     <p className="analysis__line analysis__route-mnf">
-      <span className="analysis__pick-label">AND</span>
-      <span>{mondayNightPoints(outlook)}</span>
+      <span className="analysis__pick-label analysis__and">AND</span>
+      {/* In full, since the route this closes carries no title naming it. */}
+      <span>{mondayNightPoints(outlook, "MNF Points")}</span>
       <span>
         {/* A list rather than a sentence, since the line around it is one too. */}
         <span className="analysis__term">TO BEAT</span>{" "}

--- a/src/components/playerAnalysis/mondayNight.tsx
+++ b/src/components/playerAnalysis/mondayNight.tsx
@@ -1,58 +1,27 @@
-import { Fragment } from "react";
 import { MondayNightOutlook } from "../../types/PlayerAnalysis";
-import { NAMES, Section } from "./analysisParts";
+import { Section } from "./analysisParts";
 import "./AnalysisSummary.scss";
-
-/** The outlooks worth a sentence: a week won outright says so on its own line. */
-type DecidingOutlook = Exclude<MondayNightOutlook, { kind: "notNeeded" }>;
 
 /** The one outlook a route of its own carries, which is a total still to come. */
 type MondayNightRange = Extract<MondayNightOutlook, { kind: "range" }>;
 
-/**
- * The totals that win, as a comparison. `term` names the scoreboard column, in
- * full only where nothing beside the line already names it.
- */
-function mondayNightPoints(
-  { min, max }: MondayNightRange,
-  term: string,
-): string {
+/** The totals that win, as a comparison on the scoreboard column's own name. */
+function mondayNightPoints({ min, max }: MondayNightRange): string {
   if (min != null && max != null) {
-    return min === max ? `${term} = ${min}` : `${min} ≤ ${term} ≤ ${max}`;
+    return min === max ? `MNF Points = ${min}` : `${min} ≤ MNF Points ≤ ${max}`;
   }
-  return min != null ? `${term} ≥ ${min}` : `${term} ≤ ${max}`;
-}
-
-function mondayNightSentence(outlook: DecidingOutlook): string {
-  if (outlook.kind === "settled") {
-    return "MNF Points are already final, so the games above settle it.";
-  }
-  // The section title over this line is the column's name, so the line itself
-  // only has to say which number.
-  const points = mondayNightPoints(outlook, "Points");
-  return `${points} to beat ${NAMES.format(outlook.rivals)}.`;
+  return min != null ? `MNF Points ≥ ${min}` : `MNF Points ≤ ${max}`;
 }
 
 /**
  * The total a route of its own asks for, set out the way its picks are: what to do
- * in the ink they use, and the words holding it together in their labels' ink.
+ * in the ink they use, and the word holding it to them in their labels' ink.
  */
 export function RouteMondayNight({ outlook }: { outlook: MondayNightRange }) {
   return (
     <p className="analysis__line analysis__route-mnf">
       <span className="analysis__pick-label analysis__and">AND</span>
-      {/* In full, since the route this closes carries no title naming it. */}
-      <span>{mondayNightPoints(outlook, "MNF Points")}</span>
-      <span>
-        {/* A list rather than a sentence, since the line around it is one too. */}
-        <span className="analysis__term">TO BEAT</span>{" "}
-        {outlook.rivals.map((name, index) => (
-          <Fragment key={name}>
-            {index > 0 && <span className="analysis__term">, </span>}
-            {name}
-          </Fragment>
-        ))}
-      </span>
+      <span>{mondayNightPoints(outlook)}</span>
     </p>
   );
 }
@@ -65,9 +34,16 @@ export function MondayNight({
   conjoined?: boolean;
 }) {
   if (outlook == null || outlook.kind === "notNeeded") return null;
-  return (
-    <Section conjoined={conjoined} title="MNF Points">
-      <p className="analysis__line">{mondayNightSentence(outlook)}</p>
-    </Section>
-  );
+  if (outlook.kind === "settled") {
+    return (
+      <Section conjoined={conjoined} title="MNF Points">
+        <p className="analysis__line">
+          MNF Points are already final, so the games above settle it.
+        </p>
+      </Section>
+    );
+  }
+  // The totals are the whole of what this block asks for, so the title carries
+  // them and there is nothing left to set under it.
+  return <Section conjoined={conjoined} title={mondayNightPoints(outlook)} />;
 }

--- a/src/types/PlayerAnalysis.ts
+++ b/src/types/PlayerAnalysis.ts
@@ -63,6 +63,12 @@ export type PlayerAnalysis =
       minimumWins: number;
       /** Whether the player only draws level at that count, leaving Monday night to decide. */
       needsMondayNight: boolean;
+      /**
+       * Games no floor above reaches a rival without, so every way of winning needs
+       * them. Proven from the same arithmetic, which can prove fewer of them than a
+       * full search finds but never names one wrongly.
+       */
+      mustWin: Array<RemainingPick>;
     }
   | {
       kind: "paths";

--- a/src/types/PlayerAnalysis.ts
+++ b/src/types/PlayerAnalysis.ts
@@ -25,13 +25,7 @@ export type UncontrolledGame = {
 export type MondayNightOutlook =
   | { kind: "notNeeded" }
   | { kind: "settled" }
-  | {
-      kind: "range";
-      min?: number;
-      max?: number;
-      /** Who the player is level with on points, and so measured against. */
-      rivals: Array<string>;
-    };
+  | { kind: "range"; min?: number; max?: number };
 
 /** One way past the must-win games, and how it ends. */
 export type VictoryRoute = {
@@ -75,7 +69,7 @@ export type PlayerAnalysis =
       player: string;
       /** Games every route needs. */
       mustWin: Array<RemainingPick>;
-      /** Set when the routes past `mustWin` are exactly "any `choose` of these". */
+      /** Set when the routes past `mustWin` are exactly any `choose` of one pool. */
       pool?: { choose: number; games: Array<RemainingPick> };
       /** Set instead of `pool`, when the routes are not one pool of one size. */
       routes?: Array<VictoryRoute>;

--- a/src/types/PlayerAnalysis.ts
+++ b/src/types/PlayerAnalysis.ts
@@ -64,9 +64,9 @@ export type PlayerAnalysis =
       /** Whether the player only draws level at that count, leaving Monday night to decide. */
       needsMondayNight: boolean;
       /**
-       * Games no floor above reaches a rival without, so every way of winning needs
-       * them. Proven from the same arithmetic, which can prove fewer of them than a
-       * full search finds but never names one wrongly.
+       * Games no win can do without, and all of them: this is what the search
+       * would name, read a game at a time. Empty where nothing can be proven,
+       * never a part of the list.
        */
       mustWin: Array<RemainingPick>;
     }

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -23,4 +23,4 @@ The picks-to-scoreboard pipeline, sequenced by `getPlayerScores`.
 - `getPlayerAnalysis`: what a player must do, plus `getSettledAnalysis`,
   the answers a week already holds, which the dialog asks before it waits
 - `leagueResultFixtures`: test game builders
-- `benchFixtures`: the 60x19 week the benchmarks measure
+- `benchFixtures`: the 80x22 worst week the benchmarks measure

--- a/src/utils/scoring/CLAUDE.md
+++ b/src/utils/scoring/CLAUDE.md
@@ -14,7 +14,8 @@ The picks-to-scoreboard pipeline, sequenced by `getPlayerScores`.
 - `scorePlayers`: per-player totals, sorted
 - `comparePlayerScores`: rank order, on merit
 - `isWinnerDecided`: whether knockouts settled it
-- `weekShape`: open games, holes, and whether the week ran out
+- `weekShape`: open games, holes, whether a line can push, and whether the week
+  ran out
 - `remainingGames`: the open games
 - `unscoreableGames`: games nobody scores
 - `isEveryGameSettled`: whether the week finished

--- a/src/utils/scoring/applyKnockouts.test.ts
+++ b/src/utils/scoring/applyKnockouts.test.ts
@@ -329,7 +329,7 @@ describe("applyKnockouts", () => {
     expect(result[1].status.isKnockedOut).toBe(true);
     expect(result[1].status.explanation).toBe(
       "Knocked out on MNF Points tiebreaker by Alice. " +
-        "Bob is 13 points off, and Alice is 2 points off.",
+        "Off by 13 points, and Alice is off by 2 points.",
     );
   });
 

--- a/src/utils/scoring/applyKnockouts.test.ts
+++ b/src/utils/scoring/applyKnockouts.test.ts
@@ -329,7 +329,7 @@ describe("applyKnockouts", () => {
     expect(result[1].status.isKnockedOut).toBe(true);
     expect(result[1].status.explanation).toBe(
       "Knocked out on MNF Points tiebreaker by Alice. " +
-        "Off by 13 points, and Alice is off by 2 points.",
+        "Bob is 13 points off, and Alice is 2 points off.",
     );
   });
 

--- a/src/utils/scoring/applyKnockouts.ts
+++ b/src/utils/scoring/applyKnockouts.ts
@@ -180,8 +180,8 @@ export default function applyKnockouts(
             return knockedOut(
               activeScore,
               `Knocked out on MNF Points tiebreaker by ${rivalScore.name}. ` +
-                `Off by ${plural(activeDistance, "point")}, and ${rivalScore.name} is ` +
-                `off by ${plural(rivalDistance, "point")}.`,
+                `${activeScore.name} is ${plural(activeDistance, "point")} off, and ${rivalScore.name} is ` +
+                `${plural(rivalDistance, "point")} off.`,
             );
           }
         }

--- a/src/utils/scoring/applyKnockouts.ts
+++ b/src/utils/scoring/applyKnockouts.ts
@@ -180,8 +180,8 @@ export default function applyKnockouts(
             return knockedOut(
               activeScore,
               `Knocked out on MNF Points tiebreaker by ${rivalScore.name}. ` +
-                `${activeScore.name} is ${plural(activeDistance, "point")} off, and ${rivalScore.name} is ` +
-                `${plural(rivalDistance, "point")} off.`,
+                `Off by ${plural(activeDistance, "point")}, and ${rivalScore.name} is ` +
+                `off by ${plural(rivalDistance, "point")}.`,
             );
           }
         }

--- a/src/utils/scoring/benchFixtures.ts
+++ b/src/utils/scoring/benchFixtures.ts
@@ -9,11 +9,14 @@ import { LeagueResult } from "../../types/LeagueResult";
 import { toLeagueResult } from "../getLeagueResults";
 
 /**
- * The size the worst week runs to, read off every week published to the picks API:
- * six college games and sixteen pro, the twenty-two of Thanksgiving week, against a
- * median of nineteen. The field is the eighty the pool is sized for, above the
- * sixty-eight of its biggest week so far. Both cost the scoring a walk per game per
- * player, so a benchmark is worth having at the top of the range.
+ * The size of the worst week, since every game and every player costs the scoring
+ * another walk and a benchmark is worth having at the top of the range.
+ *
+ * Read in September 2026 off the 54 weeks `GET /api/picks/<season>/<week>` served
+ * for 2023 to 2025, counting the `C` and `P` columns of each: six college games and
+ * sixteen pro, the twenty-two of Thanksgiving week, against a median of nineteen
+ * and a field topping out at sixty-eight. Re-read them the same way to move these,
+ * and keep the field at the eighty the pool is sized for.
  */
 export const BENCH_PLAYERS = 80;
 export const BENCH_COLLEGE_GAMES = 6;

--- a/src/utils/scoring/benchFixtures.ts
+++ b/src/utils/scoring/benchFixtures.ts
@@ -9,18 +9,23 @@ import { LeagueResult } from "../../types/LeagueResult";
 import { toLeagueResult } from "../getLeagueResults";
 
 /**
- * The size a real week runs to, taken from the shape `SkeletonTable` draws: six
- * college games and thirteen pro, played by a field past sixty.
+ * The size the worst week runs to, read off every week published to the picks API:
+ * six college games and sixteen pro, the twenty-two of Thanksgiving week, against a
+ * median of nineteen. The field is the eighty the pool is sized for, above the
+ * sixty-eight of its biggest week so far. Both cost the scoring a walk per game per
+ * player, so a benchmark is worth having at the top of the range.
  */
-export const BENCH_PLAYERS = 60;
+export const BENCH_PLAYERS = 80;
 export const BENCH_COLLEGE_GAMES = 6;
-export const BENCH_PRO_GAMES = 13;
+export const BENCH_PRO_GAMES = 16;
 
 /**
  * How far through the week the fixture stands. `kickoff` has every game ahead,
  * `sundayNight` leaves one live and one ahead, and `settled` is the finished week.
+ * A number leaves that many of the last games to be played, which is what the cost
+ * of working out the routes is set by.
  */
-export type WeekPhase = "kickoff" | "sundayNight" | "settled";
+export type WeekPhase = "kickoff" | "sundayNight" | "settled" | number;
 
 // Fixed, or a run cannot be compared against the one before it.
 const SEASON = 2024;
@@ -136,6 +141,14 @@ export async function benchPicksBuffer(): Promise<ArrayBuffer> {
 function statusAt(phase: WeekPhase, league: League, index: number): GameStatus {
   if (phase === "kickoff") return GameStatus.UPCOMING;
   if (phase === "settled") return GameStatus.FINAL;
+  if (typeof phase === "number") {
+    // Counted from the end, so the games left are the ones the week runs last.
+    const column =
+      league === League.COLLEGE ? index : BENCH_COLLEGE_GAMES + index;
+    return column >= BENCH_COLLEGE_GAMES + BENCH_PRO_GAMES - phase
+      ? GameStatus.UPCOMING
+      : GameStatus.FINAL;
+  }
   // One live and one ahead, which keeps the week open and the cache missing.
   if (league === League.PRO && index === BENCH_PRO_GAMES - 1) {
     return GameStatus.UPCOMING;

--- a/src/utils/scoring/getPlayerAnalysis.test.ts
+++ b/src/utils/scoring/getPlayerAnalysis.test.ts
@@ -571,11 +571,11 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
     );
   }
 
-  it("gives a floor rather than routes above ten open games", () => {
-    // Eleven games the two picked differently, Alice five points back. Each one
-    // she takes is one Bob does not, so eight of them draw her level and a ninth
-    // takes it outright.
-    const count = 11;
+  it("gives a floor rather than routes above fifteen open games", () => {
+    // Sixteen games the two picked differently, Alice six points back. Each one
+    // she takes is one Bob does not, so eleven of them draw her level and a
+    // twelfth takes it outright.
+    const count = 16;
     const scores = week([
       player({
         name: "Alice",
@@ -584,7 +584,7 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
       }),
       player({
         name: "Bob",
-        total: 5,
+        total: 6,
         pro: opposed(count, "B", "+3"),
       }),
     ]);
@@ -592,36 +592,56 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
     expect(getPlayerAnalysis(scores, "Alice")).toEqual({
       kind: "headline",
       player: "Alice",
-      remainingPickCount: 11,
-      minimumWins: 8,
+      remainingPickCount: 16,
+      minimumWins: 11,
       needsMondayNight: true,
+      // Eleven of sixteen is slack enough that no single game is unaffordable.
+      mustWin: [],
     });
   });
 
   it("leaves Monday night out where winning enough clears every rival", () => {
-    // The same eleven games with Alice four points back. Eight of them put her on
-    // eight and Bob on seven, so the count that draws her level is the count that
-    // takes the week, and the guesses never come into it.
-    const count = 11;
+    // The same sixteen games with Alice five points back. Eleven of them put her
+    // on eleven and Bob on ten, so the count that draws her level is the count
+    // that takes the week, and the guesses never come into it.
+    const count = 16;
     const scores = week([
       player({ name: "Alice", total: 0, pro: opposed(count, "A", "-3") }),
-      player({ name: "Bob", total: 4, pro: opposed(count, "B", "+3") }),
+      player({ name: "Bob", total: 5, pro: opposed(count, "B", "+3") }),
     ]);
 
     expect(getPlayerAnalysis(scores, "Alice")).toEqual({
       kind: "headline",
       player: "Alice",
-      remainingPickCount: 11,
-      minimumWins: 8,
+      remainingPickCount: 16,
+      minimumWins: 11,
       needsMondayNight: false,
+      mustWin: [],
     });
   });
 
-  it("counts the games left, whether or not they are in dispute", () => {
-    // Eleven games left, ten of them picked the same way by both. Only one can
-    // change the order, and a week this far out still gives a floor rather than
-    // routes.
-    const agreed = Array.from({ length: 10 }, (_, index) =>
+  it("names the must-win games on a week too big to search", () => {
+    // Sixteen games the two picked differently, Alice sixteen points back. Every
+    // one of them is a two-point swing and she needs all thirty-two, so losing
+    // any single game puts Bob out of reach.
+    const count = 16;
+    const scores = week([
+      player({ name: "Alice", total: 0, pro: opposed(count, "A", "-3") }),
+      player({ name: "Bob", total: 16, pro: opposed(count, "B", "+3") }),
+    ]);
+
+    const result = getPlayerAnalysis(scores, "Alice");
+    expect(result?.kind).toBe("headline");
+    expect(
+      labels((result as { mustWin: Array<{ label: string }> }).mustWin),
+    ).toEqual(Array.from({ length: count }, (_, index) => `P${index + 1}`));
+  });
+
+  it("never names a game the player cannot lose ground in", () => {
+    // Sixteen games left and Alice a point back, fifteen of them picked the same
+    // way by both. Only the one they differ in can change the order, and she has
+    // to take it, so the games they agree on are named by nothing.
+    const agreed = Array.from({ length: 15 }, (_, index) =>
       pick(`S${index} -3`),
     );
     const scores = week([
@@ -629,18 +649,22 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
       player({ name: "Bob", total: 1, pro: [...agreed, pick("DEN +3")] }),
     ]);
 
-    expect(getPlayerAnalysis(scores, "Alice")?.kind).toBe("headline");
+    const result = getPlayerAnalysis(scores, "Alice");
+    expect(result?.kind).toBe("headline");
+    expect(
+      labels((result as { mustWin: Array<{ label: string }> }).mustWin),
+    ).toEqual(["P16"]);
   });
 
-  it("works the routes out at ten", () => {
-    const count = 10;
+  it("works the routes out at fifteen", () => {
+    const count = 15;
     const scores = week([
       player({ name: "Alice", total: 0, pro: opposed(count, "A", "-3") }),
       player({ name: "Bob", total: 0, pro: opposed(count, "B", "+3") }),
     ]);
 
     const result = paths(getPlayerAnalysis(scores, "Alice"));
-    expect(result.pool?.choose).toBe(5);
-    expect(result.pool?.games).toHaveLength(10);
+    expect(result.pool?.choose).toBe(8);
+    expect(result.pool?.games).toHaveLength(15);
   });
 });

--- a/src/utils/scoring/getPlayerAnalysis.test.ts
+++ b/src/utils/scoring/getPlayerAnalysis.test.ts
@@ -5,7 +5,10 @@ import {
   RakMadnessScores,
   Status,
 } from "../../types/RakMadnessScores";
-import getPlayerAnalysis, { getSettledAnalysis } from "./getPlayerAnalysis";
+import getPlayerAnalysis, {
+  getSettledAnalysis,
+  MAX_SEARCHED_GAMES,
+} from "./getPlayerAnalysis";
 
 /** A game still to be played unless a status says otherwise. */
 function pick(text: string, status: Status = "incomplete"): PickResult {
@@ -564,6 +567,13 @@ describe("getPlayerAnalysis, games out of the player's hands", () => {
 });
 
 describe("getPlayerAnalysis, weeks too big to search", () => {
+  /**
+   * One game past the ceiling, so every week below answers off the floor rather
+   * than a search. Each deficit is written against this count, since what draws
+   * the player level turns on whether the count and the deficit share a parity.
+   */
+  const ABOVE_LIMIT = MAX_SEARCHED_GAMES + 1;
+
   /** Two sides of one game, on the same spread, so no tiebreaker tier splits them. */
   function opposed(count: number, prefix: string, spread: string) {
     return Array.from({ length: count }, (_, index) =>
@@ -571,11 +581,11 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
     );
   }
 
-  it("gives a floor rather than routes above fifteen open games", () => {
-    // Sixteen games the two picked differently, Alice six points back. Each one
-    // she takes is one Bob does not, so eleven of them draw her level and a
-    // twelfth takes it outright.
-    const count = 16;
+  it("gives a floor rather than routes above the ceiling", () => {
+    // Every open game picked the other way, and a deficit six under that count.
+    // Each game she takes is one Bob does not, so three short of all of them
+    // draws her exactly level and nothing takes it outright.
+    const count = ABOVE_LIMIT;
     const scores = week([
       player({
         name: "Alice",
@@ -584,7 +594,7 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
       }),
       player({
         name: "Bob",
-        total: 6,
+        total: count - 6,
         pro: opposed(count, "B", "+3"),
       }),
     ]);
@@ -592,42 +602,42 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
     expect(getPlayerAnalysis(scores, "Alice")).toEqual({
       kind: "headline",
       player: "Alice",
-      remainingPickCount: 16,
-      minimumWins: 11,
+      remainingPickCount: count,
+      minimumWins: count - 3,
       needsMondayNight: true,
-      // Eleven of sixteen is slack enough that no single game is unaffordable.
+      // Three games of slack, so no single one of them is unaffordable.
       mustWin: [],
     });
   });
 
   it("leaves Monday night out where winning enough clears every rival", () => {
-    // The same sixteen games with Alice five points back. Eleven of them put her
-    // on eleven and Bob on ten, so the count that draws her level is the count
-    // that takes the week, and the guesses never come into it.
-    const count = 16;
+    // The same games with the deficit one point wider, which no count of them can
+    // land level on. So the count that draws her level is the count that takes the
+    // week, and the guesses never come into it.
+    const count = ABOVE_LIMIT;
     const scores = week([
       player({ name: "Alice", total: 0, pro: opposed(count, "A", "-3") }),
-      player({ name: "Bob", total: 5, pro: opposed(count, "B", "+3") }),
+      player({ name: "Bob", total: count - 5, pro: opposed(count, "B", "+3") }),
     ]);
 
     expect(getPlayerAnalysis(scores, "Alice")).toEqual({
       kind: "headline",
       player: "Alice",
-      remainingPickCount: 16,
-      minimumWins: 11,
+      remainingPickCount: count,
+      minimumWins: count - 2,
       needsMondayNight: false,
       mustWin: [],
     });
   });
 
   it("names the must-win games on a week too big to search", () => {
-    // Sixteen games the two picked differently, Alice sixteen points back. Every
-    // one of them is a two-point swing and she needs all thirty-two, so losing
-    // any single game puts Bob out of reach.
-    const count = 16;
+    // A deficit as wide as the count of games. Every one of them is a two-point
+    // swing and she needs all of them, so losing any single game puts Bob out of
+    // reach.
+    const count = ABOVE_LIMIT;
     const scores = week([
       player({ name: "Alice", total: 0, pro: opposed(count, "A", "-3") }),
-      player({ name: "Bob", total: 16, pro: opposed(count, "B", "+3") }),
+      player({ name: "Bob", total: count, pro: opposed(count, "B", "+3") }),
     ]);
 
     const result = getPlayerAnalysis(scores, "Alice");
@@ -638,11 +648,11 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
   });
 
   it("names nothing where a game the player left blank has to fall their way", () => {
-    // Fifteen games the two picked differently and one only Bob picked, Alice
-    // fifteen points back. Winning all fifteen of her own only draws her level,
-    // and only while Bob's extra game misses, so no game of hers is enough on its
-    // own terms and the week names none of them.
-    const count = 15;
+    // All but one open game picked the other way, the last one only Bob picked,
+    // and a deficit as wide as her own count. Winning all of hers only draws her
+    // level, and only while Bob's extra game misses, so no game of hers is enough
+    // on its own terms and the week names none of them.
+    const count = ABOVE_LIMIT - 1;
     const scores = week([
       player({
         name: "Alice",
@@ -651,7 +661,7 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
       }),
       player({
         name: "Bob",
-        total: 15,
+        total: count,
         pro: [...opposed(count, "B", "+3"), pick("SEA -3")],
       }),
     ]);
@@ -663,7 +673,7 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
 
   /** The same week twice, with `blanks` games only a third player picked. */
   function withBlanks(blanks: number) {
-    const count = 16;
+    const count = ABOVE_LIMIT;
     // Half a point, so none of these can push. A game that can is held to its push
     // and leaves nothing to walk, which is what `walkMask` drops.
     const spare = (prefix: string) =>
@@ -694,7 +704,7 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
   it("names the must-win games while the blanks are few enough to walk", () => {
     const result = getPlayerAnalysis(withBlanks(8), "Alice");
     expect(result?.kind).toBe("headline");
-    expect(mustWin(result)).toHaveLength(16);
+    expect(mustWin(result)).toHaveLength(ABOVE_LIMIT);
   });
 
   it("names nothing once too many games are left blank to walk", () => {
@@ -704,10 +714,10 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
   });
 
   it("never names a game the player cannot lose ground in", () => {
-    // Sixteen games left and Alice a point back, fifteen of them picked the same
-    // way by both. Only the one they differ in can change the order, and she has
-    // to take it, so the games they agree on are named by nothing.
-    const agreed = Array.from({ length: 15 }, (_, index) =>
+    // Alice a point back, and all but one of the open games picked the same way by
+    // both. Only the one they differ in can change the order, and she has to take
+    // it, so the games they agree on are named by nothing.
+    const agreed = Array.from({ length: ABOVE_LIMIT - 1 }, (_, index) =>
       pick(`S${index} -3`),
     );
     const scores = week([
@@ -717,7 +727,7 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
 
     const result = getPlayerAnalysis(scores, "Alice");
     expect(result?.kind).toBe("headline");
-    expect(mustWin(result)).toEqual(["P16"]);
+    expect(mustWin(result)).toEqual([`P${ABOVE_LIMIT}`]);
   });
 
   it("works the routes out at fifteen", () => {

--- a/src/utils/scoring/getPlayerAnalysis.test.ts
+++ b/src/utils/scoring/getPlayerAnalysis.test.ts
@@ -67,6 +67,14 @@ function labels(games: Array<{ label: string }>): Array<string> {
   return games.map((game) => game.label);
 }
 
+/** The must-win labels of an answer that carries them, in its own order. */
+function mustWin(result: PlayerAnalysis | undefined): Array<string> {
+  expect(result?.kind === "headline" || result?.kind === "paths").toBe(true);
+  return labels(
+    (result as Extract<PlayerAnalysis, { kind: "headline" }>).mustWin,
+  );
+}
+
 describe("getPlayerAnalysis, whether there is anything to work out", () => {
   it("has no answer for a name the sheet does not hold", () => {
     const scores = week([player({ name: "Alice" })]);
@@ -632,9 +640,73 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
 
     const result = getPlayerAnalysis(scores, "Alice");
     expect(result?.kind).toBe("headline");
-    expect(
-      labels((result as { mustWin: Array<{ label: string }> }).mustWin),
-    ).toEqual(Array.from({ length: count }, (_, index) => `P${index + 1}`));
+    expect(mustWin(result)).toEqual(
+      Array.from({ length: count }, (_, index) => `P${index + 1}`),
+    );
+  });
+
+  it("names nothing where a game the player left blank has to fall their way", () => {
+    // Fifteen games the two picked differently and one only Bob picked, Alice
+    // fifteen points back. Winning all fifteen of her own only draws her level,
+    // and only while Bob's extra game misses, so no game of hers is enough on its
+    // own terms and the week names none of them.
+    const count = 15;
+    const scores = week([
+      player({
+        name: "Alice",
+        total: 0,
+        pro: [...opposed(count, "A", "-3"), pick("")],
+      }),
+      player({
+        name: "Bob",
+        total: 15,
+        pro: [...opposed(count, "B", "+3"), pick("SEA -3")],
+      }),
+    ]);
+
+    const result = getPlayerAnalysis(scores, "Alice");
+    expect(result?.kind).toBe("headline");
+    expect(mustWin(result)).toEqual([]);
+  });
+
+  /** The same week twice, with `blanks` games only a third player picked. */
+  function withBlanks(blanks: number) {
+    const count = 16;
+    const spare = (prefix: string) =>
+      Array.from({ length: blanks }, (_, index) =>
+        pick(`${prefix}${index} -3`),
+      );
+    return week([
+      player({
+        name: "Alice",
+        total: 0,
+        pro: [...opposed(count, "A", "-3"), ...spare("X").map(() => pick(""))],
+      }),
+      player({
+        name: "Bob",
+        total: 16,
+        pro: [...opposed(count, "B", "+3"), ...spare("X").map(() => pick(""))],
+      }),
+      // Far enough back that her extra games cannot reach anyone, so they only
+      // widen the outcomes a proof has to hold across.
+      player({
+        name: "Carol",
+        total: -40,
+        pro: [...opposed(count, "C", "-3"), ...spare("X")],
+      }),
+    ]);
+  }
+
+  it("names the must-win games while the blanks are few enough to walk", () => {
+    const result = getPlayerAnalysis(withBlanks(8), "Alice");
+    expect(result?.kind).toBe("headline");
+    expect(mustWin(result)).toHaveLength(16);
+  });
+
+  it("names nothing once too many games are left blank to walk", () => {
+    const result = getPlayerAnalysis(withBlanks(9), "Alice");
+    expect(result?.kind).toBe("headline");
+    expect(mustWin(result)).toEqual([]);
   });
 
   it("never names a game the player cannot lose ground in", () => {
@@ -651,9 +723,7 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
 
     const result = getPlayerAnalysis(scores, "Alice");
     expect(result?.kind).toBe("headline");
-    expect(
-      labels((result as { mustWin: Array<{ label: string }> }).mustWin),
-    ).toEqual(["P16"]);
+    expect(mustWin(result)).toEqual(["P16"]);
   });
 
   it("works the routes out at fifteen", () => {

--- a/src/utils/scoring/getPlayerAnalysis.test.ts
+++ b/src/utils/scoring/getPlayerAnalysis.test.ts
@@ -359,7 +359,6 @@ describe("getPlayerAnalysis, the Monday night tiebreaker", () => {
       kind: "range",
       min: undefined,
       max: 45,
-      rivals: ["Bob"],
     });
     expect(result.outrightAt).toBeUndefined();
   });
@@ -385,7 +384,6 @@ describe("getPlayerAnalysis, the Monday night tiebreaker", () => {
       kind: "range",
       min: 46,
       max: undefined,
-      rivals: ["Bob"],
     });
   });
 
@@ -414,7 +412,6 @@ describe("getPlayerAnalysis, the Monday night tiebreaker", () => {
       kind: "range",
       min: 45,
       max: undefined,
-      rivals: ["Bob"],
     });
   });
 
@@ -449,12 +446,7 @@ describe("getPlayerAnalysis, the Monday night tiebreaker", () => {
       },
       {
         games: [{ label: "P2", pick: "BUF -1" }],
-        mondayNight: {
-          kind: "range",
-          min: undefined,
-          max: 32,
-          rivals: ["Bob"],
-        },
+        mondayNight: { kind: "range", min: undefined, max: 32 },
       },
     ]);
   });

--- a/src/utils/scoring/getPlayerAnalysis.test.ts
+++ b/src/utils/scoring/getPlayerAnalysis.test.ts
@@ -664,9 +664,11 @@ describe("getPlayerAnalysis, weeks too big to search", () => {
   /** The same week twice, with `blanks` games only a third player picked. */
   function withBlanks(blanks: number) {
     const count = 16;
+    // Half a point, so none of these can push. A game that can is held to its push
+    // and leaves nothing to walk, which is what `walkMask` drops.
     const spare = (prefix: string) =>
       Array.from({ length: blanks }, (_, index) =>
-        pick(`${prefix}${index} -3`),
+        pick(`${prefix}${index} -3.5`),
       );
     return week([
       player({

--- a/src/utils/scoring/getPlayerAnalysis.ts
+++ b/src/utils/scoring/getPlayerAnalysis.ts
@@ -325,16 +325,13 @@ function outlookOf(verdict: Verdict, isSettled: boolean): MondayNightOutlook {
     kind: "range",
     min: verdict.lo > 0 ? verdict.lo : undefined,
     max: Number.isFinite(verdict.hi) ? verdict.hi : undefined,
-    rivals: verdict.rivals,
   };
 }
 
 function sameOutlook(a: MondayNightOutlook, b: MondayNightOutlook): boolean {
   if (a.kind !== b.kind) return false;
   if (a.kind !== "range" || b.kind !== "range") return true;
-  return (
-    a.min === b.min && a.max === b.max && a.rivals.join() === b.rivals.join()
-  );
+  return a.min === b.min && a.max === b.max;
 }
 
 function combinations(count: number, size: number): number {

--- a/src/utils/scoring/getPlayerAnalysis.ts
+++ b/src/utils/scoring/getPlayerAnalysis.ts
@@ -100,28 +100,37 @@ function subMasksBySize(mask: number): Array<Array<number>> {
   return bySize;
 }
 
+/**
+ * What each way the games can fall is worth to one player.
+ *
+ * A game named in `pushMask` is held to its push, where both sides take the point,
+ * so this player scores it whichever way the bit falls.
+ */
 function gainsFor(
   playerIndex: number,
   contested: Array<RemainingGame>,
   coverers: Array<string>,
+  pushMask: number,
 ): Gains {
   const gains = { ...NO_GAINS };
   contested.forEach((game, bit) => {
     const cell = game.cells[playerIndex];
     if (cell.team == null) return;
     const mask = 1 << bit;
-    const scoresWhenSet = cell.team === coverers[bit];
+    const covers = cell.team === coverers[bit];
+    const onSet = covers || (pushMask & mask) !== 0;
+    const onClear = !covers || (pushMask & mask) !== 0;
     if (game.league === "college") {
-      if (scoresWhenSet) gains.setCollege |= mask;
-      else gains.clearCollege |= mask;
+      if (onSet) gains.setCollege |= mask;
+      if (onClear) gains.clearCollege |= mask;
     } else if (cell.hasSpread) {
       // Pro against the spread is a tiebreaker tier of its own, and counts only
       // the pro games that carry a spread.
-      if (scoresWhenSet) gains.setSpread |= mask;
-      else gains.clearSpread |= mask;
+      if (onSet) gains.setSpread |= mask;
+      if (onClear) gains.clearSpread |= mask;
     }
-    if (scoresWhenSet) gains.setTotal |= mask;
-    else gains.clearTotal |= mask;
+    if (onSet) gains.setTotal |= mask;
+    if (onClear) gains.clearTotal |= mask;
   });
   return gains;
 }
@@ -588,6 +597,15 @@ function reduceRoutes(
  * Answers for every player, knocked out or not, and for a week already decided as
  * well as one being played. Undefined where the sheet holds nobody by that name,
  * which is the only way the question has no answer at all.
+ *
+ * A game of the player's own that lands on the line is read as their win alone. The
+ * pool scores a push for both sides, so it also scores for the rival who picked the
+ * other side, and a route named here can fall to that. Read the other way this
+ * answers nothing: winning every game they picked would leave the gap where it
+ * started, so a player even a point back could never be told they are live. Every
+ * other answer holds either way. A knockout and a must-win game only become more
+ * true, and a clinch reads a week where none of the player's own picks land, which
+ * is a week with no push in them to read.
  */
 /**
  * The answer where the week already holds one, and undefined where the search below
@@ -689,47 +707,78 @@ export default function getPlayerAnalysis(
       live.map((index) => game.cells[index].team).find((team) => team != null)!,
   );
 
-  const gains = gainsFor(playerIndex, contested, coverers);
-  const scoredRivals: Array<Rival> = rivals.map((rival) => ({
-    player: rival.player,
-    gains: gainsFor(rival.index, contested, coverers),
-  }));
   const isMondayNightSettled = scores.tiebreaker != null;
 
   let mineMask = 0;
   let luckMask = 0;
+  let pushMask = 0;
   contested.forEach((game, bit) => {
-    if (game.cells[playerIndex].team != null) mineMask |= 1 << bit;
-    else luckMask |= 1 << bit;
+    const mask = 1 << bit;
+    if (game.cells[playerIndex].team != null) {
+      mineMask |= mask;
+      return;
+    }
+    luckMask |= mask;
+    if (game.canPush) pushMask |= mask;
   });
+
+  /**
+   * The games the player left blank that are still worth a walk.
+   *
+   * A push scores for everyone who picked the game, and the player picked none of
+   * these, so it lifts every rival at once and lifts the player not at all. Taking
+   * the week means standing level with each rival on that rival's own comparison,
+   * and a walk of the game's two sides already holds the side each rival scores on.
+   * So the push asks the same question in one read where the walk takes two, which
+   * `pushEquivalence.test.ts` holds to and `scoring.bench.ts` measures: the worst
+   * week answers in 14ms where the walk of the same week costs 47ms.
+   */
+  const walkMask = luckMask & ~pushMask;
+
+  const gains = gainsFor(playerIndex, contested, coverers, pushMask);
+  const rivalGains = (pushed: number) =>
+    rivals.map((rival) => ({
+      player: rival.player,
+      gains: gainsFor(rival.index, contested, coverers, pushed),
+    }));
 
   // A player who picked every open game has one way each set of their picks can
   // land, so every outcome is read once and holding them costs more than it saves.
-  const verdicts =
-    luckMask === 0 ? undefined : new Map<number, ReturnType<typeof evaluate>>();
-  const read = (outcome: number) => {
-    const held = verdicts?.get(outcome);
-    if (held != null) return held;
-    const verdict = evaluate(
-      player,
-      gains,
-      scoredRivals,
-      outcome,
-      isMondayNightSettled,
-    );
-    verdicts?.set(outcome, verdict);
-    return verdict;
+  const reader = (against: Array<Rival>, walk: number) => {
+    const verdicts =
+      walk === 0 ? undefined : new Map<number, ReturnType<typeof evaluate>>();
+    return (outcome: number) => {
+      const held = verdicts?.get(outcome);
+      if (held != null) return held;
+      const verdict = evaluate(
+        player,
+        gains,
+        against,
+        outcome,
+        isMondayNightSettled,
+      );
+      verdicts?.set(outcome, verdict);
+      return verdict;
+    };
   };
+
+  // Two readings of the same week. `read` lets every blank game fall the best way
+  // it can, which is what the routes past a dead end are found on. `readHeld` holds
+  // the ones that can push to their push, which is what a route reported without
+  // conditions has to survive. With nothing to push they are one reading.
+  const read = reader(rivalGains(0), luckMask);
+  const readHeld =
+    pushMask === 0 ? read : reader(rivalGains(pushMask), walkMask);
 
   // Above the ceiling the week is answered off the floor, plus the must-win games
   // the outcomes above prove, which cost a verdict each rather than a search.
   if (games.length > MAX_SEARCHED_GAMES) {
-    const isWalkable = bitCount(luckMask) <= MAX_UNPICKED_GAMES;
+    const isWalkable = bitCount(walkMask) <= MAX_UNPICKED_GAMES;
     const mustWin = isWalkable
       ? provenMustWin(
           mineMask,
-          subMasks(luckMask),
-          read,
+          subMasks(walkMask),
+          readHeld,
           contested,
           playerIndex,
         )
@@ -738,12 +787,13 @@ export default function getPlayerAnalysis(
   }
 
   const ordered = subMasksBySize(mineMask);
+  const heldOutcomes = subMasks(walkMask);
   const luckOutcomes = subMasks(luckMask);
 
   // Held against the player first, so a route that survives every way the games
   // they left blank can fall is reported without conditions.
   let { minimal, outrightAt } = search(ordered, (hits) => ({
-    verdict: guaranteedVerdict(hits, luckOutcomes, read),
+    verdict: guaranteedVerdict(hits, heldOutcomes, readHeld),
     luck: 0,
   }));
   let needsHelp: Array<UncontrolledGame> = [];

--- a/src/utils/scoring/getPlayerAnalysis.ts
+++ b/src/utils/scoring/getPlayerAnalysis.ts
@@ -9,6 +9,7 @@ import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
 import { comparePlayerScoresOnMerit } from "./comparePlayerScores";
 import isWinnerDecided from "./isWinnerDecided";
 import remainingGames, {
+  PickDifference,
   pickDifference,
   RemainingGame,
 } from "./remainingGames";
@@ -16,8 +17,13 @@ import remainingGames, {
 /**
  * The most games still to play the routes are worked out for. Only the contested
  * ones are searched, and the search doubles per one, so this is a loose ceiling.
+ *
+ * Set by what a phone can hold the thread for. At fifteen the worst row of an
+ * eighty-player week is tens of milliseconds on a laptop, and every game past it
+ * doubles that. A week above it still names the must-win games, which cost a walk
+ * of the players rather than a search.
  */
-const MAX_SEARCHED_GAMES = 10;
+export const MAX_SEARCHED_GAMES = 15;
 
 /** How many routes are carried before the rest are only counted. */
 const MAX_LISTED_ROUTES = 8;
@@ -72,6 +78,26 @@ function subMasks(mask: number): Array<number> {
     if (subset === 0) break;
   }
   return masks;
+}
+
+/**
+ * The same subsets, bucketed by how many bits they hold and ascending inside a
+ * bucket, which is the order the search reads them in.
+ *
+ * Bucketed rather than sorted, because a week at the ceiling holds tens of
+ * thousands of subsets and sorting them costs more than reading them all does.
+ */
+function subMasksBySize(mask: number): Array<Array<number>> {
+  const bySize: Array<Array<number>> = Array.from(
+    { length: bitCount(mask) + 1 },
+    () => [],
+  );
+  for (const subset of subMasks(mask)) {
+    bySize[bitCount(subset)].push(subset);
+  }
+  // `subMasks` walks largest first, so every bucket comes out descending.
+  bySize.forEach((bucket) => bucket.reverse());
+  return bySize;
 }
 
 function gainsFor(
@@ -346,22 +372,72 @@ function fewestWinsToCatch(
   return onOwn > playerOnly ? undefined : onDifferent + onOwn;
 }
 
+/** One rival, as the arithmetic above reads them. */
+type Measured = { index: number; gap: number; against: PickGap };
+
+/** The same rival once one of the player's games is written off as lost. */
+function withoutGame(rival: Measured, difference: PickDifference): Measured {
+  const { opposed, playerOnly } = rival.against;
+  // An opposed game hands its point to the rival, so the gap grows by one and the
+  // swing left to close it shrinks. A game only the player picked is a point they
+  // simply do not take.
+  return difference === "opposed"
+    ? {
+        ...rival,
+        gap: rival.gap + 1,
+        against: { opposed: opposed - 1, playerOnly },
+      }
+    : { ...rival, against: { opposed, playerOnly: playerOnly - 1 } };
+}
+
+/**
+ * The games the player cannot afford to lose, on the arithmetic `minimumWins` runs.
+ *
+ * A game is here when losing it puts a rival out of reach. `fewestWinsToCatch` is
+ * a floor, optimistic about the rival, so a game it calls unaffordable really is
+ * one. It can miss a game a full search would catch, which is the safe direction:
+ * a week too big to search names must-win games it can prove and no others.
+ */
+function mustWinGames(
+  playerIndex: number,
+  rivals: Array<Measured>,
+  games: Array<RemainingGame>,
+): Array<RemainingPick> {
+  return games
+    .filter((game) =>
+      rivals.some((rival) => {
+        const difference = pickDifference(game, playerIndex, rival.index);
+        // The player left it blank, or the two picked the same team, so the game
+        // moves both scores together and cannot put anyone out of reach.
+        if (difference === "none") return false;
+        const lost = withoutGame(rival, difference);
+        return fewestWinsToCatch(lost.against, lost.gap, false) == null;
+      }),
+    )
+    .map((game) => ({
+      label: game.label,
+      pick: game.cells[playerIndex].text,
+    }));
+}
+
 function headline(
   player: PlayerScore,
   playerIndex: number,
   rivals: Array<{ player: PlayerScore; index: number }>,
   games: Array<RemainingGame>,
 ): PlayerAnalysis {
-  const counts = rivals.map((rival) => {
-    const gap = rival.player.score.total - player.score.total;
-    // Both targets read off one walk. They differ only by the point that clears a
-    // draw, never in what the two players have left to differ on.
-    const against = countAgainst(playerIndex, rival.index, games);
-    return {
-      toLevel: fewestWinsToCatch(against, gap, false),
-      toClear: fewestWinsToCatch(against, gap, true),
-    };
-  });
+  const measured: Array<Measured> = rivals.map((rival) => ({
+    index: rival.index,
+    gap: rival.player.score.total - player.score.total,
+    // Read once and handed on. The targets below and the must-win walk all ask
+    // the same question of what the two players have left to differ on.
+    against: countAgainst(playerIndex, rival.index, games),
+  }));
+  const counts = measured.map((rival) => ({
+    // The two targets differ only by the point that clears a draw.
+    toLevel: fewestWinsToCatch(rival.against, rival.gap, false),
+    toClear: fewestWinsToCatch(rival.against, rival.gap, true),
+  }));
 
   // `toLevel` is only absent where `applyKnockouts` has already knocked the player
   // out on total score, which `getPlayerAnalysis` answers before reaching here.
@@ -381,6 +457,7 @@ function headline(
     needsMondayNight: counts.some(
       (count) => count.toClear == null || count.toClear > minimumWins,
     ),
+    mustWin: mustWinGames(playerIndex, measured, games),
   };
 }
 
@@ -391,27 +468,29 @@ type Search = { minimal: Array<Route>; outrightAt?: number };
 /**
  * The sets of the player's own picks that take the week, each one minimal.
  *
- * `ordered` is read fewest games first, so a set holding a winner already found adds
- * nothing. It is still read while `outrightAt` is open, since a bigger set can win
+ * `ordered` is read fewest games first, a bucket at a time, so a set holding a
+ * winner already found adds nothing. It is still read while `outrightAt` is open, since a bigger set can win
  * outright where the one inside it only draws level.
  */
 function search(
-  ordered: Array<number>,
+  ordered: Array<Array<number>>,
   outcomeOf: (hits: number) => RouteOutcome,
 ): Search {
   const minimal: Array<Route> = [];
   let outrightAt: number | undefined;
-  for (const hits of ordered) {
-    const isRedundant = minimal.some(
-      (found) => (found.hits & hits) === found.hits,
-    );
-    if (isRedundant && outrightAt != null) continue;
-    const outcome = outcomeOf(hits);
-    if (outcome.verdict.kind === "loss") continue;
-    if (outcome.verdict.kind === "win" && outrightAt == null) {
-      outrightAt = bitCount(hits);
+  for (const [size, bucket] of ordered.entries()) {
+    for (const hits of bucket) {
+      const isRedundant = minimal.some(
+        (found) => (found.hits & hits) === found.hits,
+      );
+      if (isRedundant && outrightAt != null) continue;
+      const outcome = outcomeOf(hits);
+      if (outcome.verdict.kind === "loss") continue;
+      if (outcome.verdict.kind === "win" && outrightAt == null) {
+        outrightAt = size;
+      }
+      if (!isRedundant) minimal.push({ hits, outcome });
     }
-    if (!isRedundant) minimal.push({ hits, outcome });
   }
   return { minimal, outrightAt };
 }
@@ -632,20 +711,6 @@ export default function getPlayerAnalysis(
     gains: gainsFor(rival.index, contested, coverers),
   }));
   const isMondayNightSettled = scores.tiebreaker != null;
-  const verdicts = new Map<number, ReturnType<typeof evaluate>>();
-  const read = (outcome: number) => {
-    const held = verdicts.get(outcome);
-    if (held != null) return held;
-    const verdict = evaluate(
-      player,
-      gains,
-      scoredRivals,
-      outcome,
-      isMondayNightSettled,
-    );
-    verdicts.set(outcome, verdict);
-    return verdict;
-  };
 
   let mineMask = 0;
   let luckMask = 0;
@@ -654,10 +719,25 @@ export default function getPlayerAnalysis(
     else luckMask |= 1 << bit;
   });
 
-  const ordered = subMasks(mineMask)
-    .map((mask) => ({ mask, bits: bitCount(mask) }))
-    .sort((a, b) => a.bits - b.bits || a.mask - b.mask)
-    .map((counted) => counted.mask);
+  // A player who picked every open game has one way each set of their picks can
+  // land, so every outcome is read once and holding them costs more than it saves.
+  const verdicts =
+    luckMask === 0 ? undefined : new Map<number, ReturnType<typeof evaluate>>();
+  const read = (outcome: number) => {
+    const held = verdicts?.get(outcome);
+    if (held != null) return held;
+    const verdict = evaluate(
+      player,
+      gains,
+      scoredRivals,
+      outcome,
+      isMondayNightSettled,
+    );
+    verdicts?.set(outcome, verdict);
+    return verdict;
+  };
+
+  const ordered = subMasksBySize(mineMask);
   const luckOutcomes = subMasks(luckMask);
 
   // Held against the player first, so a route that survives every way the games

--- a/src/utils/scoring/getPlayerAnalysis.ts
+++ b/src/utils/scoring/getPlayerAnalysis.ts
@@ -18,12 +18,13 @@ import remainingGames, {
  * ones are searched, and the search doubles per one, so this is a loose ceiling.
  *
  * Set by what a phone can hold the thread for, since the search holds it while it
- * runs. `scoring.bench.ts` measures a move of this number: at fifteen its worst
- * week answers in about 50ms on an M-series laptop, fourteen in 24ms, and every
- * game added from here roughly doubles the last. A week above the ceiling still
- * names its must-win games, which `provenMustWin` reads without a search.
+ * runs. `scoring.bench.ts` measures a move of this number, and at sixteen its
+ * worst week answers in about 18ms on an M-series laptop. The same week in
+ * Chromium under CPU throttling, which is how a phone is read from a laptop,
+ * answers in 63ms at 4x and 147ms at 10x. A week above the ceiling still names
+ * its must-win games, which `provenMustWin` reads without a search.
  */
-export const MAX_SEARCHED_GAMES = 15;
+export const MAX_SEARCHED_GAMES = 16;
 
 /** How many routes are carried before the rest are only counted. */
 const MAX_LISTED_ROUTES = 8;

--- a/src/utils/scoring/getPlayerAnalysis.ts
+++ b/src/utils/scoring/getPlayerAnalysis.ts
@@ -9,7 +9,6 @@ import { PlayerScore, RakMadnessScores } from "../../types/RakMadnessScores";
 import { comparePlayerScoresOnMerit } from "./comparePlayerScores";
 import isWinnerDecided from "./isWinnerDecided";
 import remainingGames, {
-  PickDifference,
   pickDifference,
   RemainingGame,
 } from "./remainingGames";
@@ -22,7 +21,7 @@ import remainingGames, {
  * runs. `scoring.bench.ts` measures a move of this number: at fifteen its worst
  * week answers in about 50ms on an M-series laptop, fourteen in 24ms, and every
  * game added from here roughly doubles the last. A week above the ceiling still
- * names the must-win games, which cost a walk of the players rather than a search.
+ * names its must-win games, which `provenMustWin` reads without a search.
  */
 export const MAX_SEARCHED_GAMES = 15;
 
@@ -257,6 +256,46 @@ function guaranteedVerdict(
 }
 
 /**
+ * How many games a player can leave blank before the ways they can fall stop being
+ * worth a walk. Each one doubles the outcomes the proof below reads.
+ */
+const MAX_UNPICKED_GAMES = 8;
+
+/**
+ * The games no win can do without, proven one game at a time rather than searched.
+ *
+ * Winning one of your own picks never costs you ground. It adds a point in every
+ * tier it touches and denies the rival who picked the other side, so the best a
+ * player can do without a game is to win every other pick they made. A game is
+ * must-win exactly when even that loses, which is one verdict per game where the
+ * search reads one per subset of them.
+ *
+ * Empty rather than partial, in the two cases it can prove nothing about: a player
+ * who cannot take the week on their own picks alone, so they need a game they left
+ * blank to fall their way, and one who left so many blank that the ways they fall
+ * are not worth walking. A list this returns holds every must-win game there is.
+ */
+function provenMustWin(
+  mineMask: number,
+  luckOutcomes: Array<number>,
+  read: (outcome: number) => Verdict,
+  contested: Array<RemainingGame>,
+  playerIndex: number,
+): Array<RemainingPick> {
+  if (guaranteedVerdict(mineMask, luckOutcomes, read).kind === "loss") {
+    return [];
+  }
+  return contested.flatMap((game, bit) => {
+    const mask = 1 << bit;
+    if ((mineMask & mask) === 0) return [];
+    const without = guaranteedVerdict(mineMask & ~mask, luckOutcomes, read);
+    return without.kind === "loss"
+      ? [{ label: game.label, pick: game.cells[playerIndex].text }]
+      : [];
+  });
+}
+
+/**
  * The best those same picks can do once the games the player left blank are allowed
  * to fall their way, and the way they have to fall, which is where `needsHelp` comes
  * from.
@@ -373,72 +412,23 @@ function fewestWinsToCatch(
   return onOwn > playerOnly ? undefined : onDifferent + onOwn;
 }
 
-/** One rival, as the arithmetic above reads them. */
-type Measured = { index: number; gap: number; against: PickGap };
-
-/** The same rival once one of the player's games is written off as lost. */
-function withoutGame(rival: Measured, difference: PickDifference): Measured {
-  const { opposed, playerOnly } = rival.against;
-  // An opposed game hands its point to the rival, so the gap grows by one and the
-  // swing left to close it shrinks. A game only the player picked is a point they
-  // simply do not take.
-  return difference === "opposed"
-    ? {
-        ...rival,
-        gap: rival.gap + 1,
-        against: { opposed: opposed - 1, playerOnly },
-      }
-    : { ...rival, against: { opposed, playerOnly: playerOnly - 1 } };
-}
-
-/**
- * The games the player cannot afford to lose, on the arithmetic `minimumWins` runs.
- *
- * A game is here when losing it puts a rival out of reach. `fewestWinsToCatch` is
- * a floor, optimistic about the rival, so a game it calls unaffordable really is
- * one. It can miss a game a full search would catch, which is the safe direction:
- * a week too big to search names must-win games it can prove and no others.
- */
-function mustWinGames(
-  playerIndex: number,
-  rivals: Array<Measured>,
-  games: Array<RemainingGame>,
-): Array<RemainingPick> {
-  return games
-    .filter((game) =>
-      rivals.some((rival) => {
-        const difference = pickDifference(game, playerIndex, rival.index);
-        // The player left it blank, or the two picked the same team, so the game
-        // moves both scores together and cannot put anyone out of reach.
-        if (difference === "none") return false;
-        const lost = withoutGame(rival, difference);
-        return fewestWinsToCatch(lost.against, lost.gap, false) == null;
-      }),
-    )
-    .map((game) => ({
-      label: game.label,
-      pick: game.cells[playerIndex].text,
-    }));
-}
-
 function headline(
   player: PlayerScore,
   playerIndex: number,
   rivals: Array<{ player: PlayerScore; index: number }>,
   games: Array<RemainingGame>,
+  mustWin: Array<RemainingPick>,
 ): PlayerAnalysis {
-  const measured: Array<Measured> = rivals.map((rival) => ({
-    index: rival.index,
-    gap: rival.player.score.total - player.score.total,
-    // Read once and handed on. The targets below and the must-win walk all ask
-    // the same question of what the two players have left to differ on.
-    against: countAgainst(playerIndex, rival.index, games),
-  }));
-  const counts = measured.map((rival) => ({
-    // The two targets differ only by the point that clears a draw.
-    toLevel: fewestWinsToCatch(rival.against, rival.gap, false),
-    toClear: fewestWinsToCatch(rival.against, rival.gap, true),
-  }));
+  const counts = rivals.map((rival) => {
+    const gap = rival.player.score.total - player.score.total;
+    // Both targets read off one walk. They differ only by the point that clears a
+    // draw, never in what the two players have left to differ on.
+    const against = countAgainst(playerIndex, rival.index, games);
+    return {
+      toLevel: fewestWinsToCatch(against, gap, false),
+      toClear: fewestWinsToCatch(against, gap, true),
+    };
+  });
 
   // `toLevel` is only absent where `applyKnockouts` has already knocked the player
   // out on total score, which `getPlayerAnalysis` answers before reaching here.
@@ -458,7 +448,7 @@ function headline(
     needsMondayNight: counts.some(
       (count) => count.toClear == null || count.toClear > minimumWins,
     ),
-    mustWin: mustWinGames(playerIndex, measured, games),
+    mustWin,
   };
 }
 
@@ -686,13 +676,9 @@ export default function getPlayerAnalysis(
   const { playerIndex, player, rivals } = settled;
   const players = scores.scores;
 
+  const games = remainingGames(players);
   // A game every live player picked the same way moves all their scores together,
   // in the total and in both tiebreaker tiers, so it cannot change the order.
-  const games = remainingGames(players);
-  if (games.length > MAX_SEARCHED_GAMES) {
-    return headline(player, playerIndex, rivals, games);
-  }
-
   const live = [playerIndex, ...rivals.map((it) => it.index)];
   const contested = games.filter(
     (game) => new Set(live.map((index) => game.cells[index].team)).size > 1,
@@ -737,6 +723,22 @@ export default function getPlayerAnalysis(
     verdicts?.set(outcome, verdict);
     return verdict;
   };
+
+  // Above the ceiling the week is answered off the floor, plus the must-win games
+  // the outcomes above prove, which cost a verdict each rather than a search.
+  if (games.length > MAX_SEARCHED_GAMES) {
+    const isWalkable = bitCount(luckMask) <= MAX_UNPICKED_GAMES;
+    const mustWin = isWalkable
+      ? provenMustWin(
+          mineMask,
+          subMasks(luckMask),
+          read,
+          contested,
+          playerIndex,
+        )
+      : [];
+    return headline(player, playerIndex, rivals, games, mustWin);
+  }
 
   const ordered = subMasksBySize(mineMask);
   const luckOutcomes = subMasks(luckMask);

--- a/src/utils/scoring/getPlayerAnalysis.ts
+++ b/src/utils/scoring/getPlayerAnalysis.ts
@@ -18,10 +18,11 @@ import remainingGames, {
  * The most games still to play the routes are worked out for. Only the contested
  * ones are searched, and the search doubles per one, so this is a loose ceiling.
  *
- * Set by what a phone can hold the thread for. At fifteen the worst row of an
- * eighty-player week is tens of milliseconds on a laptop, and every game past it
- * doubles that. A week above it still names the must-win games, which cost a walk
- * of the players rather than a search.
+ * Set by what a phone can hold the thread for, since the search holds it while it
+ * runs. `scoring.bench.ts` measures a move of this number: at fifteen its worst
+ * week answers in about 50ms on an M-series laptop, fourteen in 24ms, and every
+ * game added from here roughly doubles the last. A week above the ceiling still
+ * names the must-win games, which cost a walk of the players rather than a search.
  */
 export const MAX_SEARCHED_GAMES = 15;
 

--- a/src/utils/scoring/pushEquivalence.test.ts
+++ b/src/utils/scoring/pushEquivalence.test.ts
@@ -1,0 +1,92 @@
+import {
+  PickResult,
+  PlayerScore,
+  RakMadnessScores,
+} from "../../types/RakMadnessScores";
+import getPlayerAnalysis from "./getPlayerAnalysis";
+
+/**
+ * A game the player left blank is held to its push rather than walked both ways,
+ * which `getPlayerAnalysis` explains and this holds to.
+ *
+ * The same week is built twice, once on a whole line a margin can land on and once
+ * half a point off it. Nothing else about the two differs, so every answer has to
+ * match. A week is read at random because the property is about every shape of
+ * week, not one, and the generator is seeded so a failure repeats.
+ */
+
+const WEEKS = 200;
+const PLAYERS = 6;
+const GAMES = 8;
+/** How often a row leaves a game blank, which is what puts games in the walk. */
+const BLANK_RATE = 0.25;
+
+const TEAMS = ["KC", "BUF", "SF", "DAL", "PHI", "NYG", "BAL", "CIN"];
+
+function pick(text: string): PickResult {
+  return {
+    pick: text,
+    status: "incomplete",
+    explanation: { header: "", message: "" },
+  };
+}
+
+/** A linear congruential generator, so a seed reads the same week every run. */
+function seeded(seed: number) {
+  let state = seed;
+  return () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    return state / 0x7fffffff;
+  };
+}
+
+function randomWeek(seed: number, line: string): RakMadnessScores {
+  const rand = seeded(seed);
+  const sides = Array.from({ length: GAMES }, (_unused, game) => [
+    TEAMS[(game * 2) % TEAMS.length],
+    TEAMS[(game * 2 + 1) % TEAMS.length],
+  ]);
+  const scores: Array<PlayerScore> = Array.from(
+    { length: PLAYERS },
+    (_unused, index) => ({
+      name: `P${index}`,
+      score: {
+        total: Math.floor(rand() * 5),
+        college: 0,
+        pro: 0,
+        proAgainstTheSpread: 0,
+      },
+      tiebreaker: { pick: 30 + Math.floor(rand() * 20) },
+      college: [],
+      pro: sides.map(([home, away]) =>
+        rand() < BLANK_RATE
+          ? pick("")
+          : pick(`${rand() < 0.5 ? home : away} ${line}`),
+      ),
+      status: { hasNoPicks: false, isKnockedOut: false },
+    }),
+  );
+  return { scores };
+}
+
+/** An answer with the cells dropped, since those carry the line that differs. */
+function withoutPicks(result: unknown): string {
+  return JSON.stringify(result, (key, value) =>
+    key === "pick" && typeof value === "string" ? "" : value,
+  );
+}
+
+describe("a blank game held to its push", () => {
+  it("answers a week the way a walk of both sides does", () => {
+    for (let seed = 1; seed <= WEEKS; seed++) {
+      const held = randomWeek(seed, "-3");
+      const walked = randomWeek(seed, "-3.5");
+      for (const player of held.scores) {
+        expect(
+          withoutPicks(getPlayerAnalysis(held, player.name)),
+          `week ${seed}, ${player.name}`,
+        ).toBe(withoutPicks(getPlayerAnalysis(walked, player.name)));
+      }
+    }
+  });
+});

--- a/src/utils/scoring/remainingGames.ts
+++ b/src/utils/scoring/remainingGames.ts
@@ -12,6 +12,12 @@ type Cell = {
 export type RemainingGame = {
   label: string;
   league: LeagueKey;
+  /**
+   * Whether the game can land on its own line, which scores it for both sides at
+   * once. True where the line is a whole number, and where there is none at all,
+   * since a straight pick does the same on a tie.
+   */
+  canPush: boolean;
   /** Every row's cell, in the order the scores hold their players. */
   cells: Array<Cell>;
 };

--- a/src/utils/scoring/scoring.bench.ts
+++ b/src/utils/scoring/scoring.bench.ts
@@ -8,7 +8,7 @@ import {
   benchResults,
   WeekPhase,
 } from "./benchFixtures";
-import getPlayerAnalysis from "./getPlayerAnalysis";
+import getPlayerAnalysis, { MAX_SEARCHED_GAMES } from "./getPlayerAnalysis";
 import { getPlayerScores } from "./getPlayerScores";
 import getTiebreakerScore from "./getTiebreakerScore";
 import isEveryGameSettled from "./isEveryGameSettled";
@@ -48,6 +48,7 @@ function weekAt(phase: WeekPhase) {
 const kickoff = weekAt("kickoff");
 const sundayNight = weekAt("sundayNight");
 const settled = weekAt("settled");
+const atSearchLimit = weekAt(MAX_SEARCHED_GAMES);
 
 describe("getPlayerScores, end to end", () => {
   const run = (phase: WeekPhase) => async () => {
@@ -100,5 +101,18 @@ describe("getPlayerAnalysis", () => {
   });
   bench("settled", () => {
     getPlayerAnalysis(settled.scores, chased);
+  });
+  // The dialog's ceiling: as many games open as the routes are worked out for, so
+  // this is the slowest answer a reader can ask for, and what moving
+  // `MAX_SEARCHED_GAMES` is measured on.
+  bench("at the search limit", () => {
+    getPlayerAnalysis(
+      atSearchLimit.scores,
+      atSearchLimit.scores.scores[10].name,
+    );
+  });
+  // A game more than the limit, which answers off a walk of the players instead.
+  bench("above the search limit", () => {
+    getPlayerAnalysis(kickoff.scores, kickoff.scores.scores[10].name);
   });
 });

--- a/src/utils/scoring/weekShape.ts
+++ b/src/utils/scoring/weekShape.ts
@@ -52,14 +52,25 @@ export default function weekShape(players: Array<PlayerScore>): WeekShape {
         if (isOpen && isHole) break;
       }
       if (isOpen) {
+        const picks = players.map((player) => {
+          const text = player[league][index].pick ?? "";
+          return { text, ...parsePick(text) };
+        });
         remaining.push({
           label: labels[index],
           league,
-          cells: players.map((player) => {
-            const text = player[league][index].pick ?? "";
-            const { teamAbbreviation, spread } = parsePick(text);
-            return { team: teamAbbreviation, hasSpread: spread !== 0, text };
-          }),
+          // A pick scores on a margin of zero or better, so a whole-number line is
+          // one the margin can land exactly on, and both sides take the point.
+          // Half a point rules that out. Read off any row that wrote the line,
+          // since `validateSpreads` holds a column to one.
+          canPush: Number.isInteger(
+            picks.find((pick) => pick.spread !== 0)?.spread ?? 0,
+          ),
+          cells: picks.map(({ teamAbbreviation, spread, text }) => ({
+            team: teamAbbreviation,
+            hasSpread: spread !== 0,
+            text,
+          })),
         });
       }
       if (isHole) unscoreable.push(labels[index]);


### PR DESCRIPTION
## What

Player analysis works out the paths to victory from sixteen open games, not ten. Above that ceiling it names the must-win games rather than a bare floor.

## Why

Ten was never measured. The search costs about 2ms there, so a reader saw a floor most of the week. Cost doubles per open game.

## Changes

- Hold a game the player left blank to its push rather than walk both sides. A push lifts every rival and the player not at all, and the walk already held the side each rival scores on. Same answer, 3.3x faster.
- Set the ceiling at sixteen. The worst week answers in 18ms on an M-series laptop, and in 63ms at 4x CPU throttling and 147ms at 10x.
- Name the must-win games above the ceiling. A win never costs a player ground, so the best without a game is every other pick. It is must-win when even that loses.
- Read a win as one condition. Each block after the first opens with `And`, and the MNF Points block holds its numbers in its own title.
- Bucket the search's masks by size instead of a sort.

## Screenshots

| Above the ceiling | One pool, then the points | Must win, a pool, the points |
| --- | --- | --- |
| ![the floor and the must-win games](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/analysis-limit/analysis-headline.png) | ![a pool and the tiebreaker](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/analysis-limit/analysis-paths.png) | ![three blocks](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/analysis-limit/analysis-chain.png) |

| A total per route | A blank game | Dark |
| --- | --- | --- |
| ![routes](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/analysis-limit/analysis-routes.png) | ![out of your hands](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/analysis-limit/analysis-help.png) | ![the same three blocks in dark mode](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/analysis-limit/analysis-chain-dark.png) |

| Clinched | Clinched a share | Knocked out |
| --- | --- | --- |
| ![a week already won](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/analysis-limit/analysis-clinched.png) | ![two players no game can part](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/analysis-limit/analysis-clinchedTie.png) | ![a player who cannot win](https://raw.githubusercontent.com/crombach/rak-madness-calculator/pr-assets/analysis-limit/analysis-knockedOut.png) |

## Verification

Ran `make bench`, then the same week in Chromium under CPU throttling. CI runs neither.

## Notes

A push on a game the player picked scores for the opposing rival too, which the model does not read. Closing that gap tells nobody they are live, so `getPlayerAnalysis` states it instead.

🕵️ Handled by [Agent Juni Cortez](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
