### PR TITLE
docs: rewrite every comment and agent-facing file to the writing guide

### DIFF
--- a/.claude/hooks/build_hint.py
+++ b/.claude/hooks/build_hint.py
@@ -2,12 +2,12 @@
 """PreToolUse hook: point Claude at the repo's build-run-test skill.
 
 Pairs with the agentify-build skill. The skill holds what a Makefile target name
-cannot carry — toolchain versions, ports, prereqs, offline-test handling — and a
-skill only loads when the model picks it. This hook makes that pick deterministic:
+cannot carry: toolchain versions, ports, prereqs, offline-test handling. A skill
+only loads when the model picks it. This hook makes that pick deterministic:
 before the first build-shaped Bash command of a session it injects one line naming
 the skill.
 
-Never blocks. The command runs either way; the hook only adds context.
+Never blocks. The command runs either way. The hook only adds context.
 
 Fires once per session, keyed on session_id, so a build-fix loop costs one
 reminder. Silent when the skill is absent, when the command is not build-shaped,
@@ -60,7 +60,7 @@ PYTHON_MODULES = {"pytest", "unittest", "build", "tox", "nox", "py_compile"}
 
 SEPARATORS = re.compile(r"&&|\|\||;|\||&|\n")
 ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
-# Wrappers Claude Code strips before matching; strip them here for the same reason.
+# Wrappers Claude Code strips before matching. Strip them here for the same reason.
 WRAPPERS = {"timeout", "time", "nice", "nohup", "stdbuf", "command", "builtin",
             "noglob", "xargs", "env", "sudo"}
 DURATION = re.compile(r"^\d+(\.\d+)?[smhd]?$")

--- a/.claude/hooks/check_conventions.py
+++ b/.claude/hooks/check_conventions.py
@@ -44,7 +44,7 @@ ISSUE_PATTERN = re.compile(r"^[a-z]+(?:\([^()\s]+\))?!?: \[([^\]\s]+)\]",
                            re.IGNORECASE)
 
 TEMPLATE = os.path.join(".github", "pull_request_template.md")
-# The template says so in its own comments; the hook only enforces what it finds.
+# The template says so in its own comments. The hook only enforces what it finds.
 PUNCTUATION_RULE = "No em-dashes, no semicolons"
 # The branch's key is the one ticket a hook can find. Any other ticket the work
 # belongs to is the agent's to link, which is why the skill states the rule too.

--- a/.claude/hooks/claude_md_hook.py
+++ b/.claude/hooks/claude_md_hook.py
@@ -14,7 +14,7 @@ over its upstream. Either way a directory is dropped once the same change touche
 the CLAUDE.md that covers it, so a documented addition never nags.
 
 Deliberately ignores in-place edits to existing files: rewriting a function body
-rarely changes a one-line directory summary. The hook only detects; Claude judges
+rarely changes a one-line directory summary. The hook only detects. Claude judges
 whether the summary actually needs to change and rewrites it.
 
 Self-gating: silent when the command is neither, when cwd is not a git repo, when
@@ -63,7 +63,7 @@ def emit(context):
 
 def working_tree_changes(root):
     """(paths added, CLAUDE.md paths touched) in the working tree."""
-    # -z avoids porcelain's quoting of unusual paths; a rename or copy entry
+    # -z avoids porcelain's quoting of unusual paths. A rename or copy entry
     # carries its source path as an extra NUL-separated field.
     fields = git(root, "status", "--porcelain", "-z",
                  "--untracked-files=all").split("\0")
@@ -174,7 +174,7 @@ def main():
         file_dir = os.path.join(root, rel_dir) if rel_dir else root
         nearest = nearest_claude_md(file_dir, root)
         if nearest is None:
-            continue  # no CLAUDE.md tree here; skill hasn't been run
+            continue  # no CLAUDE.md tree here. Skill hasn't been run
         rel_md = os.path.relpath(nearest, root)
         if rel_md in touched_md:
             continue  # already answered for, in this same change

--- a/.claude/scripts/lint_claude_md.py
+++ b/.claude/scripts/lint_claude_md.py
@@ -31,8 +31,8 @@ indexed. Pass-through directories (no direct files of their own, any number of
 children, e.g. `skills/` or a Java/Kotlin package prefix) are collapsed: they get
 no CLAUDE.md and parents link through them.
 
-File scope comes from `git ls-files` when available (respects .gitignore and lists
-only tracked files); otherwise it falls back to os.walk with a skip list.
+File scope comes from `git ls-files` when available, which respects .gitignore and
+lists only tracked files. Otherwise it falls back to os.walk with a skip list.
 """
 
 import json
@@ -142,7 +142,7 @@ def build(root):
     def depth(d):
         return 0 if d == "" else d.count(os.sep) + 1
 
-    # Deepest first; path as a stable tiebreaker so output is deterministic
+    # Deepest first. Path is used as a stable tiebreaker so output is deterministic
     # (all_dirs is a set, whose iteration order varies with hash seeding).
     ordered = sorted(all_dirs, key=lambda d: (-depth(d), d))
 
@@ -181,7 +181,7 @@ def build(root):
             continue
         kids = sorted({k for c in children[d] if meaningful[c] for k in resolve(c)})
         abs_dir = root if d == "" else os.path.join(root, d)
-        # Precomputed markdown link parts, relative to this dir; collapsed
+        # Precomputed markdown link parts, relative to this dir. Collapsed
         # pass-through chains make these multi-segment (kotlin/com/yahoo/...).
         child_links = [
             {
@@ -212,7 +212,7 @@ def structure_findings(root):
     """Where the tree on disk does not match the plan.
 
     Companion to the duplication check. That one catches a parent repeating a
-    child's summary; this one catches a parent not linking the child at all,
+    child's summary. This one catches a parent not linking the child at all,
     which is what breaks navigation.
     """
     tree = build(root)
@@ -282,7 +282,7 @@ def report_structure(root):
 MAX_POINTER_CHARS = 70
 # Word-overlap (Jaccard) at or above this between pointer and child summary =
 # near-copy. A correct short pointer reuses the child's role words (child leads
-# with the same phrase), so a subset alone is fine; only high overlap = a copy.
+# with the same phrase), so a subset alone is fine. Only high overlap = a copy.
 JACCARD_FLAG = 0.6
 
 # - [`child/`](child/CLAUDE.md) — description text
@@ -422,7 +422,7 @@ LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
 def counted_lines(text):
     """The lines that count toward the ceiling, in order.
 
-    A heading at level 1 or 2 opens or closes an exemption; deeper headings stay
+    A heading at level 1 or 2 opens or closes an exemption. Deeper headings stay
     inside whatever section they belong to.
 
     No heading counts, at any level. A section title is navigation rather than

--- a/.claude/skills/build-run-test/SKILL.md
+++ b/.claude/skills/build-run-test/SKILL.md
@@ -68,14 +68,14 @@ The scoring path logs through `src/utils/debugLog.ts`, which is silent when the 
 - `.wrangler/` is in the ESLint ignore list. It holds generated bundles that fail every rule.
 - `make format` runs `eslint --fix`, then prettier. That order matters. ESLint's fixes are not prettier-clean, so the formatter has to run last or `make check` fails right after `make format`.
 - Two tsconfigs, and root excludes `functions/**/*`, so `make typecheck` runs `tsc` twice. Both set `strict: true` explicitly, because TypeScript 6 changed the default and leaving it implicit hides which behavior is intended.
-- `src/vite-env.d.ts` carries the `vite/client` and `vitest/globals` references. Don't move them into `compilerOptions.types`: that switches off automatic `@types` inclusion and VS Code reports the entry point as missing.
+- `src/vite-env.d.ts` carries the `vite/client` and `vitest/globals` references. Don't move them into `compilerOptions.types`. That switches off automatic `@types` inclusion and VS Code reports the entry point as missing.
 - `.vscode/settings.json` points the editor at the workspace TypeScript. VS Code bundles 5.x and misreads a TypeScript 6 config.
 
 ## Cloudflare Pages, not wrapped in make
 
 **Nothing in this repo deploys.** There is no deploy script, and adding one would create a second path to production that ignores the settings Cloudflare's own build uses. wrangler is here for local testing only. `README.md` carries the mechanism.
 
-- `npm run pages:dev` builds, then runs `wrangler pages dev ./build --port 3000`. Verified on wrangler 4: `/` serves 200, the Pages Function executes, assets serve. This is the supported form; the older `pages dev -- <command>` proxy form is deprecated and gone from this repo.
+- `npm run pages:dev` builds, then runs `wrangler pages dev ./build --port 3000`. Verified on wrangler 4: `/` serves 200, the Pages Function executes, assets serve. This is the supported form. The older `pages dev -- <command>` proxy form is deprecated and gone from this repo.
 - `pages:dev` serves a build, so there is no hot reload. Two workflows, on purpose: `make run` for iterating on the UI, `pages:dev` for anything touching the Function or the binding. Rerun it to pick up a code change.
 - No make target wraps `pages:dev` because it needs Cloudflare context that `make` targets deliberately stay out of.
 - `wrangler.toml` holds `name = "rak-sadness"` (the real Pages project, which Cloudflare cannot rename), `compatibility_date`, and the `RAK_MADNESS_BUCKET` R2 binding pointing at the `rak-madness-calculator` bucket. It configures `pages dev` and nothing else. The same binding has to exist on the Pages project itself, for preview and production both.

--- a/.claude/skills/build-run-test/SKILL.md
+++ b/.claude/skills/build-run-test/SKILL.md
@@ -14,7 +14,7 @@ description: How to build, run, and test this repo. Read before any npm, make, t
 - Vite 8, React 19, TypeScript 6, Vitest 4, ESLint 9 flat config, wrangler 4.
 - Base UI for behavior, react-router 8 for routing, SCSS for looks. There is no theme provider. `src/CLAUDE.md` covers the `--rak-*` design tokens, `src/styles/CLAUDE.md` the Sass mixins, `src/components/icon/CLAUDE.md` the icons.
 - Node `v22.23` (`.nvmrc`), npm 10 (`lockfileVersion: 3`). `nvm use` before anything. wrangler 4 refuses to run on Node 20, and jsdom 30 needs `>=22.22.2`, which is why the pin carries a minor. `make setup` fails with an actionable message on an older Node or another major.
-- Three CI signals on a PR: `check` (`.github/workflows/check.yml`) runs the same `make check` you run locally, `conventional-commit-title` (`.github/workflows/pr-title.yml`) matches the title format, and `Cloudflare Pages` builds from git using the dashboard's own settings. Break `make check` locally and CI breaks the same way.
+- CI signals on a PR: `check` (`.github/workflows/check.yml`) runs the same `make check` you run locally, `conventional-commit-title` (`.github/workflows/pr-title.yml`) matches the title format, and `Cloudflare Pages` builds from git using the dashboard's own settings. Break `make check` locally and CI breaks the same way.
 
 ## Verified
 
@@ -24,9 +24,9 @@ From a clean checkout: `make setup`, `make build`, `make run`, `make test`, `mak
 
 ## Tests
 
-Every suite sits beside the module it covers, and they all run offline. `npm test` is `vitest run`; `npm run test:watch` watches.
+Every suite sits beside the module it covers, and they all run offline. `npm test` is `vitest run`. `npm run test:watch` watches.
 
-Three suites at `src/` mount the routed app, each on its own axis, and each mocks `getPlayerScores` wholesale so none of them re-exercise scoring:
+Suites at `src/` mount the routed app, each on its own axis, and each mocks `getPlayerScores` wholesale so none of them re-exercise scoring:
 
 - `src/App.picks.test.tsx` — first load, the season and week pickers, the picks fetch, and upload.
 - `src/App.routes.test.tsx` — which week a `/:season/:week` URL fetches, and what shows while it does.
@@ -44,8 +44,8 @@ Writing a test here:
 - `getLeagueInfo` also caches week counts in a module-level `Map` that no reset clears, so a case that counts calendar requests needs a season number no other case in the file uses. The existing ones use 3001 upward.
 - `mountLoadedApp` waits for the home controls, so it only works for URLs that land on `/`. Deep-link cases use `mountApp` and await something on the results route.
 - The week `Select` compares option values by reference, so a fixture's `activeWeek` must be the same object as its entry in `weeks`.
-- Don't name a helper `render*` unless it returns the render result — `testing-library/render-result-naming-convention` is an error, not a warning.
-- `testing-library/no-node-access` is off for test files (`eslint.config.js` override): the file input is hidden and the navbar buttons are only identifiable by class. `testing-library/no-container` is on, so reach for `screen` queries.
+- Don't name a helper `render*` unless it returns the render result. `testing-library/render-result-naming-convention` is an error, not a warning.
+- `testing-library/no-node-access` is off for test files (`eslint.config.js` override). The file input is hidden and the navbar buttons are only identifiable by class. `testing-library/no-container` is on, so reach for `screen` queries.
 - `mockReset` is on in `vite.config.ts`. Set mock implementations in `beforeEach`, not at module scope.
 - A `waitFor` or `findBy` gets 5s, raised from the 1s default in `src/setupTests.ts`, and a test gets 15s (`testTimeout`). The app suites mount the whole app and wait on chained promises, which outran 1s on a loaded CI runner. Keep the test limit the larger of the two, so a wait that never resolves fails on its own assertion.
 - `src/setupTests.ts` shims a `jest` global. `@testing-library/dom` looks for it to decide whether fake timers are installed, and without it every interaction in a `vi.useFakeTimers()` suite times out. Don't remove it.
@@ -61,12 +61,12 @@ The scoring path logs through `src/utils/debugLog.ts`, which is silent when the 
 - Vite does not open a browser, so there is no `BROWSER=none` to set. `make run PORT=3001` moves the port, which is how you get two dev servers side by side. `strictPort` is on, so a busy port fails instead of silently sliding to the next one.
 - Sass prints deprecation warnings on compile. Noise, not breakage.
 - Breakpoints are Sass mixins. `src/styles/CLAUDE.md` names them and how to reach them.
-- `make check` does not build. Sass errors, an undefined mixin among them, surface only in `npm run build`, because `css: false` keeps stylesheets out of the test run. Run both before pushing a change to any stylesheet.
+- `make check` does not build. Sass errors, an undefined mixin among them, surface only in `npm run build`. Because `css: false` keeps stylesheets out of the test run. Run both before pushing a change to any stylesheet.
 - Never drop `viewport-fit=cover` or `interactive-widget=resizes-content` from `index.html`'s viewport meta. The comment above them names what breaks.
 - One ESLint config: `eslint.config.js` (flat). It names its plugins directly. `package.json` has no `eslintConfig` key and there is no `.eslintrc.json`.
 - `import/no-unresolved` is off. `tsc` already resolves modules for both tsconfigs, and the import plugin misreads ESM exports maps without its own resolver.
 - `.wrangler/` is in the ESLint ignore list. It holds generated bundles that fail every rule.
-- `make format` runs `eslint --fix`, then prettier. That order matters: eslint's fixes are not prettier-clean, so the formatter has to run last or `make check` fails right after `make format`.
+- `make format` runs `eslint --fix`, then prettier. That order matters. ESLint's fixes are not prettier-clean, so the formatter has to run last or `make check` fails right after `make format`.
 - Two tsconfigs, and root excludes `functions/**/*`, so `make typecheck` runs `tsc` twice. Both set `strict: true` explicitly, because TypeScript 6 changed the default and leaving it implicit hides which behavior is intended.
 - `src/vite-env.d.ts` carries the `vite/client` and `vitest/globals` references. Don't move them into `compilerOptions.types`: that switches off automatic `@types` inclusion and VS Code reports the entry point as missing.
 - `.vscode/settings.json` points the editor at the workspace TypeScript. VS Code bundles 5.x and misreads a TypeScript 6 config.

--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -12,7 +12,7 @@ description: This repo's commit and PR conventions. Read before writing any git 
 - PR body length: under 256 words, bullets one line each. Only what a reviewer needs to review the diff. No ticket retelling, no history, no counts or benchmark numbers, no per-file walkthrough, no self-assessment. Headings, an attribution footer, embedded screenshots and recordings don't count against the budget.
 - Commit body: only a why subject can't carry.
 - Prose in a subject, commit body, or PR body: the ASD-STE100 rules `.github/pull_request_template.md` lists. The hook reads them off that file at runtime.
-- Hook denies, never warns: the header format, the branch's ticket key opening the summary, a PR body built from the template with no leftover guidance comments and no empty sections, a body link to the branch's ticket, an em-dash, en-dash or semicolon in a PR body, the PR body word budget, and three prose rules over a subject, a `-m` body and a PR body: the 20-word sentence cap, a long word with a short swap, an `-ing` form used as a noun.
+- Hook denies, never warns: the header format, the branch's ticket key opening the summary, a PR body built from the template with no leftover guidance comments and no empty sections, a body link to the branch's ticket, an em-dash, en-dash or semicolon in a PR body, the PR body word budget, and prose rules over a subject, a `-m` body and a PR body: the 20-word sentence cap, a long word with a short swap, an `-ing` form used as a noun.
 - Yours to judge: every other template rule, active voice, tense, noun clusters, American spellings, and every ticket the branch does not name.
 - Enforced by `.claude/hooks/check_conventions.py`, `.github/workflows/pr-title.yml`.
 - No bypass. Rewrite text, don't work around hook.

--- a/.claude/skills/parallel-work/SKILL.md
+++ b/.claude/skills/parallel-work/SKILL.md
@@ -18,7 +18,7 @@ One `package.json`, but two TypeScript roots. The root `tsconfig.json` excludes 
 - `src/components/button/` and `src/components/icon/` — the shared primitives. Every other component directory imports one or both, and neither imports anything.
 - `src/components/dialog/` — backs `gameStatus/`, `playerAnalysis/`, and `settings/`.
 - `src/appTestFixtures.tsx` and `src/weekFixtures.ts` — two fixture hotspots, not one. The three app-mounting suites at `src/` (`App.picks`, `App.routes`, `App.results`) share the first. The second was split out because the first mounts `App`, so `src/hooks/usePlayerScores.test.tsx` and `src/hooks/useWeekRouteGuard.test.tsx` cannot import it at all.
-- `src/setupTests.ts` — 44 lines holding four concerns, not one import line: a raised `asyncUtilTimeout`, a `ResizeObserver` stub, a `matchMedia` stub, and the `jest` global shim.
+- `src/setupTests.ts` — 44 lines holding more than an import line: a raised `asyncUtilTimeout`, a `ResizeObserver` stub, a `matchMedia` stub, and the `jest` global shim.
 - `src/index.scss` and `src/styles/_breakpoints.scss` — the design tokens and the breakpoint mixins. Small and append-mostly.
 - `src/types/` — imported across `src/`, append-mostly, and rarely a conflict.
 - Each `*.test.*` file pairs with one source file, so test work splits the way the source does. Two agents adding suites for different files do not collide.

--- a/.claude/skills/record-demo/SKILL.md
+++ b/.claude/skills/record-demo/SKILL.md
@@ -34,7 +34,7 @@ node .claude/skills/record-demo/scripts/record.js \
   --out <path>.png --screenshot
 ```
 
-Same scenario files work for both; `--screenshot` takes one final-state PNG
+Same scenario files work for both. `--screenshot` takes one final-state PNG
 instead of recording the whole run.
 
 ## Existing scenarios
@@ -71,7 +71,7 @@ Copy an existing one under `scenarios/`. A scenario is a default-exported
 1. Calls `registerAppMocks(context, { season, week, xlsxBuffer, events })`
    from `lib/mocks.js`, so the real app renders against fixture data instead
    of the network. `buildPicksWorkbook(rows)` builds the xlsx `route.fulfill`
-   serves for `/api/picks/:season/:week`; `makeGame(...)` builds one ESPN
+   serves for `/api/picks/:season/:week`. `makeGame(...)` builds one ESPN
    scoreboard event for `events()` to return.
 2. Navigates and drives `page` with normal Playwright calls.
 

--- a/.claude/skills/record-demo/scripts/lib/browser.js
+++ b/.claude/skills/record-demo/scripts/lib/browser.js
@@ -31,9 +31,9 @@ export async function launchDemo({
     : await mkdtemp(path.join(tmpdir(), "record-demo-"));
   const context = await browser.newContext({
     viewport,
-    // A phone rather than a narrow desktop window. Off by default, because it
-    // also turns off every `can-hover` rule, which is what the other scenarios
-    // are capturing. Without it Chromium reports `hover: hover` and
+    // A phone rather than a narrow desktop window. Off by default. It also turns
+    // off every `can-hover` rule, which is what the other scenarios are
+    // capturing. Without it Chromium reports `hover: hover` and
     // `pointer: fine`, so a scenario driving a touch gets no phone-only rules.
     hasTouch: touch,
     isMobile: touch,

--- a/.claude/skills/record-demo/scripts/lib/mocks.js
+++ b/.claude/skills/record-demo/scripts/lib/mocks.js
@@ -132,7 +132,7 @@ export function calendarJson(slug, weeksCount) {
  * tree (`AppDataContextProvider` down) renders against mocked picks and ESPN
  * data instead of the network. Matches the exact request shapes
  * `functions/api/picks/**`, `src/utils/getLeagueInfo.ts`, and
- * `src/utils/getLeagueResults.ts` make; keep this in step with those if their
+ * `src/utils/getLeagueResults.ts` make. Keep this in step with those if their
  * URLs or query params change.
  *
  * @param {import("playwright").BrowserContext} context

--- a/.claude/skills/record-demo/scripts/scenarios/led-indicator.js
+++ b/.claude/skills/record-demo/scripts/scenarios/led-indicator.js
@@ -69,8 +69,8 @@ async function openIn(page, baseUrl, theme, route) {
 }
 
 /**
- * Shows the lamp that says which key in a row is chosen, on both controls that
- * draw one, in both themes.
+ * Shows the lamp that says which key in a row is chosen. It appears on both
+ * controls that draw one, in both themes.
  *
  * The navbar's Scoreboard/Picks switch sits on the darker `--rak-key-face` the
  * bar sets for itself. The settings dialog's theme switch sits on the default

--- a/.claude/skills/record-demo/scripts/scenarios/live-refresh.js
+++ b/.claude/skills/record-demo/scripts/scenarios/live-refresh.js
@@ -128,8 +128,8 @@ export default async function run({ page, context, baseUrl }) {
   await page.waitForSelector("td.table__pick", { timeout: 20000 });
   await page.waitForTimeout(500);
 
-  // Row 0 ranks first already (score ties resolve to insertion order here);
-  // its first `.table__pick` cell is P1, since this fixture has no college
+  // Row 0 ranks first already (score ties resolve to insertion order here).
+  // Its first `.table__pick` cell is P1, since this fixture has no college
   // columns. Click it to open the Game Status dialog on the still-live game.
   const firstPickButton = page
     .locator("tbody tr")
@@ -141,15 +141,15 @@ export default async function run({ page, context, baseUrl }) {
   await page.getByText("Game Status").waitFor({ timeout: 5000 });
   await page.waitForTimeout(1500);
 
-  state.gameOneFinal = true; // the next poll reads this; nothing else pokes the app
+  state.gameOneFinal = true; // The next poll reads this. Nothing else pokes the app
 
   await page.waitForTimeout(POLL_WAIT_MS);
 
   // The dialog's own search-combobox label resets around here (a pre-existing
   // Base UI Combobox quirk: `scores.games` is rebuilt fresh on every scoring
-  // pass, so the combobox's stale item reference stops matching) — orthogonal
-  // to this fix, so close the dialog to end on the table's own updated colors
-  // rather than dwelling on it.
+  // pass, so the combobox's stale item reference stops matching). This is
+  // orthogonal to this fix, so close the dialog to end on the table's own
+  // updated colors rather than dwelling on it.
   await page.getByRole("button", { name: "Close" }).click();
   await page.waitForTimeout(600);
 }

--- a/.claude/skills/record-demo/scripts/scenarios/pull-close-variants.js
+++ b/.claude/skills/record-demo/scripts/scenarios/pull-close-variants.js
@@ -61,8 +61,8 @@ async function pull({ cdp, page, distance, steps }) {
  *
  * The candidate is CSS injected over the running app, read from `$CLOSE_CSS` and
  * `$CLOSE_CSS_SLOW`, so every variant runs against one unmodified build. The slow
- * pass stretches the CSS rather than the clock, because the timer that drops
- * `data-pull` is JavaScript and would cut a stretched transition off mid-flight.
+ * pass stretches the CSS rather than the clock. The timer that drops `data-pull`
+ * is JavaScript and would cut a stretched transition off mid-flight.
  */
 export default async function run({ page, context, baseUrl }) {
   await registerAppMocks(context, {

--- a/.claude/skills/record-demo/scripts/scenarios/pull-to-refresh.js
+++ b/.claude/skills/record-demo/scripts/scenarios/pull-to-refresh.js
@@ -38,7 +38,7 @@ const events = {
 /**
  * Drags one finger down the table and lets go.
  *
- * Chrome DevTools Protocol rather than `page.dispatchEvent`, which builds a
+ * Uses Chrome DevTools Protocol rather than `page.dispatchEvent`. That builds a
  * `Touch` the page can read but the compositor never sees, so `preventDefault`
  * and the scroller do not actually contend. This is a real touch.
  */

--- a/.claude/skills/upload-pr-media/SKILL.md
+++ b/.claude/skills/upload-pr-media/SKILL.md
@@ -11,12 +11,12 @@ bash .claude/skills/upload-pr-media/scripts/upload_pr_media.sh \
 ```
 
 Prints `RESULT: OK` then one `https://raw.githubusercontent.com/...` URL per
-file. Embed it in the PR body: `![before](<url>)` for an image, `<video
-src="<url>" controls></video>` for an `.mp4`/`.webm` (GitHub's markdown
+file. Embed it in the PR body: `![before](<url>)` for an image,
+`<video src="<url>" controls></video>` for an `.mp4`/`.webm` (GitHub's markdown
 renders both).
 
 `--feature` should read like a slug for what the PR is about, not the git
-branch name character for character: readable in a URL, and stable if the
+branch name character for character. Readable in a URL, and stable if the
 branch gets renamed. Reuse the same `--feature` for every file in one PR,
 and reuse it again on a later commit to that PR instead of inventing a new
 name, so a repeat run lands in the same directory rather than scattering it.

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 # misc
 .DS_Store
 
-# Local secrets. Vite reads .env and .env.<mode>; wrangler reads .dev.vars.
+# Local secrets. Vite reads .env and .env.<mode>. wrangler reads .dev.vars.
 # Ignore the whole family rather than naming modes, so a new one cannot slip in.
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Rakulator
 
-Simple auto-scoring web application for [Rak Madness](https://rakmadness.net/). The [public site](https://rak.cullenrombach.com/) is hosted on [CloudFlare Pages](https://developers.cloudflare.com/pages/).
+Simple auto-scoring web application for [Rak Madness](https://rakmadness.net/). The [public site](https://rak.cullenrombach.com/) is hosted on [Cloudflare Pages](https://developers.cloudflare.com/pages/).
 
 Results are viewable on the web and can be exported to an XLSX spreadsheet.
 
 Uses [the hidden ESPN API](https://gist.github.com/akeaswaran/b48b02f1c94f873c6655e7129910fc3b) to fetch game results, and consumes the weekly Rak Madness spreadsheet to do auto-scoring.
-Spreadsheets provided by Rak may require some cleanup before they can be parsed, though an effort has been made to standardize on the ESPN team abbreviations.
+Spreadsheets provided by Rak may require some cleanup before they can be parsed, though the app standardizes on the ESPN team abbreviations.
 
 Here is a [spreadsheet for team abbreviations](https://docs.google.com/spreadsheets/d/1qPdaaXTtnA33izapArCRN--BTNYb-Q0GwhhycJ4dx3w/edit?usp=drivesdk) in both the NFL and NCAA.
 Here is a link to [the Google Drive folder containing historical picks and scores spreadsheets](https://drive.google.com/drive/folders/1oHVWKoAbDtT2vJLU3yBP9ofEOPEzNrqi?usp=sharing).
 
-This was thrown together using KISS principles for a small, family-and-friends football pool. It is not intended for public (or at-scale) use and, as such, should not be judged too harshly.
+This app follows KISS principles for a small, family-and-friends football pool. It is not intended for public (or at-scale) use and, as such, should not be judged too harshly.
 
 ## Development
 
@@ -33,7 +33,7 @@ make format     # eslint --fix, then prettier
 
 `make help` lists every target.
 
-`npm run pages:dev` builds first, then serves `./build` through wrangler on port 3000. Use it to exercise the Cloudflare side; use `make run` for hot reload. The `/api/picks` route lists the seasons that have picks, and `/api/picks/<season>/<week>` reads `picks/<season>/<week>.xlsx` from the `RAK_MADNESS_BUCKET` binding declared in `wrangler.toml`. Locally that bucket is simulated and starts empty, so both routes come back empty or 404 and the app falls back to manual spreadsheet upload. `wrangler.toml` carries the command that seeds it.
+`npm run pages:dev` builds first, then serves `./build` through wrangler on port 3000. Use it to exercise the Cloudflare side. Use `make run` for hot reload. The `/api/picks` route lists the seasons that have picks, and `/api/picks/<season>/<week>` reads `picks/<season>/<week>.xlsx` from the `RAK_MADNESS_BUCKET` binding declared in `wrangler.toml`. Locally that bucket is simulated and starts empty, so both routes come back empty or 404 and the app falls back to manual spreadsheet upload. `wrangler.toml` carries the command that seeds it.
 
 ## Deploying
 

--- a/functions/api/picks/[season]/[week].ts
+++ b/functions/api/picks/[season]/[week].ts
@@ -3,7 +3,7 @@ import { cachedGet, serviceUnavailable } from "../env";
 
 /**
  * An hour of reuse, then the browser asks whether its copy still stands. A week's
- * picks are rewritten when the sheet turns out to carry an error, and the URL for
+ * picks are rewritten when the sheet turns out to carry an error. The URL for
  * them never changes, so a copy that can outlive a correction has to be able to
  * find out about one.
  *
@@ -31,7 +31,7 @@ async function readWeek(
     return new Response("Not Found", { status: 404 });
   }
 
-  // Only this one header, rather than the request's own: R2 reads every
+  // Only this one header is set, rather than the request's own. R2 reads every
   // conditional in whatever it is handed, and the rest belong to requests this
   // route has no answer for.
   const conditional = new Headers();
@@ -40,7 +40,6 @@ async function readWeek(
     conditional.set("If-None-Match", ifNoneMatch);
   }
 
-  // Get the spreadsheet from R2.
   const filePath = `picks/${season}/${week}.xlsx`;
   let spreadsheet;
   try {

--- a/functions/api/picks/env.ts
+++ b/functions/api/picks/env.ts
@@ -20,12 +20,11 @@ type CacheableContext = {
 /**
  * `build`'s answer, served from the colo's cache when it is already there.
  *
- * Both routes send a `Cache-Control` that says how long their answer stands, and
- * neither was reaching a cache: Cloudflare will not cache a Function's JSON or
- * xlsx without being asked, so every request ran an R2 round trip and measured
- * 430-540ms of TTFB. The Cache API is the asking. It honors the same
- * `Cache-Control` already on the response, so the TTL stays where the route
- * declares it.
+ * Both routes send a `Cache-Control` that says how long their answer stands.
+ * Cloudflare caches neither a Function's JSON nor its xlsx without being asked,
+ * so skipping that ask costs an R2 round trip on every request and 430-540ms of
+ * TTFB. The Cache API is the asking. It honors the same `Cache-Control` already
+ * on the response, so the TTL stays where the route declares it.
  *
  * Per-colo and not tiered, so this earns nothing for the first reader to want a
  * week in their region and everything for the next one.
@@ -35,10 +34,10 @@ type CacheableContext = {
  * stand. A stored 200 still answers a later `If-None-Match` with a 304, because
  * `match` reads the `ETag` it was stored with.
  *
- * So a colo whose copy has expired refills only when a reader who holds no `ETag`
- * arrives. Everyone else revalidates, gets a 304 built from R2's metadata, and
- * stores nothing. Storing on a 304 would mean reading the whole workbook from R2
- * on the requests that currently read none of it, which costs more than the colo
+ * A colo's copy can expire. It refills again only when a reader arrives holding
+ * no `ETag`. Everyone else revalidates, gets a 304 built from R2's metadata, and
+ * stores nothing. Storing on a 304 would mean reading the whole workbook from R2,
+ * on the requests that currently read none of it. That costs more than the colo
  * copy is worth at a minute of edge TTL. Left as it is on purpose.
  */
 export async function cachedGet(

--- a/index.html
+++ b/index.html
@@ -10,12 +10,12 @@
          layout viewport, so the dialog sheet's `bottom: 0`, every `dvh`, and Base
          UI's own idea of the room a popup has are all the screen the reader can
          see. Measuring that instead left the search behind the keyboard wherever
-         the measurement was wrong, which on Firefox for Android is always: it
-         shrinks the layout viewport, so `window.innerHeight` drops with the visual
-         viewport and the two report no keyboard at all.
+         the measurement was wrong, which on Firefox for Android is always the
+         case. It shrinks the layout viewport, so `window.innerHeight` drops with
+         the visual viewport and the two report no keyboard at all.
 
          It costs the rotate overlay a guard. A small phone with a keyboard up is
-         wider than it is tall, which reads as landscape; `phone-landscape` in
+         wider than it is tall, which reads as landscape. `phone-landscape` in
          src/styles/_breakpoints.scss holds it off with an aspect ratio.
 
          src/hooks/useViewportInsets.ts stays for iOS Safari, which ignores this. -->

--- a/public/_headers
+++ b/public/_headers
@@ -1,6 +1,6 @@
 # Cloudflare Pages reads this from the build root, which is where Vite copies
 # public/. Pages' own default is `max-age=14400, must-revalidate`, and the
-# must-revalidate is what makes the edge ask the origin on every hit: measured
+# must-revalidate is what makes the edge ask the origin on every hit. Measured
 # `cf-cache-status: REVALIDATED` and 290-350ms TTFB on the chunk the first paint
 # waits for, when a cache hit would cost neither.
 #

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,7 +1,16 @@
 # src
 
-`index.tsx`: Vite entry, loaded by the root `index.html`. React 19 `createRoot` mount into `#root`, wraps `App` in `BrowserRouter`, `SettingsContextProvider`, `ToastContextProvider`, and `AppDataContextProvider`, with `Toaster` beside it. `App.tsx`: the route table. `index.scss`: global resets, the body baseline, every `--rak-*` design token, and
-a `dark-tokens` mixin the OS or a saved `data-theme` applies. Its comment explains `<html>`'s overflow. Base UI is unstyled, so tokens plus SCSS carry the whole look. `setupTests.ts`: Vitest setup. jest-dom, a raised `asyncUtilTimeout`, `ResizeObserver` and `matchMedia` stubs, and the `jest` global shim @testing-library/dom needs to drive fake timers.
+- `index.tsx`: Vite entry, loaded by the root `index.html`. React 19 `createRoot`
+  mount into `#root`, wraps `App` in `BrowserRouter`, `SettingsContextProvider`,
+  `ToastContextProvider`, and `AppDataContextProvider`, with `Toaster` beside it.
+- `App.tsx`: the route table.
+- `index.scss`: global resets, the body baseline, every `--rak-*` design token,
+  and a `dark-tokens` mixin the OS or a saved `data-theme` applies. Its comment
+  explains `<html>`'s overflow. Base UI is unstyled, so tokens plus SCSS carry
+  the whole look.
+- `setupTests.ts`: Vitest setup. jest-dom, a raised `asyncUtilTimeout`,
+  `ResizeObserver` and `matchMedia` stubs, and the `jest` global shim
+  `@testing-library/dom` needs to drive fake timers.
 
 ## Subdirectories
 

--- a/src/components/button/Button.scss
+++ b/src/components/button/Button.scss
@@ -5,7 +5,7 @@
 // A key at rest and a key sunk under a finger. The top face travels by the
 // difference between the two lifts, so the face lands where the lower edge was
 // and nothing around the key moves. Transform rather than margin for that
-// reason, and a state rather than an animation: the travel is eased by the
+// reason, and a state rather than an animation. The travel is eased by the
 // transition below, and where motion is turned off the key still lands sunk.
 @mixin key($lift) {
   transform: translateY(calc(var(--rak-key-lift) - #{$lift}));
@@ -31,7 +31,7 @@
   }
 }
 
-// Fixed white ink rather than `--rak-on-solid`: that token now inverts with the
+// Fixed white ink rather than `--rak-on-solid`. That token now inverts with the
 // primary ramp's own chrome, but these fills each stay their own fixed color in
 // both modes, so their ink has to stay fixed too.
 @mixin fixed-white-ink {
@@ -63,7 +63,7 @@
   //
   // This order (background-color, color, transform, box-shadow) is read
   // positionally by every `transition-delay` override below, `--selectable`'s
-  // included, since a custom property cannot carry a delay: one that changes
+  // included, since a custom property cannot carry a delay. One that changes
   // value on the same state change it delays reads its own stale value, and
   // never delays anything.
   transition:
@@ -100,9 +100,9 @@
     aspect-ratio: 1;
   }
 
-  // A key molded out of the panel: lit along its top edge, standing on a lower
-  // edge in its own color one step down. Each variant names that step below, so
-  // a key is never edged in a color it does not otherwise carry.
+  // A key molded out of the panel. It is lit along its top edge and stands on a
+  // lower edge in its own color one step down. Each variant names that step
+  // below, so a key is never edged in a color it does not otherwise carry.
   &.--solid {
     --rak-key-edge: var(--rak-disabled-edge);
 
@@ -150,9 +150,9 @@
       @include key(var(--rak-key-pressed));
     }
 
-    // Two fills, not three or four: a pointer on the key, a finger down on it, and
+    // Two fills, not three or four. A pointer on the key, a finger down on it, and
     // the route holding it selected all land on the same fill. A step apart, and
-    // two eased moves land back to back — the browser drops `:active` the instant
+    // two eased moves land back to back. The browser drops `:active` the instant
     // the pointer lifts, a render tick before React can add `--selected`, so a fill
     // a step darker flashes through the one below it on every click. The press is
     // said in the travel and the edge instead, which is what a molded key says it
@@ -161,7 +161,7 @@
     // Properties rather than an override, because a fill that varies by surface
     // cannot be overridden at one specificity without also beating the rules below.
     // The navbar shifts the whole set a step to stand its keys off a bar in the same
-    // color, and they move together: a rest fill raised on its own leaves a press
+    // color, and they move together. A rest fill raised on its own leaves a press
     // crossing two steps at once.
     &.--primary {
       @include button-color(
@@ -199,7 +199,7 @@
     }
 
     // The key that goes somewhere rather than reports something, in the same blue
-    // the lamp is lit in: a fill that stays one saturated blue in both modes,
+    // the lamp is lit in. A fill that stays one saturated blue in both modes,
     // 5.45:1 on white ink.
     &.--info {
       @include button-color(
@@ -213,7 +213,7 @@
 
     // The key that hands the week to something outside the app, in the orange
     // the tables already spend on a knockout, so it reads as neither a result
-    // nor a route: 5.02:1 on white ink.
+    // nor a route. That's 5.02:1 on white ink.
     &.--warning {
       @include button-color(
         var(--rak-warning-700),
@@ -226,7 +226,7 @@
   }
 
   // Which one is chosen, said in something other than a fill one step from its
-  // neighbors': a lamp set into the key's bottom lip, on the edge it shares
+  // neighbors'. A lamp set into the key's bottom lip, on the edge it shares
   // with the page. A key that could be chosen carries the lamp unlit, so the
   // row reads as lamps with one of them on rather than as one key wearing a
   // rule under it.
@@ -294,7 +294,7 @@
 
     // A key is disabled for as long as it is working, so this is where most of the
     // app's waiting is seen. The sweep is white, which is invisible on the gray a
-    // disabled key stands in, and the key looked switched off rather than busy.
+    // disabled key stands in, and the key would look switched off rather than busy.
     &:disabled {
       --rak-loading-sheen: var(--rak-loading-sheen-on-light);
     }

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -33,8 +33,8 @@ export default function Button({
   disabled?: boolean;
   /**
    * Unavailable for now rather than unavailable outright. Keeps the button in the
-   * tab order and looking like itself, which `disabled` does neither of, for a
-   * control that is only waiting on something.
+   * tab order and looking like itself, for a control that is only waiting on
+   * something. `disabled` does neither.
    */
   ariaDisabled?: boolean;
   /** Set while the button's own work is running. Draws the shared loading sheen. */
@@ -58,7 +58,7 @@ export default function Button({
       // Set whenever `selected` is passed at all, true or false, not just when
       // held. `--selected` alone cannot carry this: it disappears the moment
       // the route deselects the button, which is exactly when the release
-      // delay below still needs to apply.
+      // delay in `Button.scss`'s `--selectable` rule still needs to apply.
       "--selectable": selected !== undefined,
       "--selected": !!selected,
       "--busy": busy,

--- a/src/components/dialog/DialogCombobox.scss
+++ b/src/components/dialog/DialogCombobox.scss
@@ -4,8 +4,8 @@
 
 // Base UI ships the combobox unstyled, so these rules carry its whole look. It
 // sits inside a popup and is shorter than a page-level control, so it keeps its own
-// box rather than the home page's, and borrows only the well: `lcd-field` is the
-// same one the app name, the scoreline, and the home page's own selects share.
+// box rather than the home page's, and borrows only the well. `lcd-field` is the
+// same one the home page's selects and the settings dialog's clear button share.
 .dialog__search {
   @include lcd-field;
 
@@ -21,9 +21,9 @@
   @include focus-ring(":focus-within");
 }
 
-// Fills the field. Positioned, so it sits above the icon and the adornment,
-// neither of which is, and a press on either reaches it. The input is lifted
-// back above it below.
+// Fills the field. It is positioned, so it sits above the icon and the
+// adornment. Neither of those is positioned, so a press on either reaches it
+// instead. The input is lifted back above it below.
 .dialog__search-trigger {
   position: absolute;
   inset: 0;
@@ -33,7 +33,7 @@
 }
 
 .dialog__input {
-  // Over the trigger, since a press here is the input's own: it is what opens a
+  // Over the trigger, since a press here is the input's own. It is what opens a
   // phone's keyboard, and it places the caret.
   position: relative;
   flex: 1;

--- a/src/components/dialog/DialogCombobox.tsx
+++ b/src/components/dialog/DialogCombobox.tsx
@@ -7,7 +7,7 @@ import "./DialogCombobox.scss";
 /**
  * The search a dialog is pointed at one of its subjects with.
  *
- * Fully controlled: both the choice and the text in the input are held by the
+ * Fully controlled. Both the choice and the text in the input are held by the
  * caller, so a subject arriving from outside can be taken without the combobox
  * being torn down and rebuilt around it.
  */
@@ -62,8 +62,8 @@ export default function DialogCombobox<T>({
   /**
    * Choosing is the end of the search, so the input gives the focus up.
    *
-   * A phone's keyboard covers the bottom of the screen while the input holds it,
-   * which is where the answer that was just chosen reads. The dialog itself takes
+   * A phone's keyboard covers the bottom of the screen while the input holds it.
+   * That is where the answer that was just chosen reads. The dialog itself takes
    * the focus rather than nothing, so it is still what Escape and a screen reader
    * are working in.
    */
@@ -102,7 +102,7 @@ export default function DialogCombobox<T>({
       // Tapping the search is the start of looking something else up, so what is
       // already in it goes rather than being deleted by hand. A press on the input
       // and a press on the trigger over the rest of the field report their own
-      // reason, and both are the same tap to the reader. Only a press: opening by
+      // reason, and both are the same tap to the reader. Only a press. Opening by
       // typing reports `input-change`, and wiping that would take the letters that
       // opened the list.
       onOpenChange={(listOpen, details) => {
@@ -127,8 +127,9 @@ export default function DialogCombobox<T>({
           keyboard to type into it. The click covers that, and it is the gesture a
           phone raises the keyboard on.
 
-          Out of a reader's way, which has the input's own `combobox` role for all
-          of this and would otherwise be offered a second, nameless control.
+          The trigger stays hidden from a reader. The input already carries the
+          combobox role for all of this, so an exposed trigger would only be a
+          second, nameless control.
         */}
         <Combobox.Trigger
           className="dialog__search-trigger"
@@ -150,7 +151,7 @@ export default function DialogCombobox<T>({
       <Combobox.Portal>
         {/* Wherever there is room for it, which is under the input in all but the
             tightest case. Held below it and nowhere else, the list ran off the
-            bottom of a phone; `index.html` hands a keyboard's height back to the
+            bottom of a phone. `index.html` hands a keyboard's height back to the
             layout viewport, so a list flipped over the input lands on screen. */}
         <Combobox.Positioner className="dialog__positioner" sideOffset={4}>
           <Combobox.Popup className="dialog__list">

--- a/src/components/dialog/DialogShell.scss
+++ b/src/components/dialog/DialogShell.scss
@@ -68,7 +68,7 @@
 
   padding-top: 20px;
   padding-bottom: 0;
-  // 2px tighter than the top padding: room enough for a game dialog's crest to
+  // 2px tighter than the top padding. Room enough for a game dialog's crest to
   // carry its dark-mode rim light without the sheet's own edge cutting it off.
   // `wide-screen` below restores the full 20px, since a centered window has room
   // to spare on the sides a phone's sheet does not.
@@ -165,7 +165,7 @@ $bar-height: 2px;
     height: 100%;
     background-color: var(--rak-progress-fill);
     // The app's one sweep speed, the same `_skeleton.scss` times its sheen to.
-    // The curve is this bar's own: a sheen crosses at a constant rate, and a
+    // The curve is this bar's own. A sheen crosses at a constant rate, and a
     // progress bar eases at each end of its run.
     animation: dialog-sweep var(--rak-duration-loop) ease-in-out infinite;
   }
@@ -203,10 +203,10 @@ $bar-height: 2px;
     bottom: auto;
     width: min(640px, calc(100vw - 32px));
     max-height: min(680px, calc(var(--rak-viewport-height, 100dvh) - 64px));
-    // No keyboard to stand over and no home indicator to clear: a centered
+    // No keyboard to stand over and no home indicator to clear. A centered
     // window is off both edges already. The body still carries it.
     --rak-dialog-floor: 20px;
-    // Back to the top padding: a centered window has room on its sides a
+    // Back to the top padding. A centered window has room on its sides a
     // phone's sheet does not, so it never needed the mobile-only 18px above.
     padding-inline: 20px;
     border-radius: var(--rak-radius-lg);

--- a/src/components/dialog/DialogShell.tsx
+++ b/src/components/dialog/DialogShell.tsx
@@ -32,17 +32,16 @@ export default function DialogShell({
   /** The control that picks what the body is about. */
   search?: ReactNode;
   /**
-   * Set while the next answer is being worked out. Draws the bar on the rule,
-   * named by `label`, which says what is being worked out.
+   * Set while the next answer is being worked out. Draws the bar on the rule.
+   * `label` names what is being worked out.
    *
    * The name travels with the flag rather than beside it, so a dialog cannot draw
    * a bar with nothing to call it. A dialog that never waits passes nothing.
    */
   busy?: false | { label: string };
 }>) {
-  // Tapping a search opens a keyboard over the bottom of the screen, which the
-  // sheet is sized and padded against. Only while the dialog is up, since nothing
-  // else on any page has an input to open one.
+  // A search opens a keyboard over the screen's bottom, which the sheet sizes and
+  // pads against. Only while the dialog is up, since no other page has an input.
   useViewportInsets(open);
 
   return (

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -88,7 +88,7 @@
 // way, so this is only about overlap.
 //
 // The height it takes to clear the stack, worked from the pieces rather than
-// guessed. The stack stands 360px: five controls of `--rak-control-height` plus
+// guessed. The stack stands 360px. Five controls of `--rak-control-height` plus
 // four `--rak-control-gap` between them, inside its own 16px of padding. The
 // content box centers it, so half of whatever is left over falls below it. These
 // links stand 56px, and 16px more keeps them off the button rather than merely

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -35,8 +35,7 @@ export default function Footer() {
   const [isSettingsOpen, setSettingsOpen] = useState(false);
 
   // Only this stamp counts as having found the dialog. A reader with a theme or a
-  // name already saved still gets the pulse, since neither of those was chosen
-  // from here.
+  // name already saved still gets the pulse, since neither was chosen from here.
   const [hasSeenSettings, setSeenSettings] = useState(hasSeenLatestSettings);
 
   // Stamped on the way open rather than on the way closed, so the pulse stops as

--- a/src/components/gameStatus/GameStatusDialog.scss
+++ b/src/components/gameStatus/GameStatusDialog.scss
@@ -3,7 +3,7 @@
 
 // CheckIcon's own aspect in Icon.tsx, `viewBox="257 -654 451 333"`. Named once
 // here because the slot below is sized to it whichever mark is showing, not
-// only when the checkmark itself is: it is the widest of the four shapes.
+// only when the checkmark itself is. It is the widest of the four shapes.
 $check-icon-ratio: math.div(451, 333);
 
 // An entry reads as its column then its game. Both at the one size, in the monospace
@@ -32,14 +32,14 @@ $check-icon-ratio: math.div(451, 333);
 // A mark is set against the text it stands beside, and an entry's two lines are set
 // smaller than the popup they sit in, so the size is said again here rather than left
 // at the one the search's own mark reads. Above the pills below, which say their own
-// size: two classes each, so the later of the two is the one that lands.
+// size. Two classes each, so the later of the two is the one that lands.
 .dialog__option .game-status__mark {
   font-size: var(--rak-text-sm);
 }
 
 // What every mark is shaped like, the four sharing everything but their hue.
 //
-// Monospace, and every word four letters, so all four come out the same size: set in
+// Monospace, and every word four letters, so all four come out the same size. Set in
 // the body face, `WARN` would run wider than `LIVE` and the list's right edge would
 // step in and out as a game kicked off.
 @mixin mark-pill($background, $foreground) {
@@ -126,9 +126,9 @@ $check-icon-ratio: math.div(451, 333);
   @include ink-height(var(--rak-caps-ink), $ink-share-event);
 }
 
-// Already cropped to its own edges rather than a square Material box, so it fills
-// the slot's own width exactly rather than needing a share to divide it. `font-size:
-// inherit` counters `.icon`'s own font-size, the same way `ink-height` does.
+// Already cropped to its own edges rather than a square Material box, so it fills the
+// slot's own width exactly rather than needing a share to divide it. `font-size: inherit`
+// counters `.icon`'s own font-size, the same way `ink-height` does.
 .game-status__mark.--final .game-status__mark-icon svg {
   font-size: inherit;
   width: 100%;

--- a/src/components/gameStatus/GameStatusDialog.tsx
+++ b/src/components/gameStatus/GameStatusDialog.tsx
@@ -13,7 +13,8 @@ import GameStatusSummary from "./GameStatusSummary";
 import "./GameStatusDialog.scss";
 
 /**
- * What a query is matched against: the column the game is, then the game itself.
+ * A query is matched against the column the game is. Then it is matched against
+ * the game itself.
  *
  * Wider than the input reads once a game is chosen, which is the game alone. The
  * column is how a reader who came from a cell knows which game they clicked, so it
@@ -23,14 +24,15 @@ export function gameSearchText(game: WeekGame): string {
   return `${game.label}  ${game.name}`;
 }
 
-/** What one mark is: the state it says, in the shape, the word and the label. */
+/** What one mark is. It says the state in the shape, the word and the label. */
 type Mark = { modifier: string; label: string; icon: ReactNode; word: string };
 
 /**
- * Which mark a game wears, tested in the order the states rule each other out: a
- * column ESPN lists no game for before any status, since there is no game to have
- * one, then the game as its own status says it, with anything ESPN reports that the
- * app does not model falling through to the calendar.
+ * Which mark a game wears, tested in the order the states rule each other out.
+ *
+ * A column ESPN lists no game for comes before any status, since there is no game
+ * to have one. Then the game is tested as its own status says it. Anything ESPN
+ * reports that the app does not model falls through to the calendar.
  */
 function markFor(game: WeekGame, status?: GameStatus): Mark {
   if (game.result == null) {
@@ -70,7 +72,7 @@ function markFor(game: WeekGame, status?: GameStatus): Mark {
 /**
  * Where a game stands, in one mark, on every game the search offers.
  *
- * Every state says so in a word beside its shape: LIVE beside a red dot for a game
+ * Every state says so in a word beside its shape. LIVE beside a red dot for a game
  * being played, WARN beside a warning for a column ESPN lists no game for, which is
  * the one game the dialog can say nothing else about, DONE beside a tick once the
  * game is over, and SOON beside a calendar before kickoff. That a live game is being
@@ -122,7 +124,7 @@ export default function GameStatusDialog({
   /** The column the dialog was opened on, by clicking one of its cells. */
   gameLabel?: string;
   scores?: RakMadnessScores;
-  /** Which week the games belong to, which fetching one again needs. */
+  /** Which week the games belong to, needed to fetch one again. */
   week?: WeekInfo;
   season?: number;
   /**
@@ -179,9 +181,8 @@ export default function GameStatusDialog({
           // search matches, and saying it back here only crowds the game's name.
           itemToStringLabel={(option) => option.name}
           itemKey={(option) => option.label}
-          // The chosen game's own mark, on the freshest status rather than the one
-          // the week was scored at, so a game going final stops pulsing. The week's
-          // own stands until the first answer lands.
+          // The chosen game's mark uses the freshest status, not the week's, so going
+          // final stops pulsing. The week's stands until the first answer lands.
           adornment={
             game != null && (
               <GameMark

--- a/src/components/gameStatus/GameStatusSummary.scss
+++ b/src/components/gameStatus/GameStatusSummary.scss
@@ -33,16 +33,16 @@
 }
 
 // How big the scores, the dash between them and the possession marks are set. Named
-// once here because the four have to grow and shrink together: they sit in one row,
+// once here because the four have to grow and shrink together. They sit in one row,
 // and the room a phone has left over after them is what the two names get.
-// A phone sets them a step over those names and no further down: the scores are what
+// A phone sets them a step over those names and no further down. The scores are what
 // the row is about, and a pair set as big as the two names stops reading as the answer
 // to it.
 //
 // The mark is given as the height of the shape rather than of a box around it, and
 // the gap is every space around it: mark to edge, mark to score. One value, because
 // a mark spaced two different ways from what it stands beside reads as two different
-// marks. The score meets the dash with no gap at all: the pair reads as one number
+// marks. The score meets the dash with no gap at all. The pair reads as one number
 // split by the line between them, not as two numbers with room to spare.
 .game-status {
   --rak-score-size: 1.5rem;
@@ -79,7 +79,7 @@
   text-align: center;
 }
 
-// The line itself, in the face the picks table sets every number in. `None` too: it
+// The line itself, in the face the picks table sets every number in. `None` too. It
 // answers the same question, and a value that changes face with its own value reads
 // as two different fields. Set in the gray the records under the two names carry,
 // which is the same gray their labels do, so the face is what tells the answer from
@@ -88,12 +88,12 @@
   color: var(--rak-text-secondary);
   font-family: var(--rak-font-mono);
   // Off the label's own weight, which is the other half of telling the answer from
-  // the question: the label is what is bold here, and the line it gives is read.
+  // the question. The label is what is bold here, and the line it gives is read.
   font-weight: normal;
 }
 
-// What is the same about the game however it is going: when it starts and where it
-// is being played. Under the scoreline, as a footnote to it.
+// What is the same about the game however it is going. It starts at a fixed time and
+// is played at a fixed place. Under the scoreline, as a footnote to it.
 //
 // One line where the dialog is wide enough to hold both halves, wrapping back to two
 // where it is not. Set apart by the space between them rather than by a glyph, since
@@ -145,8 +145,8 @@
 //
 // Laid in the name's own row rather than across all three. Across them it centers on
 // the grid, whose first row is as tall as the line over the scores rather than as
-// tall as a side's label, which stood the mark above the name, the record block and
-// the glass alike. In this row it is level with all three.
+// tall as a side's label, which would stand the mark above the name, the record block
+// and the glass alike. In this row it is level with all three.
 //
 // Whether there is room for it at all is `useScorelineFit`'s to say, since what it costs
 // the name beside it is what that name is. The last thing that hook gives up, and only
@@ -159,7 +159,7 @@
   height: 32px;
   // None outside dark mode, so this only ever draws the edge `--rak-logo-outline`
   // gives a crest that mode cannot otherwise be sure will show. A filter rather
-  // than an outline or a border: both of those trace the image's own rectangular
+  // than an outline or a border. Both of those trace the image's own rectangular
   // box, where this traces the crest's own alpha channel, so a round logo gets a
   // round edge instead of a square one.
   filter: var(--rak-logo-outline);
@@ -246,11 +246,11 @@
 }
 
 // Held to the scores it joins, so it grows with them. Lit plain white rather than in
-// either side's hue: it belongs to neither of them, and on a readout a cell that is on
+// either side's hue. It belongs to neither of them, and on a readout a cell that is on
 // is on.
 //
 // A cell of the same readout, in the same face, which is what stands it level with the
-// digits either side: its hyphen is the bar across the middle of a cell, drawn on the
+// digits either side. Its hyphen is the bar across the middle of a cell, drawn on the
 // line the digits leave a gap on. Any drawn face puts its dash somewhere of its own.
 .game-status__dash {
   @include segment-face;
@@ -268,7 +268,7 @@
 }
 
 // A step up on the rest of the side text, since the score beside it is what the row is
-// otherwise all about, and set tighter than the app's own leading: a name of two or
+// otherwise all about, and set tighter than the app's own leading. A name of two or
 // three words is one name, and reads as one thing only if its lines are set close.
 .game-status__team-name {
   color: var(--rak-text);
@@ -360,9 +360,8 @@
   position: relative;
   min-width: 2ch;
   font-variant-numeric: tabular-nums;
-  // A score in single figures fills the units cell, its own place, and leaves the
-  // tens cell unlit, the way a hardware scoreboard blanks that digit rather than
-  // showing it as a zero. Centering across both would stand the number over neither.
+  // A score in single figures fills the units cell, tens unlit, as a hardware
+  // scoreboard blanks a digit, not zero. Centering both stands over neither.
   text-align: right;
 }
 
@@ -377,24 +376,24 @@
   // A cell has no color of its own until it is lit.
   color: var(--rak-glass-unlit);
   // Out of any selection dragged over the scoreline. Selectable, copying the score
-  // carried the row of eights out with it.
+  // would carry the row of eights out with it.
   user-select: none;
 }
 
 // A drawn shape rather than a triangle character, and no nudge off the middle of its
 // box. The shape is cut to its own edges, and a seven-segment digit runs the whole em
 // box, so both are centered in the line the row centers on and the mark lands on the
-// bar across the middle of the digit. A glyph landed wherever the reader's font stack
-// drew it.
+// bar across the middle of the digit. A glyph would land wherever the reader's font
+// stack draws it.
 .game-status__marker {
   display: flex;
-  // Lit like the dash between the scores, and for the same reason: the mark belongs
+  // Lit like the dash between the scores, and for the same reason. The mark belongs
   // to neither side's hue, and on a readout a cell that is on is on.
   color: var(--rak-glass-ink);
 
   // Sized outright rather than in `em`, because `.icon` sets a font size of its
   // own that an `em` here would be read against. Across, whatever that height makes
-  // it: the shape is 440 units wide over 560 tall in the box it is cut to, and the
+  // it. The shape is 440 units wide over 560 tall in the box it is cut to, and the
   // gap either side of the mark is the readout's to set rather than the box's.
   > svg {
     width: calc(var(--rak-marker-size) * 440 / 560);
@@ -404,7 +403,7 @@
   // Both sides carry a marker whatever the game is doing, and the side without the
   // ball wears an unlit one. It holds the room the lit one takes, so the scores stay
   // either side of the middle as the ball changes hands, and it is the same cell the
-  // digits beside it show waiting: the readout has a shape for possession whether or
+  // digits beside it show waiting. The readout has a shape for possession whether or
   // not anybody has it.
   &.--blank {
     color: var(--rak-glass-unlit);
@@ -433,7 +432,7 @@
   justify-self: center;
   // The same space a side's own marker sits its score apart by, so the glass keeps
   // one rhythm rather than two. The plate below is drawn outside this box, so it is
-  // not room the readout has to find: what is spaced here is what is lit.
+  // not room the readout has to find. What is spaced here is what is lit.
   padding-inline: var(--rak-score-gap);
   // One screen holding both scores and the dash they meet at, sunk into the dialog the
   // way the app name is sunk into the navbar. The pair is one reading, so it is lit
@@ -461,7 +460,7 @@
   font-weight: var(--rak-weight-semibold);
 }
 
-// Smaller than the line above it: a down and distance runs to `2nd & 7 at ATL 34`,
+// Smaller than the line above it. A down and distance runs to `2nd & 7 at ATL 34`,
 // and the middle column is only as wide as its widest line, so every character here
 // is width taken off the names either side.
 .game-status__down,

--- a/src/components/gameStatus/GameStatusSummary.tsx
+++ b/src/components/gameStatus/GameStatusSummary.tsx
@@ -145,9 +145,8 @@ function Game({
   gamecastHref: string;
 }) {
   const [scoreline, fit] = useScorelineFit(result.id);
-  // The link rides with the place, not the kickoff, so it stays at the strip's end,
-  // not moving when the halves stack, and a game ESPN sent no address for still
-  // carries it.
+  // The link rides with the place, not the kickoff, so it holds the strip's end
+  // when the halves stack. A game ESPN sent no address for still carries it.
   const placeParts = [
     result.venue,
     <a

--- a/src/components/gameStatus/GameStatusSummary.tsx
+++ b/src/components/gameStatus/GameStatusSummary.tsx
@@ -14,9 +14,9 @@ const GAMECAST_LABEL = "Gamecast";
 /**
  * What each side is called over its name.
  *
- * Neither side of a game played at neither of their grounds is hosting anybody, so
- * both are said to be a team and nothing more. ESPN names a home side for one of them
- * anyway, and the pool scores the line against it, but the label would be wrong.
+ * In a game played at neither side's own ground, nobody is hosting, so both are said
+ * to be a team and nothing more. ESPN names a home side for one of them anyway, and
+ * the pool scores the line against it, but the label would be wrong.
  *
  * One word, where a label of two would wrap in the room a phone leaves beside a score
  * and take the name below it down a line.
@@ -98,7 +98,7 @@ function Side({
         >
           {/* The abbreviation on a phone and the name once there is width for it.
               Both are in the page, so neither costs a measurement to choose
-              between. Whichever one is drawn is the one read out: the other is
+              between. Whichever one is drawn is the one read out. The other is
               `display: none`, which takes it out of the accessibility tree as
               well, so hiding either from a reader by hand would leave the side
               with no name at all at the widths that hide the other. */}
@@ -117,7 +117,7 @@ function Side({
   );
 }
 
-/** Both marks or neither: one side wearing a logo and the other nothing reads as the
+/** Both marks or neither. One side wearing a logo and the other nothing reads as the
  *  app having lost track of a team. */
 function hasLogos(result: LeagueResult): boolean {
   return result.home.team.logoUrl != null && result.away.team.logoUrl != null;
@@ -127,7 +127,7 @@ function hasLogos(result: LeagueResult): boolean {
  * The game, laid out the same way whether it is the one just fetched or the week's own
  * copy of it standing in until that answer lands.
  *
- * One layout for both is what lets an answer replace the copy in place: a game the week
+ * One layout for both is what lets an answer replace the copy in place. A game the week
  * had live carries a down and a link out, one it had finished carries neither, and each
  * of those is read off the game on screen rather than guessed at.
  */
@@ -145,9 +145,9 @@ function Game({
   gamecastHref: string;
 }) {
   const [scoreline, fit] = useScorelineFit(result.id);
-  // The link rides with the place rather than the kickoff, so it ends the strip at
-  // every width rather than moving when the two halves stack. Both parts are their
-  // own, so a game ESPN sent no address for still carries the link.
+  // The link rides with the place, not the kickoff, so it stays at the strip's end,
+  // not moving when the halves stack, and a game ESPN sent no address for still
+  // carries it.
   const placeParts = [
     result.venue,
     <a
@@ -166,9 +166,9 @@ function Game({
   // same thing. A side ahead at half time has won nothing yet.
   const isOver = result.status === GameStatus.FINAL;
   const scored = isOver ? scoringTeam(result, spread) : undefined;
-  // Both sides where the game is over and nobody scored, which is a push or a tie
-  // with no line to push against. The pool gives everybody the point there, so
-  // whichever side a pick was on, it was on a side that scored.
+  // Both sides where the game is over and nobody scored, a push or tie with no line
+  // to beat, since the pool gives everybody the point, so any pick was on a scoring
+  // side.
   const outcomeOf = (side: GameSide): SideOutcome | undefined => {
     if (!isOver) return undefined;
     if (scored == null) return "scored";
@@ -204,7 +204,7 @@ function Game({
           outcome={outcomeOf(result.home)}
         />
       </div>
-      {/* Under the scoreline rather than over it: the game is what the dialog was
+      {/* Under the scoreline rather than over it. The game is what the dialog was
           opened for, and when and where it is played is the footnote. */}
       <div className="game-status__meta">
         <MetaGroup parts={kickoffParts(result.date)} />
@@ -215,7 +215,7 @@ function Game({
 }
 
 /**
- * A game the way ESPN's own boxscore says it: each side out on its own edge, the two
+ * A game the way ESPN's own boxscore says it. Each side out on its own edge, the two
  * scores meeting at a dash between them, with where the game is up to over those scores
  * and what the offense or the pool has to say under them.
  *
@@ -247,9 +247,8 @@ export default function GameStatusSummary({
     );
   }
 
-  // The game as last fetched, or the week's own copy until the first answer lands.
-  // Both are the same game, so the only thing the week's copy can be behind on is a
-  // score or a clock, and a live one is replaced in place a moment later.
+  // The game as last fetched, or the week's copy meanwhile. Same game either way, so
+  // the copy can only lag on a score or a clock, replaced in place a moment later.
   const shown = result ?? game.result;
   const logos = hasLogos(shown) && logolessId !== shown.id;
 
@@ -268,7 +267,7 @@ export default function GameStatusSummary({
                   // The team's name is beside it, so the mark says nothing a
                   // reader of the page in words is missing.
                   alt=""
-                  // `GameStatusDialog` has already warmed every logo the week could
+                  // `ResultsFrame` has already warmed every logo the week could
                   // show, so this is normally a cache hit, and decoding it before
                   // the frame goes up puts the mark on screen with the name beside
                   // it rather than a frame behind it.

--- a/src/components/gameStatus/Scoreline.tsx
+++ b/src/components/gameStatus/Scoreline.tsx
@@ -10,7 +10,7 @@ import "./GameStatusSummary.scss";
 /**
  * Joins the two scores, which meet in the middle of the scoreline at every width.
  *
- * A hyphen rather than an en dash, because the readout is what draws it: DSEG7 has
+ * A hyphen rather than an en dash, because the readout is what draws it. DSEG7 has
  * no en dash, and its hyphen is the bar across the middle of a cell, which is the
  * one glyph in the face guaranteed to stand level with the digits either side.
  */
@@ -31,7 +31,7 @@ const HAS_BALL_LABEL = "Has the ball";
  * Said in place of the down and distance while a game being played has none, which is
  * every ball that is not yet dead and every break in the game.
  *
- * A line either way, rather than one that comes and goes: the game is asked about again
+ * A line either way, rather than one that comes and goes. The game is asked about again
  * every `POLL_MS`, and an answer with no down in it would otherwise take the line away
  * and move the scoreline under it.
  */
@@ -64,7 +64,7 @@ function Detail({ result }: { result: LeagueResult }) {
 }
 
 /**
- * Under the scores: what the offense is facing while the game is being played, and
+ * Under the scores is what the offense is facing while the game is being played, and
  * what the pool made of it once the game is over.
  *
  * Who has the ball is left to the marker beside their score.
@@ -134,9 +134,8 @@ function Score({
       {/* Held apart from the marker beside it so a number of one digit takes the
           room two do. */}
       <span className="game-status__points">
-        {/* Both cells, lit or not, so a score in single figures shows the one it is
-            not using rather than a zero standing in it. The face is monospaced, so
-            the row lands exactly under the number without being measured. */}
+        {/* Both cells render, lit or not, so a single-figure score shows the unused
+            cell, not a zero. Monospaced, the row lands under the number unmeasured. */}
         <span className="game-status__points-ghost" aria-hidden="true">
           {DSEG7_ALL_SEGMENTS.repeat(SCORE_CELLS)}
         </span>

--- a/src/components/gameStatus/gameStatusDialogTestSupport.tsx
+++ b/src/components/gameStatus/gameStatusDialogTestSupport.tsx
@@ -8,12 +8,12 @@ import GameStatusDialog from "./GameStatusDialog";
 
 /**
  * Shared by `GameStatusDialog.test.tsx` and `GameStatusDialogOnGameFinal.test.tsx`,
- * which mock the same fetch and open the dialog the same way but cannot share a file:
- * Base UI leaves scroll-lock and focus guards behind a mounted dialog, which puts a
- * second dialog's own search out of reach.
+ * which mock the same fetch and open the dialog the same way but cannot share a
+ * file. Base UI leaves scroll-lock and focus guards behind a mounted dialog, which
+ * puts a second dialog's own search out of reach.
  *
- * Each importer must still call `vi.mock("../../utils/getLeagueResults")` itself:
- * that hoists above the importer's own top-level imports, which is what keeps
+ * Each importer must still call `vi.mock("../../utils/getLeagueResults")` itself.
+ * That hoists above the importer's own top-level imports, which is what keeps
  * `GameStatusDialog`'s real fetch from loading before the mock is in place. A
  * `vi.mock` call here would only hoist within this file.
  */

--- a/src/components/gameStatus/gameStatusText.ts
+++ b/src/components/gameStatus/gameStatusText.ts
@@ -18,7 +18,7 @@ const PREGAME_DETAIL = "Pregame";
 
 /**
  * How a game that finished level, or on its number, was scored. Both are a point for
- * everybody: the pool counts a tie as picking the winner, and a margin that lands on
+ * everybody. The pool counts a tie as picking the winner, and a margin that lands on
  * the spread as covering it. Said in the word alone, because the scoreline above
  * marks both sides as having scored and would only be repeating itself here.
  */
@@ -88,8 +88,8 @@ export function detailText(result: LeagueResult): string {
   if (result.status === GameStatus.UPCOMING) {
     return PREGAME_DETAIL;
   }
-  // Postponed, delayed, canceled: a stage the app has no short form for, so ESPN's
-  // own word for it stands. Its wording of those carries no kickoff to repeat.
+  // Postponed, delayed, and canceled are a stage the app has no short form for, so
+  // ESPN's own word for it stands. Its wording of those carries no kickoff to repeat.
   if (result.status !== GameStatus.LIVE || result.period == null) {
     return result.detailMessage;
   }

--- a/src/components/gameStatus/useScorelineFit.ts
+++ b/src/components/gameStatus/useScorelineFit.ts
@@ -42,18 +42,18 @@ export const MARKS_OFF = 2;
 /**
  * How much of the scoreline there is room for, measured rather than read off a width.
  *
- * What a side needs is what it is called, and no width tells `CONN` and `BUF` apart:
- * the same phone holds one game's scoreline and breaks the next one's. So the whole
+ * What a side needs is what it is called, and no width tells `CONN` and `BUF` apart.
+ * The same phone holds one game's scoreline and breaks the next one's. So the whole
  * thing goes in, the scoreline is measured, and it is cut back a step at a time for as
  * long as a name is still running over the room it was given.
  *
- * Two steps rather than one because a phone names both sides in full nowhere: below
+ * Two steps rather than one because a phone names both sides in full nowhere. Below
  * `$breakpoint-roomy` the first step is already what is on screen, so it changes nothing
  * and the marks are what has to go.
  *
  * The verdict is held against the game it was reached on and the width it was reached
  * at, rather than as a flag. Either one moving puts the whole scoreline back and asks
- * again: another game is another pair of names, and another width is other room to hold
+ * again. Another game is another pair of names, and another width is other room to hold
  * them.
  *
  * @param id the game on screen, which is what the verdict is about.
@@ -82,9 +82,8 @@ export default function useScorelineFit(
     }
   }, [id, step, width]);
 
-  // Every render, since what the scoreline holds is what decides this and a game going
-  // final rewrites half of it. Before the browser paints, so a step the scoreline is
-  // about to give up is never one the reader saw it holding.
+  // Every render, since what the scoreline holds decides this, and going final rewrites
+  // half of it. Runs before paint, so a dropped step was never seen holding it.
   useLayoutEffect(measure);
 
   // A name measured in the fallback font was measured at the wrong width, and the swap

--- a/src/components/home/HomePage.scss
+++ b/src/components/home/HomePage.scss
@@ -4,8 +4,8 @@
 
 // Base UI ships the select unstyled, so these rules carry its whole look. Both
 // the season and the week select share them, read as a readout rather than a
-// form field: `lcd-field` is the well the app name, the scoreline, and the
-// dialog's own search are all cut into too.
+// form field. `lcd-field` is the well the dialog's search and the settings
+// dialog's clear button are cut into too.
 .select__trigger {
   @include lcd-field;
   @include focus-ring;
@@ -14,7 +14,7 @@
   align-items: center;
   justify-content: space-between;
   min-height: var(--rak-touch-target);
-  // No padding on the trailing edge: the chevron below has a bay of its own there.
+  // No padding on the trailing edge. The chevron below has a bay of its own there.
   padding: var(--rak-space-1) 0 var(--rak-space-1) var(--rak-space-3);
   font-family: var(--rak-font-mono);
   font-size: var(--rak-text-md);
@@ -24,7 +24,7 @@
 
   &[data-disabled] {
     cursor: default;
-    // A dim readout rather than a grayed field: the glass stays, only the
+    // A dim readout rather than a grayed field. The glass stays, only the
     // value goes dark, the same as a socket with nothing chosen yet.
     color: var(--rak-unlit);
   }
@@ -41,7 +41,7 @@
   align-items: center;
   align-self: stretch;
   padding-inline: var(--rak-space-2);
-  // Lit chrome, not muted UI: nothing else on a piece of glass carries a border.
+  // Lit chrome, not muted UI. Nothing else on a piece of glass carries a border.
   color: var(--rak-on-solid);
 }
 
@@ -62,13 +62,11 @@
   justify-content: center;
   width: min(340px, 100%);
   padding: var(--rak-space-4);
-  // What sits between every control. Carried as margins rather than a flex
-  // `gap`, because a button that hides itself collapses its own margin as part
-  // of that transition, which a gap on the container cannot do.
+  // What sits between every control. Margins rather than a flex `gap`, since a
+  // button that hides itself collapses its own margin, which a gap cannot do.
   --rak-control-gap: var(--rak-space-3);
-  // What every control down this column stands, fields and buttons alike. Taller
-  // than the touch target a button asks for on its own, so saying it here is what
-  // keeps the two from standing at different heights in the same stack.
+  // What every control in this column stands, fields and buttons alike. Taller than
+  // a button's own touch target, so setting it here keeps both at the same height.
   --rak-control-height: 3.5rem;
 }
 

--- a/src/components/home/LabeledSelect.tsx
+++ b/src/components/home/LabeledSelect.tsx
@@ -2,7 +2,7 @@ import { Select } from "@base-ui/react/select";
 import { UnfoldMoreIcon } from "../icon/Icon";
 
 /**
- * The season and week pickers' shared shape: a Base UI select styled by
+ * The season and week pickers' shared shape. A Base UI select styled by
  * `home__week-input`/`select__*`, so both read from one place instead of
  * drifting apart one field at a time. Those rules live in HomePage.scss,
  * its only caller's sheet.

--- a/src/components/icon/Icon.scss
+++ b/src/components/icon/Icon.scss
@@ -1,7 +1,7 @@
 .icon {
   // 1em at 1.5rem is the 24px box the Material icons are drawn in, and is what
-  // `SvgIcon` sized them at. Anything wanting another size overrides it, the way
-  // `PlayerStatusIcon.scss` asks for 16px.
+  // `Icon`, defined in `Icon.tsx`, sized them at. Anything wanting another size
+  // overrides it, the way `PlayerStatusIcon.scss` asks for 16px.
   width: 1em;
   height: 1em;
   font-size: 1.5rem;

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -11,13 +11,13 @@ const SYMBOLS_VIEW_BOX = "0 -960 960 960";
 /**
  * The icon set, drawn from Material Symbols Sharp at weight 400, which Google
  * ships under Apache 2.0. Sharp because its terminals are square and its corners
- * unrounded, which is the same panel the app's keys and bezels are pressed out of.
+ * unrounded. That is the same panel the app's keys and bezels are pressed out of.
  *
  * Inlined as path data rather than imported, because an icon package built on
  * components pulls a UI library and a CSS-in-JS runtime into the bundle for the
  * sake of a dozen shapes.
  *
- * One shape is not Material at all: `GitHubIcon` is a wordmark, and passes the
+ * One shape is not Material at all. `GitHubIcon` is a wordmark, and passes the
  * `viewBox` it was drawn in.
  */
 function Icon({
@@ -129,7 +129,7 @@ export function SkullOutlinedIcon() {
  * A player still standing, drawn as an outline beside the other two a status
  * wears. Filled, the face is a disc with the eyes and the mouth cut out of it in
  * the same direction the disc is drawn, which the non-zero fill rule reads as one
- * shape rather than as holes: it came out as a blot.
+ * shape rather than as holes. It came out as a blot.
  */
 export function SentimentVerySatisfiedOutlinedIcon() {
   return (

--- a/src/components/navbar/LogoButton.tsx
+++ b/src/components/navbar/LogoButton.tsx
@@ -27,7 +27,7 @@ export default function LogoButton({ onClick }: { onClick: () => void }) {
         </span>
         {/*
           The name in a box of its own, because the well around it is a flex
-          container: the glass has to fill the whole key, and `text-overflow`
+          container. The glass has to fill the whole key, and `text-overflow`
           reaches the text of a block, not a flex item the browser wrapped for it.
         */}
         <span className="logo-button__name-text">{APP_NAME}</span>

--- a/src/components/navbar/ScoresNavbar.tsx
+++ b/src/components/navbar/ScoresNavbar.tsx
@@ -65,9 +65,8 @@ export default function ScoresNavbar({
   /** Cleared once the week is over, when rescoring cannot change anything. */
   isWeekLive: boolean;
 }) {
-  // A week arrives loading, so this is usually on screen by the time it turns out
-  // to be decided. Kept mounted for the length of the collapse so it animates out,
-  // and a week already known to be decided never renders it at all.
+  // A week arrives loading, so this is usually on screen before it's decided, kept
+  // through the collapse to animate out. Skipped once already decided.
   const [isLiveMounted, setLiveMounted] = useState(isWeekLive);
   if (isWeekLive && !isLiveMounted) setLiveMounted(true);
   useEffect(() => {
@@ -77,10 +76,10 @@ export default function ScoresNavbar({
   }, [isWeekLive, isLiveMounted]);
 
   // A results route always names a view, even while it loads, so that button
-  // keeps looking selected through the wait: only `aria-disabled`, never a real
-  // `disabled` that would grayscale its highlight. The home page has no view
-  // yet to show as selected, so there is nothing that look would protect, and
-  // it grays out for real instead.
+  // keeps looking selected through the wait. Only `aria-disabled` marks it,
+  // never a real `disabled` that would grayscale its highlight. The home page
+  // has no view yet to show as selected, so there is nothing that look would
+  // protect, and it grays out for real instead.
   const noViewYet = disabled && view == null;
 
   return (

--- a/src/components/pageLayout/CLAUDE.md
+++ b/src/components/pageLayout/CLAUDE.md
@@ -4,7 +4,7 @@
 Its `pull` prop arms `usePullToRefresh` on the scrolling area and draws
 `PullIndicator`, the puck a pull brings out from under the navbar.
 
-It also holds the note that covers a phone turned on its side, on every page: a
+It also holds the note covering a phone turned on its side, on every page. A
 week's table cannot be read across the 500px of height `phone-landscape` allows
 for, so the app asks for the phone back the way round instead, under a
 `ScreenRotation` icon saying the same thing in a shape.

--- a/src/components/pageLayout/PageLayout.tsx
+++ b/src/components/pageLayout/PageLayout.tsx
@@ -59,9 +59,8 @@ export default function PageLayout({
         {children}
       </main>
       {/*
-        Drawn only on a phone turned on its side, where the stylesheet covers the
-        page with it. `display: none` the rest of the time, so it is out of the
-        accessibility tree rather than merely off screen.
+        Drawn only on a sideways phone, covering the page. Otherwise
+        `display: none`, out of the accessibility tree, not just off screen.
       */}
       <div className="page__rotate">
         <span className="page__rotate-icon">

--- a/src/components/pageLayout/PullIndicator.tsx
+++ b/src/components/pageLayout/PullIndicator.tsx
@@ -4,7 +4,7 @@ import "./PullIndicator.scss";
 /**
  * What a pull on the content below drags out from under the navbar.
  *
- * No props and no state: everything it draws comes off the root element, which is
+ * No props and no state. Everything it draws comes off the root element, which is
  * where `usePullToRefresh` writes the pull rather than re-rendering the table
  * under it. Hidden from a screen reader, which has the refresh button instead and
  * is told the outcome by the toast either way.

--- a/src/components/playerAnalysis/AnalysisBody.tsx
+++ b/src/components/playerAnalysis/AnalysisBody.tsx
@@ -72,9 +72,8 @@ export default function AnalysisBody({
   }
 
   if (result.kind === "clinched") {
-    // The standing calls a clinched player the winner without saying of what, so
-    // this names the week. Only a week still running needs the line under it,
-    // since a week with nothing left to play cannot be undone.
+    // The standing calls a clinched player the winner, not the week, so this names
+    // it. Only an open week needs it below, since a finished one can't be undone.
     return (
       <Message
         lines={[
@@ -97,7 +96,7 @@ export default function AnalysisBody({
           ]}
         />
 
-        {/* Every must-win game there is, or none: `provenMustWin` holds nothing
+        {/* Every must-win game there is, or none. `provenMustWin` holds nothing
             back, and answers empty where it can prove nothing. */}
         {result.mustWin.length > 0 && (
           <Section title="Must win">

--- a/src/components/playerAnalysis/AnalysisRoutes.tsx
+++ b/src/components/playerAnalysis/AnalysisRoutes.tsx
@@ -44,8 +44,7 @@ export default function AnalysisRoutes({
         ))}
       </ol>
       {/* Worked out, then left off, so the count is what the reader is missing.
-          Held back while there are routes folded away, which are the ones to read
-          before hearing what came after them. */}
+          Held back while folded routes remain, since those come first to read. */}
       {(isExpanded || folded <= 0) && hiddenCount > 0 && (
         <p className="analysis__note --upright">
           {plural(hiddenCount, "other path")} found but not shown.

--- a/src/components/playerAnalysis/CLAUDE.md
+++ b/src/components/playerAnalysis/CLAUDE.md
@@ -11,7 +11,7 @@ their name in either table.
 - `AnalysisSummary`: the standing above the body. Decides once whether the week
   is done, for both halves.
 - `analysisParts`: `Section`, `Picks`, `Message`, the pieces with no analysis
-  logic of their own, shared by the three files below.
+  logic of their own, shared by the files below.
 - `mondayNight`: the MNF Points tiebreaker, its own block and its route line.
 - `AnalysisRoutes`: the paths list, folded until asked to show more.
 - `AnalysisBody`: the switch on `PlayerAnalysis.kind` that picks what to render.

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.test.tsx
@@ -173,7 +173,7 @@ describe("PlayerAnalysisDialog", () => {
     );
 
     // Typing above left the list open, which in the app it never is when a name
-    // arrives: the dialog is modal, so the table that names one is out of reach
+    // arrives. The dialog is modal, so the table that names one is out of reach
     // until it closes and takes the search with it.
     await user.keyboard("{Escape}");
 

--- a/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
+++ b/src/components/playerAnalysis/PlayerAnalysisDialog.tsx
@@ -67,8 +67,8 @@ export default function PlayerAnalysisDialog({
 
   // The answers the week already holds: a knocked out player, and a week the
   // knockouts have settled. Both are a walk of the players, so they are read here
-  // rather than waited for below, where the bar used to stand over an answer that
-  // was ready and then grow the dialog under it.
+  // rather than waited for below. That keeps the dialog's height steady while the
+  // search runs.
   const settled = useMemo(() => {
     if (scores == null || player == null) return undefined;
     const paths = getSettledAnalysis(scores, player.name);
@@ -95,9 +95,8 @@ export default function PlayerAnalysisDialog({
     };
   }, [scores, player, settled]);
 
-  // The answer already on screen stays there while the next one is worked out, so
-  // moving between players reads as one answer replacing another rather than as the
-  // dialog emptying and filling again. Only a rescore takes it away.
+  // The answer on screen stays until the next lands, so switching players swaps one
+  // for another rather than emptying and refilling. Only a rescore clears it.
   const searched = found?.scores === scores ? found : undefined;
   const shown = settled ?? searched;
   const isAnalysisLoading = player != null && shown?.name !== player.name;
@@ -126,9 +125,8 @@ export default function PlayerAnalysisDialog({
               "--knocked-out": option.isKnockedOut,
             })
           }
-          // The player named in the input is marked the way the tables mark them,
-          // so the search says where they stand before the answer below it has
-          // been worked out.
+          // The player named in the input is marked the way the tables do, so the
+          // search shows where they stand before the answer below finishes.
           adornment={
             player != null && (
               <span

--- a/src/components/playerAnalysis/Standing.tsx
+++ b/src/components/playerAnalysis/Standing.tsx
@@ -9,7 +9,7 @@ import "./AnalysisSummary.scss";
 
 /**
  * Everyone the tiers leave tied at the top, which is everyone who won the week.
- * Points alone would not do: two players level on them can still be told apart by
+ * Points alone would not do. Two players level on them can still be told apart by
  * the tiebreakers, leaving one winner rather than two.
  */
 function winners(players: Array<PlayerScore>): Array<PlayerScore> {
@@ -29,10 +29,10 @@ function hasKickedOff(players: Array<PlayerScore>): boolean {
 }
 
 /**
- * Where the player picked stands. Nothing here repeats the answer below it: a
- * player who cannot win reads as knocked out and leaves the points to the
- * explanation, and a clinched player reads as the winner outright, games left or
- * not, leaving the body to say only why that holds where some remain.
+ * Where the player picked stands. Nothing here repeats the answer below it.
+ * A player who cannot win reads as knocked out and leaves the points to the
+ * explanation. A clinched player reads as the winner outright, games left or
+ * not. The body says only why that holds where some remain.
  */
 function headline(
   players: Array<PlayerScore>,
@@ -62,7 +62,7 @@ function headline(
  * Where the player picked stands, which the scores already say. Read straight off
  * them, so it is on screen while their routes are still being worked out.
  *
- * `result` is the analysis once it lands, read only for the "clinched" word: this
+ * `result` is the analysis once it lands, read only for the "clinched" word. This
  * standing and the answer below it are worked out from the same fact, so neither
  * has to guess what the other already said. Trusted only where it answers
  * for the same player named here, since the dialog keeps the last answer on
@@ -104,9 +104,8 @@ export default function Standing({
   );
   return (
     <p className="analysis__standing">
-      {/* Held apart from the tail, which says how much of the week is behind the
-          standing rather than what the standing is, so only the standing is
-          colored by it. */}
+      {/* Held apart from the tail, which says how much of the week remains rather
+          than what the standing is, so only the standing gets the color. */}
       <span className={`analysis__headline ${tone ?? ""}`}>{text}</span>
       {" · "}
       {remaining > 0

--- a/src/components/playerAnalysis/analysisParts.tsx
+++ b/src/components/playerAnalysis/analysisParts.tsx
@@ -4,9 +4,8 @@ import "./AnalysisSummary.scss";
 
 export function Section({
   title,
-  // On where a block above this one is needed too. A gap between two blocks does
-  // not say that, and `And` on the title is what makes the two read as one
-  // condition.
+  // On whether a block above this one is needed too. A gap between blocks
+  // doesn't say that. `And` on the title makes the two read as one condition.
   conjoined,
   children,
 }: {
@@ -17,8 +16,8 @@ export function Section({
 }) {
   return (
     <section className="analysis__section">
-      {/* In the title rather than over it, which costs no height, and read out
-          with it, since a reader hearing the blocks needs the word too. */}
+      {/* In the title rather than over it, which costs no height. Read out with
+          it too, since a reader hearing the blocks needs the word. */}
       <h3 className="analysis__section-title">
         {conjoined && <span className="analysis__and">And</span>} {title}
       </h3>

--- a/src/components/results/CurrentWeekRedirect.tsx
+++ b/src/components/results/CurrentWeekRedirect.tsx
@@ -8,7 +8,7 @@ import resultsPath from "./resultsPath";
  * Sends `/scoreboard` and `/picks` to the latest week worth showing.
  *
  * That is the newest season with picks, not whichever season ESPN calls current.
- * Between the Super Bowl and the opener those differ: ESPN moves on to the season
+ * Between the Super Bowl and the opener those differ. ESPN moves on to the season
  * about to start, which has no picks and would land on a week with nothing in it.
  * `AppDataContext` already asks for the right season, so this only has to wait
  * for its schedule. A season that has finished has all of its weeks behind it, so

--- a/src/components/results/DialogLoadBoundary.tsx
+++ b/src/components/results/DialogLoadBoundary.tsx
@@ -5,7 +5,7 @@ import { Component, PropsWithChildren } from "react";
  *
  * `lazy` throws the failed import at the render that needs the module, and with
  * nothing to catch it React unmounts the whole app rather than the dialog. A
- * deploy is the ordinary way in: Pages serves only the current build's assets, so
+ * deploy is the ordinary way in. Pages serves only the current build's assets, so
  * a chunk named by a page left open since yesterday is already gone.
  *
  * There is nothing to retry. `lazy` keeps the rejected promise and throws it again

--- a/src/components/results/ResultsFrame.tsx
+++ b/src/components/results/ResultsFrame.tsx
@@ -24,10 +24,10 @@ import DialogLoadBoundary from "./DialogLoadBoundary";
 import "./ResultsFrame.scss";
 
 /*
-  Neither dialog is on the path to a table, and between them they carry Base UI's
-  combobox, the whole of `getPlayerAnalysis`, and the scoreline: 18kB gzipped of
-  the chunk every route waits on, including the home page, which has no dialog to
-  open at all.
+  Neither dialog is on the path to a table. Between them they carry Base UI's
+  combobox, the whole of `getPlayerAnalysis`, and the scoreline. That's 18kB
+  gzipped of the chunk every route waits on, including the home page, which has no
+  dialog to open at all.
 
   Held apart from the loaders below so the warm and the render ask for the same
   module. `lazy` alone would leave the first click waiting on the fetch.
@@ -58,9 +58,9 @@ type Opened =
  * The page a week's results are shown on, and the wireframe that stands in for
  * them.
  *
- * Shared by every route that can end up waiting, so the wireframe a redirect
- * shows while it works out where it is going is the same one the results
- * themselves arrive in.
+ * Shared by every route that can end up waiting. A redirect shows this wireframe
+ * while it works out where it is going. The results arrive in that same
+ * wireframe.
  */
 export default function ResultsFrame({
   view,
@@ -99,9 +99,8 @@ export default function ResultsFrame({
   // player to do it, so a mount held back until the click would put that walk
   // between the click and the dialog.
   const [hasLoaded, setHasLoaded] = useState(false);
-  // Which dialogs have been opened at all, for the click that beats the fetch.
-  // Kept once set rather than following `opened`, because Base UI plays the close
-  // animation from a dialog still mounted, and unmounting on close would cut it.
+  // Which dialogs have opened, for the click that beats the fetch. Kept once
+  // set, unlike `opened`, since unmounting would cut Base UI's close animation.
   const [hasOpened, setHasOpened] = useState({ player: false, game: false });
   if (opened?.kind === "player" && !hasOpened.player) {
     setHasOpened((seen) => ({ ...seen, player: true }));
@@ -121,9 +120,8 @@ export default function ResultsFrame({
     showToast(errorToast("Failed to open that. Reload the page to try again."));
   }, [showToast]);
 
-  // Fetched as soon as the page is quiet, so the click that opens a dialog waits
-  // for neither the fetch nor the mount. Without this the split would trade the
-  // load every reader pays for a wait the ones who open a dialog pay.
+  // Fetched as soon as the page is quiet, so opening a dialog waits for neither
+  // fetch nor mount. Skipping this trades everyone's load for a wait openers pay.
   useEffect(() => {
     let isOnScreen = true;
     // A failed fetch leaves both dialogs unmounted, and the click that wants one
@@ -171,20 +169,19 @@ export default function ResultsFrame({
           ? `${seasonParam} Week ${weekParam} ${view}`
           : `${APP_NAME} ${view}`
       }
-      // True while loading too: the wireframe is shaped like the table it stands
+      // True while loading too. The wireframe is shaped like the table it stands
       // in for, so it wants the same content area.
       showingResults
       scrollable={isReady}
-      // Exact parity with the refresh button beside it: the same live week, and
-      // only once there is a table to pull on.
+      // This matches the refresh button beside it exactly. Both gate on the
+      // same live week, and only once there is a table to pull on.
       pull={
         isReady && !isWinnerDecided ? { onRefresh, isRefreshing } : undefined
       }
       navbarLeft={<LogoButton onClick={() => navigate("/")} />}
       navbarRight={
-        // Rendered while the week loads, so the navbar does not change shape
-        // under the pointer once it arrives. Disabled until there is something to
-        // switch between.
+        // Rendered while the week loads, so the navbar's shape won't shift under
+        // the pointer once it lands. Disabled until there's anything to switch to.
         <ScoresNavbar
           view={view}
           disabled={!isReady}
@@ -201,7 +198,7 @@ export default function ResultsFrame({
           from a screen reader because that heading already says it, and says the
           view too.
 
-          Not held back until the scores land: the week is in the URL before they
+          Not held back until the scores land. The week is in the URL before they
           are, so the wireframe wears the caption the table will and nothing under
           it moves when the week arrives.
         */}
@@ -222,7 +219,7 @@ export default function ResultsFrame({
           </GameStatusContextProvider>
         </PlayerAnalysisContextProvider>
       </div>
-      {/* No fallback: nothing is on screen to stand in for. A dialog mounts
+      {/* No fallback. Nothing is on screen to stand in for. A dialog mounts
           closed, and the click that beats the fetch wants the dialog rather than
           a spinner where it will be. */}
       {(hasLoaded || hasOpened.player) && (

--- a/src/components/results/resultsPath.ts
+++ b/src/components/results/resultsPath.ts
@@ -1,6 +1,6 @@
 import { ScoresView } from "../navbar/ScoresNavbar";
 
-// `season`/`week` stay optional: a caller with no week selected yet still needs
+// `season`/`week` stay optional. A caller with no week selected yet still needs
 // the literal `undefined` segment its URL already reads today.
 export default function resultsPath(
   season: number | string | undefined,

--- a/src/components/settings/CLAUDE.md
+++ b/src/components/settings/CLAUDE.md
@@ -1,11 +1,11 @@
 # settings
 
-`SettingsDialog`: three settings in the `DialogShell` the player analysis and the
+`SettingsDialog`: settings in the `DialogShell` the player analysis and the
 game status use. Opened from the home page footer, which is the only thing that
 opens it. Player Name comes first: an `lcd-field` shell holding a text input and
 a clear button, whose value marks that player's row in both tables. Live Player
 Analysis and Theme follow, each a row of `Button`s with `selected`, the navbar's
-own switch idiom. All three go through `SettingsContext`. A new one
+own switch idiom. All of them go through `SettingsContext`. A new one
 means moving `Footer.tsx`'s `SETTINGS_CHANGED_AT` forward.
 
 `SettingsDialog.scss`: the column, its labels, and the well the field and its

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -49,8 +49,7 @@ export default function SettingsDialog({
             <label htmlFor={nameInputId}>Player Name</label>
           </h3>
           {/* The well is the shell rather than the input, so the clear button
-              sits inside it in a bay of its own, the way the home page's selects
-              hold their chevron. */}
+              sits in a bay of its own, like the home page's select chevrons. */}
           <div className="settings__field">
             <input
               ref={nameInput}
@@ -73,7 +72,7 @@ export default function SettingsDialog({
             {/* Nothing to clear while the field is empty, and a button that does
                 nothing is one more thing to tab past. Clearing therefore takes
                 this button off screen, so the focus on it has to go somewhere
-                first: left alone it falls to `<body>`, and the next tab restarts
+                first. Left alone it falls to `<body>`, and the next tab restarts
                 from the top of the document with the dialog still open. */}
             {playerName !== "" && (
               <button

--- a/src/components/table/SkeletonTable.tsx
+++ b/src/components/table/SkeletonTable.tsx
@@ -75,7 +75,7 @@ function headerClass(column: Column): string | undefined {
  * A wireframe of a results table, for while the real one is being worked out.
  *
  * Shaped like the view it stands in for, down to the width of every column. It holds
- * no rows of its own: `TableShell` fills the window with rows either way, so the
+ * no rows of its own. `TableShell` fills the window with rows either way, so the
  * wireframe is as tall as the table however many players turn out to have played.
  *
  * Memoized because it is well over a thousand cells and its route re-renders on

--- a/src/components/table/TableShell.tsx
+++ b/src/components/table/TableShell.tsx
@@ -43,9 +43,9 @@ export default function TableShell({
    *
    * Set, the filler runs to whichever is the more of this and one row past the
    * bottom of the box. Filling to the bottom alone leaves a table exactly as tall
-   * as the box, which is one row short of scrolling, so on a tall enough screen a
-   * stand-in for a table that scrolls would not. The count matters as well as the
-   * overflow: it is what sets how far the bar thinks it has to go.
+   * as the box. That box is one row short of scrolling, so on a tall enough screen
+   * a stand-in for a table that scrolls would not. The count matters as well as
+   * the overflow. It is what sets how far the bar thinks it has to go.
    *
    * Left unset, the filler only makes up what the real rows do not reach.
    */

--- a/src/components/table/picks/CLAUDE.md
+++ b/src/components/table/picks/CLAUDE.md
@@ -10,5 +10,5 @@ fill. Right, wrong, and unscoreable picks (`--yes`, `--no`, `--unscoreable`) eac
 a `PICK_STATUS_LABEL` entry as a `.table__sr-only` span, so a screen reader gets what
 the color otherwise carries alone. `incomplete` has none: it draws no color either.
 
-A cell a refresh just resolved also renders a `.table__cell-wipe`, in the status it
+A cell the refresh resolved also renders a `.table__cell-wipe`, in the status it
 left.

--- a/src/components/table/picks/PicksTable.tsx
+++ b/src/components/table/picks/PicksTable.tsx
@@ -25,7 +25,7 @@ const FIXED_COLUMN_COUNT = 5;
 
 /**
  * A pick's status, in words, for the fill color a sighted reader gets instead.
- * `incomplete` carries no entry: it draws no color of its own either, so there is
+ * `incomplete` carries no entry. It draws no color of its own either, so there is
  * nothing sighted that a screen reader needs to catch up on.
  */
 const PICK_STATUS_LABEL: Partial<Record<Status, string>> = {

--- a/src/components/table/playerName/CLAUDE.md
+++ b/src/components/table/playerName/CLAUDE.md
@@ -6,7 +6,7 @@ ellipsis rather than wrapped, so every row is one line tall.
 Where `useShowPlayerStatus` says yes, it is a `.table__cell-button` holding the
 name and `PlayerStatusIcon`, opening the player analysis through
 `PlayerAnalysisContext`, with a `.table__sr-only` span carrying the words for the
-fill color and a `.table__cell-wipe` over the fill a just-knocked-out player
+fill color and a `.table__cell-wipe` over the fill a newly knocked-out player
 held. Where it says no, it is the bare name under `--no-status`, which
 `Table.scss` takes the fill and the hit area off.
 

--- a/src/components/table/scores/CLAUDE.md
+++ b/src/components/table/scores/CLAUDE.md
@@ -2,6 +2,6 @@
 
 `ScoresTable`: memoized ranked results table. Renders nothing without scores.
 Columns: rank, `PlayerName` cell, MNF pick and distance, college/pro/ATS/total scores.
-Its `TableShell` caption, "Player rankings for the week, by total score", is the
-table's own accessible name; visually hidden, since the page around it already
+Its `TableShell` caption is the table's own accessible name: "Player rankings for
+the week, by total score". Visually hidden, since the page around it already
 says what week this is.

--- a/src/components/toaster/Toaster.tsx
+++ b/src/components/toaster/Toaster.tsx
@@ -45,8 +45,7 @@ export default function Toaster() {
             key={toast.id}
             className={`toast --${toast.type}`}
             // Only a failure interrupts. Tapping a pick raises a toast about it,
-            // and that should wait its turn rather than cut off whatever is being
-            // read.
+            // and that waits its turn rather than cut off whatever is being read.
             role={isPersistent(toast) ? "alert" : "status"}
           >
             <span className="toast__icon">

--- a/src/context/AppDataContext.tsx
+++ b/src/context/AppDataContext.tsx
@@ -20,7 +20,7 @@ type AppData = ReturnType<typeof useLeagueWeeks> &
   ReturnType<typeof usePicksSeasons> & {
     /**
      * The `WeekInfo` for a week number, or undefined if the season has no such
-     * week. Always the calendar's own object: the week picker compares options by
+     * week. Always the calendar's own object. The week picker compares options by
      * reference, so a rebuilt one would leave it unable to show a selection.
      */
     findWeek: (value: number) => WeekInfo | undefined;
@@ -54,8 +54,8 @@ const WinnerDecidedContext = createContext(false);
 
 /**
  * What the most recent scoring attempt changed, so a table can flash only the
- * cells that moved. Its own context for the same reason `WinnerDecidedContext` is:
- * every pick and player cell reads it, and `AppData` re-renders on every loading
+ * cells that moved. Its own context for the same reason `WinnerDecidedContext` is.
+ * Every pick and player cell reads it, and `AppData` re-renders on every loading
  * flag it carries.
  */
 const ScoreChangesContext = createContext<ScoreChanges>(NO_SCORE_CHANGES);
@@ -84,9 +84,8 @@ export function AppDataContextProvider({
 }: PropsWithChildren<object>) {
   const { pathname } = useLocation();
   const route = routeFromPath(pathname);
-  // Undefined until a URL or the picker names one, which is what asks ESPN for
-  // the season running now. `loadedSeason` then comes back saying which one that
-  // was.
+  // Undefined until a URL or the picker names one, which asks ESPN for the season
+  // running now. `loadedSeason` then says which one that was.
   const [selectedSeason, setSelectedSeason] = useState(route.season);
 
   // A results URL is the last word on which season is being looked at. Adjusted
@@ -104,7 +103,7 @@ export function AppDataContextProvider({
   const picksSeasons = usePicksSeasons();
   const currentSeason = useCurrentSeason();
   // The newest season with picks, unless the URL or the picker named one. Never
-  // the season ESPN calls current between the Super Bowl and the opener: nothing
+  // the season ESPN calls current between the Super Bowl and the opener. Nothing
   // of it has been played, so `useCurrentSeason` withholds it too.
   const requestedSeason = selectedSeason ?? picksSeasons.seasons?.[0];
   const leagueWeeks = useLeagueWeeks(

--- a/src/context/CLAUDE.md
+++ b/src/context/CLAUDE.md
@@ -2,8 +2,8 @@
 
 - `AppDataContext`: the season list, week list, picks, and scores, held above the
   routes, season and week derived from the pathname. Publishes
-  `WinnerDecidedContext` and `ScoreChangesContext` separately, the latter what a
-  refresh just changed, for the tables to flash.
+  `WinnerDecidedContext` and `ScoreChangesContext` separately, the latter what the
+  last refresh changed, for the tables to flash.
 - `SettingsContext`: the theme, the reader's own name, and whether a live week
   says where players stand, from `settingsStore`. Writes `data-theme` for
   `index.scss`, and answers `useIsMyPlayer`.

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -58,7 +58,7 @@ type Settings = {
   setLiveAnalysis: (enabled: boolean) => void;
 };
 
-// Defaults rather than a throw, following `PlayerAnalysisContext`: the tables read
+// Defaults rather than a throw, following `PlayerAnalysisContext`. The tables read
 // this per row and both suites mount them on their own, with no provider above.
 const SettingsContext = createContext<Settings>({
   theme: DEFAULT_THEME,
@@ -136,8 +136,8 @@ function applyTheme(theme: Theme): void {
  * The color the browser paints its own chrome in, which no stylesheet can say.
  *
  * `auto` has to resolve the OS preference here, unlike the attribute above. The
- * default is `auto`, so leaving this on the dark value stood a dark chrome bar over
- * a light navbar for every reader who never opened the settings at all.
+ * default is `auto`, so leaving this on the dark value stands a dark chrome bar
+ * over a light navbar for every reader who never opens the settings at all.
  */
 function applyThemeColor(theme: Theme): void {
   const meta = document.querySelector('meta[name="theme-color"]');
@@ -221,7 +221,7 @@ export function useSettings(): Settings {
 /**
  * Whether a player in a table is the reader themselves.
  *
- * Trimmed and case-folded, which nothing else comparing these names is: they come
+ * Trimmed and case-folded, which nothing else comparing these names is. They come
  * out of the picks sheet as whoever typed them left them, and every other consumer
  * matches one sheet value against another with `===`. This one matches a sheet
  * value against something a reader typed from memory.

--- a/src/context/ToastContext.test.tsx
+++ b/src/context/ToastContext.test.tsx
@@ -236,7 +236,7 @@ describe("the toast hooks outside a provider", () => {
   });
 });
 
-// Counting renders in the component body rather than through React.Profiler:
+// Counting renders in the component body rather than through React.Profiler.
 // Profiler does not report a commit when only a nested context consumer
 // re-renders, which is exactly the case under test.
 const renders = { actionsOnly: 0, toastList: 0 };

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -14,7 +14,7 @@ import doNothing from "../utils/doNothing";
 export const MAX_VISIBLE_TOASTS = 3;
 /**
  * How long a toast that closes itself stays up. Long enough to read one line of
- * confirmation, and no longer: the only toasts on this clock say something
+ * confirmation, and no longer. The only toasts on this clock say something
  * worked, and the reader is already looking at what it did.
  */
 export const TOAST_LIFETIME_MS = 2000;
@@ -68,9 +68,8 @@ type ToastActions = {
   resumeToasts: () => void;
 };
 
-// The actions sit in their own context because their identity never changes. That
-// keeps the parts of the app that only send toasts (every player cell, for one)
-// still while toasts appear and time out.
+// The actions sit in their own context, since their identity never changes,
+// keeping toast-only parts (a player cell) still while toasts appear and expire.
 const ToastActionsContext = createContext<ToastActions>({
   showToast: doNothing,
   removeToast: doNothing,

--- a/src/hooks/useFillerRows.test.ts
+++ b/src/hooks/useFillerRows.test.ts
@@ -54,8 +54,8 @@ describe("fillerRowCount", () => {
   });
 
   it("settles even when a filler row is not exactly one row tall", () => {
-    // Subpixel rounding used to move the answer on every pass, because the height
-    // of the rows already added was assumed rather than measured.
+    // The height of the rows already added is measured rather than assumed, so
+    // subpixel rounding cannot move the answer on a later pass.
     const content = 260;
     const realRowHeight = ROW_HEIGHT + 0.4;
     let current = 0;

--- a/src/hooks/useFillerRows.ts
+++ b/src/hooks/useFillerRows.ts
@@ -55,9 +55,10 @@ function scrollBoxOf(table: HTMLElement): HTMLElement | undefined {
 }
 
 /**
- * How far down the rows are carried: the bottom of that box's client area rather
- * than of the window. A table wide enough to need a horizontal scrollbar has that
- * bar between the two, and filling to the window would leave a strip of it bare.
+ * How far down the rows are carried. It is the bottom of that box's client area
+ * rather than of the window. A table wide enough to need a horizontal scrollbar
+ * has that bar between the two, and filling to the window would leave a strip of
+ * it bare.
  */
 function fillToY(box: HTMLElement | undefined): number {
   if (box == null) return window.innerHeight;

--- a/src/hooks/useLeagueWeeks.ts
+++ b/src/hooks/useLeagueWeeks.ts
@@ -37,9 +37,8 @@ export default function useLeagueWeeks(
   const [selectedWeek, setSelectedWeek] = useState<WeekInfo>();
   const [isCalendarLoading, setLoading] = useState(true);
 
-  // Read when the calendar lands rather than depended on, so changing week does
-  // not fetch the whole season again. The URL is what moves it, and the schedule
-  // is the same either way.
+  // Read when the calendar lands, not depended on, so a week change skips
+  // refetching, since the URL moves it and the schedule stays the same either way.
   const initialWeekNumberRef = useRef(initialWeekNumber);
   // Declared above the lookup, so a season and week that change together are in
   // step before the lookup they both belong to starts.
@@ -49,9 +48,8 @@ export default function useLeagueWeeks(
 
   useEffect(() => {
     if (!enabled) return;
-    // A season switched away from while its lookup was still out must not land.
-    // It would leave `loadedSeason` naming a season nobody asked for, which reads
-    // as loading forever, with no further lookup queued to end it.
+    // A season switched away from mid-lookup must not land. `loadedSeason` would
+    // name one nobody asked for and loop forever, with no lookup queued to end it.
     return latestOnly(async (isCurrent) => {
       const proLeagueInfo = await getLeagueInfo(League.PRO, season);
       if (!isCurrent()) return;
@@ -72,9 +70,8 @@ export default function useLeagueWeeks(
       setWeeks(calendarWeeks);
       setCurrentWeekNumber(proLeagueInfo.activeWeek?.value);
       setLoadedSeason(proLeagueInfo.season);
-      // The week the URL named, or the one the season has reached. That is the
-      // last regular week once the season is over, and none at all until its
-      // opener has been played.
+      // The week the URL named, or the one the season has reached, which is the
+      // last regular week once it is over and none at all before the opener.
       setSelectedWeek(
         calendarWeeks.find(
           (week) => week.value === initialWeekNumberRef.current,
@@ -94,8 +91,8 @@ export default function useLeagueWeeks(
     (season != null && season !== loadedSeason);
 
   // Newest first, and never a week the season has not reached. A season with no
-  // week behind it offers none, which is what the 0 stands for: `slice` would read
-  // a missing end as the whole array.
+  // week behind it offers none, which is what the 0 stands for. `slice` would
+  // read a missing end as the whole array.
   const selectableWeeks = useMemo(
     () => (weeks ?? []).slice(0, currentWeekNumber ?? 0).reverse(),
     [weeks, currentWeekNumber],

--- a/src/hooks/useLiveGame.ts
+++ b/src/hooks/useLiveGame.ts
@@ -44,9 +44,8 @@ export default function useLiveGame({
    */
   onGameFinal?: () => void;
 }): { shown?: LeagueResult; isGameLoading: boolean } {
-  // Held in a ref rather than read from the deps below. A rescore mints a new
-  // callback, and depending on it would tear the poll down and start its 20s over
-  // every time the week is scored again.
+  // Held in a ref, not read from the deps below, since a rescore mints a new
+  // callback that would tear down the poll and restart its 20s each rescore.
   const onFinal = useRef(onGameFinal);
   useEffect(() => {
     onFinal.current = onGameFinal;

--- a/src/hooks/usePlayerScores.ts
+++ b/src/hooks/usePlayerScores.ts
@@ -52,7 +52,7 @@ type ScoringRequest = {
  * are scored against. Nothing is attempted until it is known.
  *
  * `attemptedFor` names the season and week this hook has finished trying, which
- * is not always the pair asked for: switching either leaves the old scores in
+ * is not always the pair asked for. Switching either leaves the old scores in
  * place until the new ones arrive. Anything reacting to a missing score has to
  * wait for it to catch up, or it will act on the previous week's outcome. The
  * season belongs there as much as the week, since week 5 exists in every season.
@@ -70,9 +70,8 @@ export default function usePlayerScores(
   const [attemptedFor, setAttemptedFor] = useState<LastAttempt>();
   const [isScoresLoading, setScoresLoading] = useState(true);
   const [isRefreshing, setRefreshing] = useState(false);
-  // Counts scoring attempts, so a superseded one cannot write its week's scores
-  // over the week that replaced it. Two can be in flight whenever the selected
-  // week changes while the first is still loading.
+  // Counts scoring attempts, so a superseded one cannot write its scores over the
+  // week that replaced it. Two can be in flight when the week changes mid-load.
   const latestAttempt = useRef(0);
   // Set for the length of an attempt, so a second click cannot start another one
   // before the state update announcing the first has even landed.
@@ -206,7 +205,7 @@ export default function usePlayerScores(
     [selectedWeek, season, attemptScoring, showToast],
   );
 
-  // useMemo, not useCallback: the value is throttle()'s wrapper, not the
+  // useMemo, not useCallback. The value is throttle()'s wrapper, not the
   // function literal, so useCallback cannot see its dependencies.
   const refreshThrottled = useMemo(
     () =>
@@ -234,7 +233,7 @@ export default function usePlayerScores(
           }
           // No trailing edge: a second click inside the window is dropped rather
           // than queued, so it cannot fire a request of its own once the window
-          // ends. `attemptInFlight` below is what actually blocks it meanwhile.
+          // ends. `isAttemptInFlight` below is what blocks it meanwhile.
         },
         REFRESH_THROTTLE_MS,
         { trailing: false },
@@ -247,9 +246,9 @@ export default function usePlayerScores(
   useEffect(() => () => refreshThrottled.cancel(), [refreshThrottled]);
 
   const refresh = useCallback(async () => {
-    // A ref rather than the `isScoresLoading` state, which two clicks in the same
-    // tick would both still read as false: the state update announcing the first
-    // click's attempt has not landed yet.
+    // A ref rather than the `isScoresLoading` state. Two clicks in the same tick
+    // would both still read the state as false, since the update announcing the
+    // first click's attempt has not landed yet.
     if (isAttemptInFlight.current) return;
     await refreshThrottled();
   }, [refreshThrottled]);

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -57,7 +57,7 @@ export function lockAxis(dx: number, dy: number): PullAxis {
  *
  * One to one up to the trigger, so up to the point it matters the content is
  * under the finger rather than lagging it. Past that it resists, and approaches
- * `PULL_MAX_PX` without reaching it: a hard stop reads as the gesture having
+ * `PULL_MAX_PX` without reaching it. A hard stop reads as the gesture having
  * broken, where getting heavier reads as the end of it.
  */
 export function pullOffset(distance: number): number {

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -84,8 +84,8 @@ function phoneTouchQuery(): string {
  *
  * A phone's replacement for the refresh button, which `phone-touch` takes off the
  * bar at the same width. Not the browser's own pull-to-refresh, which `index.scss`
- * turns off: that reloads the document, and the scores are rescored from a
- * workbook held in memory, which a reload would throw away.
+ * turns off. That reloads the document. The scores are rescored from a workbook
+ * held in memory, which a reload would throw away.
  *
  * Writes where the pull has got to onto the root element rather than into state,
  * the way `useViewportInsets` does, so a finger moving over a table of a thousand

--- a/src/hooks/useShowPlayerStatus.ts
+++ b/src/hooks/useShowPlayerStatus.ts
@@ -5,8 +5,8 @@ import { useSettings } from "../context/SettingsContext";
  * Whether the tables may say where a player stands, and open the analysis saying
  * why.
  *
- * A decided week is history, and history is told however the reader has set this:
- * the setting only covers a week whose games are still being played. One hook
+ * A decided week is history, and history is told however the reader has set this.
+ * The setting only covers a week whose games are still being played. One hook
  * rather than the same pair of reads in each place, so a name cell and the fill
  * behind it cannot disagree about which of the two it is.
  */

--- a/src/hooks/useViewportInsets.ts
+++ b/src/hooks/useViewportInsets.ts
@@ -106,9 +106,8 @@ export default function useViewportInsets(enabled: boolean): void {
     let last: ViewportInsets | undefined;
     let frame = 0;
 
-    // Answers whether the viewport held still, which is what the loop counts. The
-    // root is written only when it moved, so the frames either side of a keyboard
-    // cost a read and nothing else.
+    // Answers whether the viewport held still, what the loop counts. The root is
+    // written only when it moved, so frames beside a keyboard cost just a read.
     const measure = (): boolean => {
       const insets = viewportInsets({
         layoutHeight: window.innerHeight,

--- a/src/hooks/useWeekRouteGuard.ts
+++ b/src/hooks/useWeekRouteGuard.ts
@@ -48,7 +48,7 @@ export default function useWeekRouteGuard(
     currentWeekNumber != null &&
     weekNumber <= currentWeekNumber;
 
-  // The URL is the source of truth. Comparing before writing matters: setting
+  // The URL is the source of truth. Comparing before writing matters. Setting
   // the same week again would restart the fetch chain behind it. The season is
   // the provider's to follow, which it does while rendering, so it is already
   // right by the time this runs.

--- a/src/index.scss
+++ b/src/index.scss
@@ -187,7 +187,7 @@
   --rak-nav-key-edge: #3b3b3b;
   --rak-nav-ink: #fff;
   // The lit rim along a key's top edge, weaker than the one every other key in
-  // the app wears. That 70% white was set against a near-white key face; on the
+  // the app wears. That 70% white was set against a near-white key face. On the
   // dark face a key in this bar carries, it reads as a white line rather than as
   // an edge, and a key held down looks as raised as its neighbors.
   --rak-nav-key-top: inset 0 1px 0 rgb(255 255 255 / 25%);
@@ -245,10 +245,10 @@
   // stops saying which of the two things it means. This is forty off that orange
   // and fifty off the green it also sits beside.
   --rak-warning-300: #edfaa0;
-  // Orange rather than the amber this step used to be, six degrees round the
-  // wheel and more saturated with it, so the key the home page exports from
-  // reads as a color rather than as a brown slab. 5.02:1 on the white ink that
-  // key is set in. The toast's warning border is the same step and follows.
+  // Orange, six degrees round the wheel from amber and more saturated with it,
+  // so the key the home page exports from reads as a color rather than as a
+  // brown slab. 5.02:1 on the white ink that key is set in. The toast's warning
+  // border is the same step and follows.
   --rak-warning-500: #b45309;
   // The pressed and hovered step of a solid warning button, and the dark lip it
   // stands on. Between the 500 and the 700, so the fill darkens by the same
@@ -296,7 +296,7 @@
   --rak-gold-500: #d9a02b;
   --rak-gold-700: #8a6415;
 
-  // A player, by whether they can still win. 300 fills their name cell; -on-light
+  // A player, by whether they can still win. 300 fills their name cell. -on-light
   // is the same hue taken far enough down to read on a white surface, which the
   // fill cannot, and is what the player analysis search draws its status icon in.
   --rak-knocked-out-300: #fac99e;
@@ -533,7 +533,7 @@
   --rak-glass-well: inset 0 1px 2px rgb(0 0 0 / 35%);
   // A cell of a combobox's field that is not lit. Enough to read as a shape
   // that could light, not so much that it crowds the ones that are. Dark on
-  // the light fill the field is sunk into here; dark mode below inverts it to
+  // the light fill the field is sunk into here. Dark mode below inverts it to
   // light, on the dark fill it sinks into there.
   --rak-unlit: rgb(0 0 0 / 12%);
   // How far a key stands off the panel, and how far it has left to travel once a
@@ -740,7 +740,7 @@ html {
 
   // The toast's own darkened fills, off the same hues as their light
   // pastel. `primary` and `neutral` are both gray chrome, so they take the
-  // selected-row and muted-panel fills already this dark; `success` and
+  // selected-row and muted-panel fills already this dark. `success` and
   // `danger` reuse the table cell's own darkened green/red. `warning` gets
   // its own: its hue is the orange the rest of its ramp runs on, not the
   // yellow-green `--rak-cell-unscoreable` took.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,9 +38,9 @@ import "./index.scss";
 // the first to paint arrives after that paint has committed to the fallback. Asking
 // for each one here fetches and decodes it up front instead.
 //
-// This is the only list of what to fetch. A `rel=prefetch` for the same files used
-// to sit above it and raced it, so every face downloaded twice: 75kB of the home
-// page's transfer, for nothing.
+// This is the only list of what to fetch. A `rel=prefetch` for the same files
+// above it would race it, downloading every face twice. That doubling costs
+// the home page's transfer 75kB, for nothing.
 //
 // A weight added here also needs its `@fontsource` stylesheet imported above, which
 // is what declares the face. `document.fonts.load` resolves quietly when no face
@@ -57,10 +57,8 @@ const FIRST_PAINT_FONTS = [
   ["400", "IBM Plex Mono"], // table cells
   ["600", "IBM Plex Mono"], // the home page's selected season row
   ["700", "IBM Plex Mono"], // a table's bold rank column
-  // The scoreline's readout. Nothing paints it until the game status dialog
-  // opens, so a decode left until then swaps the face under a dialog already on
-  // screen. `useScorelineFit` measures that dialog, and it measures the fallback
-  // when the swap has yet to land.
+  // The scoreline's readout, painted only once the dialog opens, so a late decode
+  // swaps the face under it. `useScorelineFit` measures the fallback meanwhile.
   ["700", "DSEG7 Classic"],
 ];
 for (const [weight, family] of FIRST_PAINT_FONTS) {

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -54,7 +54,7 @@ $breakpoint-wide: 601px;
  *
  * Width alone would take in a desktop window dragged narrow, where the gesture
  * this guards cannot be performed at all. The pointer is what tells the two
- * apart: a mouse reports `hover` and a fine pointer, so asking for neither leaves
+ * apart. A mouse reports `hover` and a fine pointer, so asking for neither leaves
  * only touch.
  */
 $phone-touch-query: "(max-width: #{$breakpoint-roomy - 1px}) and (hover: none) and (pointer: coarse)";
@@ -70,17 +70,17 @@ $phone-touch-query: "(max-width: #{$breakpoint-roomy - 1px}) and (hover: none) a
  * takes the whole screen and there is no way past it.
  *
  * The pointer is what tells a phone from a desktop. A window dragged short and
- * wide answers every measurement below, and used to raise the overlay on a
- * machine that cannot be turned at all. A mouse reports `hover` and a fine
- * pointer, so asking for neither leaves only touch.
+ * wide answers every measurement below, and would raise the overlay on a
+ * machine that cannot be turned at all if not for the pointer check. A mouse
+ * reports `hover` and a fine pointer, so asking for neither leaves only touch.
  *
  * The height is what tells a phone from a tablet, which is also touch and also
- * turns: every phone in landscape is under 500px tall, and the shortest tablet is
+ * turns. Every phone in landscape is under 500px tall, and the shortest tablet is
  * well over it.
  *
  * The ratio is what tells it apart from a phone held upright with a keyboard up,
  * which `index.html` asks the browser to take out of the layout viewport. A 360px
- * phone left 300px tall is landscape by width against height, and 1.2 wide; a
+ * phone left 300px tall is landscape by width against height, and 1.2 wide. A
  * phone actually on its side is past 2.
  *
  * The app is portrait only. A week of picks is a wide table under a bar of
@@ -105,7 +105,7 @@ $phone-touch-query: "(max-width: #{$breakpoint-roomy - 1px}) and (hover: none) a
 
 /**
  * A reader who has asked for less movement. `index.scss` answers this app-wide by
- * making every animation instant; this is for the two placeholders that have
+ * making every animation instant. This is for the two placeholders that have
  * something smarter to do than stop.
  */
 @mixin reduced-motion {

--- a/src/styles/_listbox.scss
+++ b/src/styles/_listbox.scss
@@ -19,9 +19,8 @@ $-max-rows: 5;
   );
   overflow-y: auto;
   padding: var(--rak-space-1) 0;
-  // The edge the table is framed in, squared off like everything else pressed out
-  // of the panel, so a list opening off a socket reads as part of the same device
-  // rather than as a card the browser dropped on top of it.
+  // The edge the table is framed in, squared off like everything pressed from the
+  // panel, so a list opening off a socket reads as one device, not a dropped card.
   border: var(--rak-border-width-hairline) solid var(--rak-panel-border);
   border-radius: var(--rak-radius-xs);
   background-color: var(--rak-surface);
@@ -40,9 +39,8 @@ $-max-rows: 5;
     background-color: var(--rak-fill-subtle);
   }
 
-  // The one already set, said in the app's own primary rather than a step further
-  // down the same grays the row under the pointer uses. Two neutrals one step
-  // apart cannot say which of them means chosen.
+  // The one already set, in the app's primary rather than a step down the grays
+  // the hovered row uses. Two neutrals a step apart cannot say which means chosen.
   &[data-selected] {
     background-color: var(--rak-selected-fill);
     font-weight: var(--rak-weight-semibold);

--- a/src/styles/_skeleton.scss
+++ b/src/styles/_skeleton.scss
@@ -2,7 +2,7 @@
 @use "breakpoints" as *;
 
 // The one way the app says it is still working. A wireframe stands in for content
-// that is not there yet; a sheen crosses content that is there but stale,
+// that is not there yet. A sheen crosses content that is there but stale,
 // including a button's own face while it works. Nothing spins, so a wait always
 // looks like a wait wherever it happens.
 //

--- a/src/types/CLAUDE.md
+++ b/src/types/CLAUDE.md
@@ -1,3 +1,13 @@
 # src/types
 
-ESPN scoreboard shapes (EspnEvent, EspnCompetitor, GameStatus); League/SeasonType/WeekInfo/LeagueInfo; LeagueResult/GameSide/Possession, a game with its event id, each side's record, logo, name in halves and the points it scored by period, which is what says how many were played, and its venue; WeekGame/GameSpread, one picks column, the game it was picked against, and the pool's line on it from the favored side; GameScore pick-scoring result; RakMadnessScores/PlayerScore/PickResult/Status; PlayerAnalysis, a union over knockedOut, clinched, headline, and paths, so a summary cannot render a field that was never worked out.
+- `EspnEvent`/`EspnCompetitor`/`GameStatus`: the ESPN scoreboard shapes.
+- `League`/`SeasonType`/`WeekInfo`/`LeagueInfo`
+- `LeagueResult`/`GameSide`/`Possession`: a game with its event id, each side's
+  record, logo, name in halves and the points it scored by period, which is what
+  says how many were played, and its venue.
+- `WeekGame`/`GameSpread`: one picks column, the game it was picked against, and
+  the pool's line on it from the favored side.
+- `GameScore`: pick-scoring result.
+- `RakMadnessScores`/`PlayerScore`/`PickResult`/`Status`
+- `PlayerAnalysis`: a union over knockedOut, clinched, headline, and paths, so a
+  summary cannot render a field that was never worked out.

--- a/src/utils/buildSpreadsheetBuffer.ts
+++ b/src/utils/buildSpreadsheetBuffer.ts
@@ -122,7 +122,7 @@ function sheetName(season: number, weekNumber: number, view: string): string {
  */
 export default async function buildSpreadsheetBuffer(
   scoresObject: RakMadnessScores,
-  // Named rather than positional: two numbers side by side, and a call with them
+  // Named rather than positional. Two numbers side by side, and a call with them
   // the wrong way round would come out as a workbook for week 2025.
   { season, weekNumber }: { season: number; weekNumber: number },
 ): Promise<ArrayBuffer> {

--- a/src/utils/espnCache.ts
+++ b/src/utils/espnCache.ts
@@ -2,9 +2,9 @@
 // is not asked again. A game that has been played keeps its score, a matchup ESPN
 // never listed keeps being a hole, and a season that is over keeps its schedule.
 //
-// Nothing about the pool is cached, only ESPN's side of it: a spread the workbook
+// Nothing about the pool is cached, only ESPN's side of it. A spread the workbook
 // contradicts itself on, and a cell nobody filled in, are worked out from the picks
-// every time, and they cost no request.
+// every time. They cost no request.
 //
 // Games are filed under the matchup the picks name, so a week whose matchups change
 // finds nothing for the ones that moved and asks about those again.
@@ -66,8 +66,8 @@ const calendars = versioned(
 /**
  * What a matchup is filed under.
  *
- * Folded and sorted, because the workbook could name the same two teams either way
- * around and in any case at all, while a result carries them already uppercased. A
+ * Folded and sorted. The workbook could name the same two teams either way around
+ * and in any case at all, while a result carries them already uppercased. A
  * column names one team where every player picked the same side, which is a matchup in
  * its own right.
  */

--- a/src/utils/getLeagueInfo.ts
+++ b/src/utils/getLeagueInfo.ts
@@ -32,7 +32,7 @@ type Scoreboard = {
  * How many weeks a season's regular season has, or undefined if the calendar for
  * it could not be read.
  *
- * The count is not the same every year: the NCAA regular season ran 15 weeks in
+ * The count is not the same every year. The NCAA regular season ran 15 weeks in
  * 2023 and 16 in 2024, and it decides where the regular season ends and the
  * postseason begins. Cached per league and season, because it is fixed once the
  * calendar is published and scoring asks for it on every refresh.
@@ -42,8 +42,7 @@ export async function getRegularSeasonWeekCount(
   season?: number,
 ): Promise<number | undefined> {
   // A season left unspecified means "whichever one is current", which changes
-  // over time, so there is nothing to key a cache lookup on until the response
-  // names the season it actually described.
+  // over time, so nothing keys a cache lookup until the response names one.
   if (season != null) {
     const cached = regularSeasonWeekCounts.get(`${league}:${season}`);
     if (cached != null) {
@@ -180,9 +179,8 @@ function toLeagueInfo(
   // every year: Off Season. Leave it out of the running.
   const datedCalendars = calendars.filter((cal) => cal.weeks.length > 0);
 
-  // For the NFL, we always want to use the regular season calendar.
-  // For the NCAA, we go by date because we cross into the postseason.
-  // Fall back to the last calendar.
+  // The NCAA goes by date rather than by season type, because it crosses
+  // into the postseason partway through.
   const activeCalendar =
     league === League.PRO
       ? datedCalendars.find((cal) => cal.seasonType === SeasonType.REGULAR)
@@ -200,9 +198,8 @@ function toLeagueInfo(
     return null;
   }
 
-  // The week being played now, or the last one begun once the season is over. A
-  // season whose opener is still ahead has none. `findLast` would say this in one
-  // call, but it is ES2023 and this builds to ES2022.
+  // The week being played now, or the last one begun once the season is
+  // over. None where the opener is ahead. `findLast` needs ES2023, not ES2022.
   const activeWeek = activeCalendar.weeks
     .filter((week) => week.startDate <= now)
     .at(-1);

--- a/src/utils/getLeagueResults.ts
+++ b/src/utils/getLeagueResults.ts
@@ -28,7 +28,6 @@ const WEEKS_PRO_REGULAR_SEASON = 18;
 
 /**
  * Week 1 of Rak Madness is week 1 in the NFL, but week 2 in the NCAA.
- * We account for this by adding 1 to the week if NCAA results have been requested.
  */
 const WEEK_OFFSET_COLLEGE = 1;
 
@@ -56,9 +55,8 @@ async function getLeagueEvents(
   league: League,
   week: WeekInfo, // Rak Madness week, corresponds with NFL regular season week
   season?: number,
-  // Left off where one game is being looked up by id. Rak has put a game in the
-  // picks sheet outside the NFL week, and dropping it here would leave that game
-  // impossible to fetch again.
+  // Left off when looking up one game by id, since Rak has put a game
+  // outside the NFL week in the picks sheet, making it otherwise unfetchable.
   { datedFromWeekStart = true }: { datedFromWeekStart?: boolean } = {},
 ): Promise<Array<EspnEvent>> {
   // This league's calendar and no other. The other league's week count decides
@@ -80,7 +78,7 @@ async function getLeagueEvents(
       ? SeasonType.REGULAR
       : SeasonType.POST;
   // For college games, the postseason is all week 1
-  // because EPSN considers the entire postseason to be "the bowl week".
+  // because ESPN considers the entire postseason to be "the bowl week".
   if (league === League.COLLEGE && seasonType === SeasonType.POST) {
     adjustedWeekNumber = 1;
   }
@@ -91,15 +89,13 @@ async function getLeagueEvents(
   const seasonParam = season != null ? `&dates=${season}` : "";
   const baseRequestUrl = `https://site.api.espn.com/apis/site/v2/sports/football/${league}/scoreboard?week=${adjustedWeekNumber}&seasontype=${seasonType}${seasonParam}`;
 
-  // For college, we need to concatenate multiple groups.
   if (league === League.COLLEGE) {
     const collegePromises = COLLEGE_GROUPS.map((groupId: number) => {
       const requestUrl = `${baseRequestUrl}&limit=400&groups=${groupId}`;
       return fetchEspnEvents(requestUrl).then((events) => {
-        // ESPN jams the entire college postseason into one week.
-        // So, we need to remove events that happen before the given NFL week.
-        // We'd also like to remove events that happen after, but Rak has (once)
-        // put a game in the picks sheet outside the NFL week. Nice.
+        // ESPN jams the entire college postseason into one week. Events before
+        // the given NFL week are dropped. Events after are kept, because a
+        // picks sheet has once named a game outside the NFL week.
         if (!datedFromWeekStart) return events;
         return events.filter(
           (event) => new Date(event.date).valueOf() >= week.startDate.valueOf(),
@@ -119,7 +115,6 @@ async function getLeagueEvents(
       .map((dated) => dated.event);
   }
 
-  // For pro, we can just return the raw events list fetched from the API.
   return fetchEspnEvents(baseRequestUrl);
 }
 
@@ -140,8 +135,9 @@ function eventSides(
   return home != null && away != null ? { home, away } : null;
 }
 
-/** A side's name as every index and every matchup key spells it. */
 /**
+ * A side's name as every index and every matchup key spells it.
+ *
  * Empty where ESPN lists a side it has no team for, which a bowl slot still to be
  * filled arrives as. The type says the field is always there and the answers do
  * not, which is what the reads below guard against.
@@ -179,8 +175,8 @@ function gameSide(competitor: EspnCompetitor): GameSide {
     team: {
       name: competitor.team.displayName,
       // The two halves of that name, which the game status sets on their own lines.
-      // Kept only where ESPN sent both: half a name on a line of its own reads as
-      // the other half having gone missing.
+      // Kept only where ESPN sent both. Half a name on a line of its own reads
+      // as the other half having gone missing.
       location: competitor.team.location,
       mascot: competitor.team.name,
       abbreviation: teamAbbreviation(competitor),
@@ -199,7 +195,7 @@ function gameSide(competitor: EspnCompetitor): GameSide {
 /**
  * Where the game is played, as the town and nothing more.
  *
- * The ground's own name is left out: a reader who wants it has the Gamecast link the
+ * The ground's own name is left out. A reader who wants it has the Gamecast link the
  * dialog carries, and the name is stored in this browser for every game of every week
  * cached otherwise.
  */
@@ -220,8 +216,8 @@ export function matchesMatchup(
   result: LeagueResult,
   teams: Set<string>,
 ): boolean {
-  // Folded on both sides, because a result carries the abbreviations already
-  // uppercased while a workbook could name them any way at all.
+  // Folded on both sides. A result carries the abbreviations already
+  // uppercased, while a workbook could name them any way at all.
   const named = new Set([...teams].map((team) => team?.toUpperCase()));
   const home = result.home.team.abbreviation;
   const away = result.away.team.abbreviation;
@@ -277,7 +273,6 @@ export function toLeagueResult(event: EspnEvent): LeagueResult | null {
   // margin just because there is no winner yet.
   const scoreMargin = Math.abs(homeScore - awayScore);
 
-  // Calculate possession object
   const possession: Possession = {
     downDistanceText: competition.situation?.downDistanceText,
   };
@@ -352,11 +347,9 @@ function inDateOrder(
  * it. Changing the picks changes which matchups are asked about, and a matchup that
  * moved has nothing stored under its new name, so the week is fetched again.
  *
- * @param league league for which to get results
  * @param week week in the season (week 1 is the first NFL week)
  * @param matchups the games the picks describe
  * @param season the year the season started in, current season if left out
- * @returns league results
  */
 export async function getLeagueResults(
   league: League,
@@ -380,9 +373,8 @@ export async function getLeagueResults(
   const events = await getLeagueEvents(league, week, season);
   debugLog(`${league} events`, events);
 
-  // The keys the picks ask about, split by how a column names its game. A college
-  // answer runs to hundreds of events, so each one is looked up rather than walked
-  // against every matchup.
+  // The keys the picks ask about, split by how a column names its game.
+  // A college answer runs hundreds of events, looked up not walked per game.
   const wantedPairs = new Set<string>();
   const wantedTeams = new Set<string>();
   matchups.forEach((teams, index) => {
@@ -407,9 +399,8 @@ export async function getLeagueResults(
   const games: Record<string, CachedGame> = {};
   const kept: Array<LeagueResult> = [];
   found.forEach((result, key) => {
-    // A game the fetch no longer lists keeps the outcome this browser already had.
-    // ESPN moves a game out of a week's answer now and then, and without this the
-    // column would go from scored to missing.
+    // A game the fetch no longer lists keeps the outcome already held, since
+    // ESPN moves a game out of a week, or scored would go missing.
     const game = result ?? held[key] ?? null;
     if (result == null && game != null) {
       kept.push(game);
@@ -432,8 +423,8 @@ export async function getLeagueResults(
  *
  * The same league fetch the scoring pass makes, picked over by event id rather
  * than by matchup, so watching a live game needs no second endpoint and no second
- * way of reading one. Null where the week no longer holds that game, which a
- * season or week switch can do while a dialog is open on it.
+ * way of reading one. Null where the week no longer holds that game. A season
+ * or week switch can do that while a dialog is open on it.
  */
 export async function getGameResult(
   league: League,

--- a/src/utils/localStorageCache.ts
+++ b/src/utils/localStorageCache.ts
@@ -2,8 +2,8 @@
 //
 // Everything kept this way is something a page load can do without, so a read or a
 // write that fails counts as a miss and never as an error. A failure of either clears
-// the cache, on the grounds that storage this browser cannot be trusted with is better
-// left empty than left half full.
+// the cache. Storage this browser cannot be trusted with is better left empty than
+// left half full.
 
 export type LocalStorageCache<T> = {
   /** The value stored under a name, or undefined for one this browser does not have. */
@@ -61,7 +61,6 @@ export default function localStorageCache<T>(options: {
       try {
         // Pruned before writing, so the entry being written is never the one dropped.
         // localStorage does not report insertion order, so which others go is arbitrary.
-        // The cap is only here to bound how much space this takes.
         const keys = ownKeys().filter((it) => it !== key);
         keys
           .slice(0, Math.max(keys.length - (cap - 1), 0))

--- a/src/utils/pickStatusFill.ts
+++ b/src/utils/pickStatusFill.ts
@@ -4,8 +4,8 @@ import { Status } from "../types/RakMadnessScores";
  * The fill behind a pick, by whether it scored.
  *
  * The same colors the browser draws these statuses in, which come from the success,
- * danger, and warning ramps in `src/index.scss`. The two cannot share one value:
- * this side needs bare hex for xlsx, and the stylesheet needs a CSS color. The suite
+ * danger, and warning ramps in `src/index.scss`. The two cannot share one value.
+ * This side needs bare hex for xlsx, and the stylesheet needs a CSS color. The suite
  * beside this file is what holds them together.
  */
 export const PICK_STATUS_FILL: Record<Status, { rgb: string }> = {

--- a/src/utils/picksCache.ts
+++ b/src/utils/picksCache.ts
@@ -1,6 +1,6 @@
 // A per-week copy of an uploaded workbook, so a results URL can be reopened
 // without asking for the file again. Only the workbook is cached, never the
-// scores: recomputing those is fast, and a cached score could go stale against a
+// scores. Recomputing those is fast, and a cached score could go stale against a
 // change to the scoring rules.
 
 import localStorageCache from "./localStorageCache";

--- a/src/utils/scoring/applyKnockouts.ts
+++ b/src/utils/scoring/applyKnockouts.ts
@@ -62,8 +62,7 @@ function countDifferences(
 /**
  * Marks every player who can no longer catch the leader, with the reason.
  *
- * Assumes the team abbreviations are all correct. If they are not, or the games
- * cannot be found for some other reason, the results will be wrong.
+ * Assumes every team abbreviation is correct. A mismatch corrupts the scores.
  */
 export default function applyKnockouts(
   sortedScores: Array<PlayerScore>,
@@ -76,7 +75,6 @@ export default function applyKnockouts(
   const isCollegeDone = games.every((game) => game.league !== "college");
 
   return sortedScores.map((activeScore, activeIndex) => {
-    // If a player has no picks, they're knocked out.
     if (activeScore.status.hasNoPicks) {
       return knockedOut(activeScore, "Knocked out due to having no picks.");
     }
@@ -114,7 +112,6 @@ export default function applyKnockouts(
         const totalScoreDiff = rivalScore.score.total - activeScore.score.total;
         const totalDifferentPicks = differentCollegePicks + differentProPicks;
         if (totalDifferentPicks < totalScoreDiff) {
-          // If the active player can't catch up on points, they're knocked out.
           return knockedOut(
             activeScore,
             `Knocked out on Total Score by ${rivalScore.name}. ` +
@@ -135,8 +132,6 @@ export default function applyKnockouts(
             rivalScore.tiebreaker.pick === activeScore.tiebreaker.pick ||
             (tiebreakerScore != null && rivalDistance === activeDistance)
           ) {
-            // If the active player has the same tiebreaker pick as the rival, run through the list of other tiebreakers.
-            // If the rival has a better college score, check if the active player can catch up.
             const collegeScoreDiff =
               rivalScore.score.college - activeScore.score.college;
             if (
@@ -154,7 +149,6 @@ export default function applyKnockouts(
                   ),
               );
             }
-            // If college games are done and players are tied, check pro against the spread tiebreaker.
             if (collegeScoreDiff === 0 && isCollegeDone) {
               const proAgainstTheSpreadScoreDiff =
                 rivalScore.score.proAgainstTheSpread -

--- a/src/utils/scoring/comparePlayerScores.ts
+++ b/src/utils/scoring/comparePlayerScores.ts
@@ -41,10 +41,8 @@ function firstAlphabetically(a: string, b: string): number {
  * are a run of returns rather than a list walked with a call each.
  */
 export function compareOnMerit(a: Merit, b: Merit): number {
-  // A row the week cannot be won by sorts under every row that can, whatever it
-  // scored, so the standings can read the leader off the first row. A player who
-  // entered nothing sorts under one who only left a game blank, and a row with no
-  // picks has every cell blank, so the wider rule is read first.
+  // A row the week can't be won by sorts under one that can, so leaders read
+  // off row one. No-picks sorts under blank-pick, wider rule checked first.
   if (a.hasNoPicks !== b.hasNoPicks) return a.hasNoPicks ? 1 : -1;
   if (a.hasBlankPick !== b.hasBlankPick) return a.hasBlankPick ? 1 : -1;
   if (a.total !== b.total) return highestFirst(a.total, b.total);
@@ -79,7 +77,7 @@ export function comparePlayerScoresOnMerit(
  * The row order, which needs every pair separated even where the rules do not
  * separate them. Two players the tiers leave tied have both won the week, so the
  * name is a row order and not a tiebreaker, which is why it lives here rather than
- * in `TIERS`.
+ * in `compareOnMerit`.
  */
 export default function comparePlayerScores(
   a: PlayerScore,

--- a/src/utils/scoring/getPickResults.test.ts
+++ b/src/utils/scoring/getPickResults.test.ts
@@ -8,7 +8,6 @@ function byTeam(results: Array<LeagueResult>): Map<string, LeagueResult> {
   return indexResults(results).byTeam;
 }
 
-// BUF beat KC by 10.
 const bufBeatKcBy10 = finalGame({
   home: "BUF",
   away: "KC",

--- a/src/utils/scoring/getPickResults.ts
+++ b/src/utils/scoring/getPickResults.ts
@@ -32,7 +32,7 @@ export function getStatus(score: GameScore): Status {
 
 /**
  * The header a cell left blank carries. Held apart from the other two because it is
- * the player's own doing rather than a game nobody can score: every week has blanks
+ * the player's own doing rather than a game nobody can score. Every week has blanks
  * in it, and a week full of them is still a week that finished.
  */
 export const MISSING_PICK = "Missing Pick";
@@ -61,7 +61,6 @@ function scoreCell(
   pick: string,
   resultsByTeam: Map<string, LeagueResult>,
 ): GameScore {
-  // Parse the pick text to extract the selected team abbreviation and spread (if present).
   const { teamAbbreviation: selectedTeam, spread } = parsePick(pick);
   const hasSpread = spread !== 0;
 
@@ -73,7 +72,6 @@ function scoreCell(
     );
   }
 
-  // Find the game result matching the selected team.
   const gameResult = resultsByTeam.get(selectedTeam);
   if (!gameResult) {
     console.warn(
@@ -87,10 +85,8 @@ function scoreCell(
     );
   }
 
-  // From the picked team's side, since that is the side the cell's spread is
-  // written from. A push counts as a win, which is why this is >= rather than >.
-  // Nothing reads `pointValue` until `isFinal`, which is when the margin
-  // means anything.
+  // From the picked team's side, since the cell's spread is written from it.
+  // A push counts as a win (>= not >). `pointValue` unread until `isFinal`.
   const margin = marginAgainstSpread(gameResult, selectedTeam, spread);
   const pointValue = margin >= 0 ? 1 : 0;
   debugLog("scored pick", {

--- a/src/utils/scoring/getPlayerAnalysis.test.ts
+++ b/src/utils/scoring/getPlayerAnalysis.test.ts
@@ -211,8 +211,8 @@ describe("getSettledAnalysis, the answers that need no search", () => {
     });
   });
 
-  // The case that sent a reader here: a week whose games are all in, where the
-  // bar used to run over an answer the knockouts had already given.
+  // A week whose games are all in clinches off the knockouts, so the bar never
+  // runs over an answer they already gave.
   it("clinches a week whose games are all played", () => {
     const scores = week(
       [

--- a/src/utils/scoring/getPlayerAnalysis.ts
+++ b/src/utils/scoring/getPlayerAnalysis.ts
@@ -131,8 +131,8 @@ function sideFor(
 
 /**
  * The most this rival can finish ahead of the player on points, over every way the
- * games can fall: every game the rival takes and the player does not, and none the
- * other way.
+ * games can fall. Every game the rival takes and the player does not widens it, and
+ * none the other way does.
  */
 function leadCeiling(me: Tier, rival: Tier): number {
   let most = 0;
@@ -247,9 +247,9 @@ function evaluate(
  * must-win exactly when even that loses, which is one verdict per game where the
  * search reads one per subset of them.
  *
- * Empty rather than partial where it can prove nothing: a player who cannot take
- * the week even with every pick landing. A list this returns holds every must-win
- * game there is.
+ * Empty rather than partial where it can prove nothing. That is a player who cannot
+ * take the week even with every pick landing. A list this returns holds every
+ * must-win game there is.
  */
 function provenMustWin(
   mineMask: number,
@@ -471,9 +471,8 @@ function search(
       const { kind } = verdict;
       if (kind !== "loss") {
         won[hits] = 1;
-        // A set inside this one that already wins makes this one no route of its
-        // own. Any such set has one a game smaller above it that wins too, and
-        // every one of those was read to get here, so the bits answer it.
+        // A subset that already wins makes this set redundant, since any
+        // winning set has a one-game-smaller winning subset, already read.
         let isRedundant = false;
         for (let bits = hits; bits !== 0; bits &= bits - 1) {
           if (won[hits ^ (bits & -bits)] === 1) {
@@ -558,22 +557,6 @@ function reduceRoutes(
 }
 
 /**
- * Where a player stands in a week, and what they still have to do to win it.
- *
- * Answers for every player, knocked out or not, and for a week already decided as
- * well as one being played. Undefined where the sheet holds nobody by that name,
- * which is the only way the question has no answer at all.
- *
- * A game of the player's own that lands on the line is read as their win alone. The
- * pool scores a push for both sides, so it also scores for the rival who picked the
- * other side, and a route named here can fall to that. Read the other way this
- * answers nothing: winning every game they picked would leave the gap where it
- * started, so a player even a point back could never be told they are live. Every
- * other answer holds either way. A knockout and a must-win game only become more
- * true, and a clinch reads a week where none of the player's own picks land, which
- * is a week with no push in them to read.
- */
-/**
  * The answer where the week already holds one, and undefined where the search below
  * is what has to find it.
  *
@@ -615,17 +598,14 @@ function settledAnalysis(
 
   const player = players[playerIndex];
   const clinched: PlayerAnalysis = { kind: "clinched", player: player.name };
-  // The blank read alongside the knockout, and not off it, because the search below
-  // reads every contested game as a pick of this player's. A caller writing its own
-  // scores can hand in a blank row `applyKnockouts` never marked.
+  // Checked beside the knockout, since the search assumes every contested
+  // game is a pick, and a caller's blank row may skip `applyKnockouts`.
   if (player.status.isKnockedOut || player.status.hasBlankPick) {
     return { playerIndex, player, rivals: [], analysis: knockedOut(player) };
   }
 
-  // Nothing is left to play, so the knockouts have already settled the week and
-  // whoever they left standing has won it. Said here rather than searched for,
-  // because the search reads the lower tiers in an order of its own, and on a
-  // week nobody can change it would sometimes disagree with the standings.
+  // Nothing left to play means the knockouts settled it, and whoever they
+  // left standing won, decided here since the search's tier order may differ.
   if (isWinnerDecided(scores)) {
     return { playerIndex, player, rivals: [], analysis: clinched };
   }
@@ -650,6 +630,22 @@ function liveRivals(
     .filter((it) => it.index !== playerIndex && !it.player.status.isKnockedOut);
 }
 
+/**
+ * Where a player stands in a week, and what they still have to do to win it.
+ *
+ * Answers for every player, knocked out or not, and for a week already decided as
+ * well as one being played. Undefined where the sheet holds nobody by that name,
+ * which is the only way the question has no answer at all.
+ *
+ * A game of the player's own that lands on the line is read as their win alone. The
+ * pool scores a push for both sides, so it also scores for the rival who picked the
+ * other side, and a route named here can fall to that. Read the other way this
+ * answers nothing. Winning every game they picked would leave the gap where it
+ * started, so a player even a point back could never be told they are live. Every
+ * other answer holds either way. A knockout and a must-win game only become more
+ * true, and a clinch reads a week where none of the player's own picks land, which
+ * is a week with no push in them to read.
+ */
 export default function getPlayerAnalysis(
   scores: RakMadnessScores,
   playerName: string,
@@ -668,10 +664,8 @@ export default function getPlayerAnalysis(
     (game) => new Set(live.map((index) => game.cells[index].team)).size > 1,
   );
 
-  // This player picked every game, since a blank row is answered above. So the bit
-  // for a game reads as their own pick landing, and every contested game is theirs
-  // to win. A rival's blank cell still reaches here, and `sideFor` scores it as no
-  // gain either way.
+  // This player has no blank pick, handled above, so every contested game
+  // is theirs to win. A rival's blank still scores no gain in `sideFor`.
   const coverers = contested.map((game) => game.cells[playerIndex].team!);
   const mineMask = (1 << contested.length) - 1;
 
@@ -697,9 +691,8 @@ export default function getPlayerAnalysis(
     return headline(player, playerIndex, rivals, games, mustWin);
   }
 
-  // Winning every pick is the best the player can do, so it settles the rest. A
-  // player it does not save is one no set of their picks saves, and a search told
-  // that only reads all `2^n` of them to say so.
+  // Winning every pick is the player's best case, so a loss there means no
+  // smaller set saves them, without reading all `2^n` subsets to say so.
   const best = read(mineMask);
   if (best.kind === "loss") return knockedOut(player);
 

--- a/src/utils/scoring/parsePick.ts
+++ b/src/utils/scoring/parsePick.ts
@@ -6,7 +6,7 @@ const trailingSpread = /([+-]?\s*\d+(?:\.\d+)?)\s*$/;
  *
  * The spread is taken off the end and whatever is left is the abbreviation, rather
  * than reading the abbreviation up to the first space or sign. Abbreviations hold
- * both: `M-OH` has a hyphen and `OLE MISS` has a space, and looking for the first
+ * both. `M-OH` has a hyphen and `OLE MISS` has a space, and looking for the first
  * one would cut either in half.
  *
  * These cells are typed by hand, so a spread with no sign is taken as written, and a

--- a/src/utils/scoring/parsePicksWorkbook.ts
+++ b/src/utils/scoring/parsePicksWorkbook.ts
@@ -25,7 +25,7 @@ export type ParsedPicks = {
 /**
  * One buffer to the parse already run on it, so a refresh rescoring the same
  * workbook does not pay for the xlsx parse again. Keyed by the buffer's own
- * identity rather than its bytes: the picks a `RakMadnessScores` was built from
+ * identity rather than its bytes. The picks a `RakMadnessScores` was built from
  * never change without a new buffer replacing it. A `WeakMap` rather than a
  * plain one, so a buffer this hook has moved on from can still be collected.
  */
@@ -51,13 +51,12 @@ async function parseWorkbook(picksBuffer: ArrayBuffer): Promise<ParsedPicks> {
   const picksSheet = workbook.Sheets[Object.keys(workbook.Sheets)[0]];
   const rows: Array<any> = XLSX.utils.sheet_to_json(picksSheet);
 
-  // From the header row, not from a player's row: `sheet_to_json` leaves a blank
+  // From the header row, not from a player's row. `sheet_to_json` leaves a blank
   // cell out of the object it builds, so a game the first player skipped would go
   // unscored for everyone, and the tiebreaker game would shift a column.
   //
-  // Kept only where some row actually carries the key. A header cell that is not
-  // text, or one repeated, does not name a property of any row, and reading a
-  // column nobody can be looked up by is worse than not knowing about it.
+  // Kept only where some row carries the key. A non-text or repeated header
+  // names no row property, and an unreachable column is worse than unlisted.
   const [headerRow = []] = XLSX.utils.sheet_to_json<Array<unknown>>(
     picksSheet,
     {
@@ -84,7 +83,6 @@ async function parseWorkbook(picksBuffer: ArrayBuffer): Promise<ParsedPicks> {
   const tiebreakerGameKey =
     tiebreakerPickIndex > 0 ? allKeys[tiebreakerPickIndex - 1] : undefined;
 
-  // Determine team matchups.
   const matchups: { [gameKey: string]: Set<string> } = {};
   rows.forEach((playerRow: any) => {
     const addToMatchups = (key: string) => {
@@ -108,7 +106,7 @@ async function parseWorkbook(picksBuffer: ArrayBuffer): Promise<ParsedPicks> {
     ...collegeKeys,
     ...proKeys,
   ]);
-  // Warned about in production, not just in a dev server: it means the workbook
+  // Warned about in production, not just in a dev server. It means the workbook
   // needs fixing, and only whoever published it can do that.
   inconsistentSpreadGames.forEach((reason, gameKey) => {
     console.error(`Cannot score game ${gameKey}. ${reason}`);

--- a/src/utils/scoring/resultsIndex.ts
+++ b/src/utils/scoring/resultsIndex.ts
@@ -55,8 +55,8 @@ export function indexResults(results: Array<LeagueResult>): ResultsIndex {
  * The one game a picks column describes.
  *
  * A column names two teams once anyone has picked either side of it, and one where
- * every player picked the same team. Both are looked up folded, because a workbook
- * could name a team any way at all while a result carries it already uppercased.
+ * every player picked the same team. Both are looked up folded. A workbook could
+ * name a team any way at all, while a result carries it already uppercased.
  */
 export function findMatchup(
   index: ResultsIndex,

--- a/src/utils/scoring/unscoreableGames.ts
+++ b/src/utils/scoring/unscoreableGames.ts
@@ -6,7 +6,7 @@ import weekShape from "./weekShape";
  *
  * A contradicted spread or a game the results do not hold is a hole in the week
  * itself, so a week carrying one is not finished however many of its games are.
- * A cell left blank is not one of those: it scores the player nothing and says
+ * A cell left blank is not one of those. It scores the player nothing and says
  * nothing about the game, and every week has some.
  */
 export default function unscoreableGames(

--- a/src/utils/scoring/validateSpreads.ts
+++ b/src/utils/scoring/validateSpreads.ts
@@ -3,7 +3,7 @@ import parsePick from "./parsePick";
 /**
  * The games whose rows disagree about the spread, mapped to the disagreement.
  *
- * A spread describes the game, not the player who picked it: two rows on the same
+ * A spread describes the game, not the player who picked it. Two rows on the same
  * side of a game carry the same spread, and two rows on opposite sides carry
  * opposite ones. A sheet that breaks that has a typo in it, and nothing here can
  * tell which of the two numbers was meant, so the game cannot be scored for

--- a/src/utils/scoring/weekGames.ts
+++ b/src/utils/scoring/weekGames.ts
@@ -17,7 +17,7 @@ const ESPN_LEAGUE: Record<LeagueKey, League> = {
  * it from the underdog's side.
  *
  * The first row that names a team settles it. Every other row describes the same
- * game, from one side or the other, and a sheet whose rows disagree reaches here
+ * game, from one side or the other. A sheet whose rows disagree reaches here
  * without its game keys at all, since nothing can tell which of the two was meant.
  */
 function gameSpread(
@@ -66,8 +66,7 @@ export default function weekGames(
     const labels = rangeWithPrefix(keys.length, LEAGUE_PREFIX[league]);
     return keys.map((key, position) => {
       const teams = parsed.matchupsByGameKey.get(key);
-      // First match wins, which is how the picks themselves are resolved, so a
-      // team playing twice in a college bowl week lands on the same game here.
+      // The same first-match rule `ResultsIndex` is built with.
       const result = teams != null ? findMatchup(index, teams) : undefined;
       return {
         label: labels[position],

--- a/src/utils/scoring/weekShape.ts
+++ b/src/utils/scoring/weekShape.ts
@@ -21,7 +21,7 @@ const EMPTY: WeekShape = {
 
 /**
  * One walk per set of scores. The knockouts read the shape, the analysis dialog
- * reads it, and the search reads it again off the rows the knockouts returned, so a
+ * reads it, and the search reads it again off the rows the knockouts returned. A
  * refresh asks the same question of the same rows more than once.
  */
 const shapes = new WeakMap<Array<PlayerScore>, WeekShape>();

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,12 +1,12 @@
-# The Pages project, which Cloudflare cannot rename, so it keeps the old name
-# while the app and the bucket carry the new one.
+# Cloudflare cannot rename the Pages project. It keeps the old name while the
+# app and the bucket carry the new one.
 name = "rak-sadness"
 # The date the runtime behavior was last verified against, not the project's age.
 compatibility_date = "2026-08-10"
 
 # Serves picks/<season>/<week>.xlsx to functions/api/picks/[season]/[week].ts,
 # lists seasons for functions/api/picks/index.ts.
-# Simulated locally by `wrangler pages dev`; seed it with
+# Simulated locally by `wrangler pages dev`. Seed it with
 # `wrangler r2 object put rak-madness-calculator/picks/2025/1.xlsx --file <path> --local`.
 # The binding also has to exist on the Pages project, for preview and production
 # both, or the deployed Function has nothing to read.


### PR DESCRIPTION
## What

A writing-guide pass over every comment, docblock, `CLAUDE.md`, `SKILL.md`, and the README. No code changed.

## Why

Four comments had gone false and misled a reader. The rest broke the guide's punctuation and structure rules.

## Changes

- Correct four comments that named the wrong symbol. `SvgIcon` becomes `Icon`, `attemptInFlight` becomes `isAttemptInFlight`, `GameStatusDialog` becomes `ResultsFrame`, and two `lcd-field` claims become `lcd-glass`.
- Move the `getPlayerAnalysis` docblock onto its own export. It sat above `getSettledAnalysis`, which carries a docblock of its own.
- Keep a fact over the guide's two-line cap for an inline comment. Some comments stay long, because no shorter form holds every fact.
- Bullet the two lookups written as prose, in `src/CLAUDE.md` and `src/types/CLAUDE.md`.
- Leave the bench figures in `getPlayerAnalysis.ts`. They are the evidence for the route limit.
- Leave the semicolons in `latestOnly.ts`. They sit inside a code sample, and a sample stays verbatim.

## Notes / Follow-ups

- The writing-guide checker reports three findings, all in the `latestOnly.ts` code sample. Those are false positives.

🚁 Extracted by [Agent Alex Rider](https://github.com/yahoo-creators/claude-tools/blob/main/skills/create-pr/README.md)
